### PR TITLE
Fix view feedback page AndrewID error.

### DIFF
--- a/app/views/assessments/viewFeedback.html.erb
+++ b/app/views/assessments/viewFeedback.html.erb
@@ -25,11 +25,9 @@ Yes, feedback if per problem but we show all annotations for this submission any
 <ul>
 <% @submission.annotations.each do |annotation| %>
   <li>
-    <%= link_to annotation.text, 
-                   :controller => "submission",
-                   :action => "view",
-                   :id => annotation.submission.id,
-                   :header_position => annotation.position # ignored, if annotation.position is nil
+    <%= link_to annotation.text,
+        view_course_assessment_submission_path(@course, @assessment, @submission),
+        :header_position => annotation.position # ignored if annotation.position is nil
     %>
     
     <% 


### PR DESCRIPTION
The feedback now displays the user email of the grader, instead of the Andrew ID (CMU dependent).
