### PR TITLE
Adding quotes around keys in autoresult

### DIFF
--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -684,7 +684,7 @@ class SubmissionsController < ApplicationController
   # with the caller. Can be overridden in the lab config file.
   #
   def parseAutoresult(autoresult, isOfficial)
-    parsed = ActiveSupport::JSON.decode(autoresult)
+    parsed = ActiveSupport::JSON.decode(autoresult.gsub(/([a-zA-Z0-9]+):/, '"\1":'))
     if !parsed then
       raise "Empty autoresult"
     end


### PR DESCRIPTION
No quotes around strings would result in parse error on some machines.
Same https://github.com/autolab/Autolab/blob/master/app/controllers/assessments_controller.rb#L1683, except that only adding quotes around keys.
