### PR TITLE
Fixed annotation issue by not overwriting @cud

### DIFF
--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -726,7 +726,6 @@ private
     end
 
     @assessment = @submission.assessment
-    @cud = @submission.course_user_datum
 
     if ((!@cud.user.administrator?) && (@cud.course_id != @assessment.course_id)) then 
       flash[:error] = "You do not have permission to access this submission"


### PR DESCRIPTION
This was causing a when we look at the source code since we're checking if @cud is an instructor, since @cud would be the owner of the submission at that point. I'm sure this would cause problems in some other cases as well.

However I want to make sure that it doesn't break anything else.
