### PR TITLE
Started reading the 'file' parameter instead of the request body

### DIFF
--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -83,7 +83,7 @@ class SubmissionsController < ApplicationController
   action_no_auth :autograde_done
   def autograde_done
     
-    feedback_str = request.body.read
+    feedback_str = params[:file].read
 
     @submission = Submission.where(:id => params[:id]).first
     @course = Course.where(:id => params[:course_id]).first


### PR DESCRIPTION
Sending the feedback file in the request body was causing issues with Apache. Therefore we started receiving the file in the 'file' parameter.

Corresponding Tango PL: https://github.com/autolab/Tango/pull/1
