### PR TITLE
Fix Submission Timestamp on Scoreboard

### DIFF
--- a/app/controllers/assessments_controller.rb
+++ b/app/controllers/assessments_controller.rb
@@ -1492,7 +1492,7 @@ class AssessmentsController < ApplicationController
         @grades[uid][:problems] = {}
       end
       if @grades[uid][:version] != row["version"] then
-        @grades[uid][:time] = row["time"]
+        @grades[uid][:time] = row["time"].localtime
         @grades[uid][:version] = row["version"].to_i
         @grades[uid][:autoresult] = row["autoresult"]
       end

--- a/app/views/assessments/_submission_history_row.html.erb
+++ b/app/views/assessments/_submission_history_row.html.erb
@@ -17,7 +17,7 @@
     <% end %>
   </td>
 
-  <td class=smallText><%= submission.created_at  %></td>
+  <td class=smallText><%= submission.created_at %></td>
 
   <% for problem in @problems do %>
     <td class="prettyBorder">


### PR DESCRIPTION
As the title suggests.

Originally the scoreboard entries have UTC timestamps. Now they are changed to be the same as `config.time_zone`.
