### PR TITLE
Handin history refreshes every 10 seconds. Fixes #33

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ tmp/
 !tmp/restart.txt
 *.swp
 db/*.sqlite3
+Gemfile

--- a/Gemfile
+++ b/Gemfile
@@ -75,4 +75,4 @@ gem 'capybara', group: [:development, :test]
 # gem 'capistrano-rails', group: :development
 
 # Use debugger
-gem 'debugger2', group: [:development, :test]
+gem 'debugger', group: [:development, :test]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,10 +53,12 @@ GEM
     coffee-script-source (1.8.0)
     columnize (0.8.9)
     daemons (1.1.9)
-    debugger-linecache (1.2.0)
-    debugger2 (1.0.0.beta2)
+    debugger (1.6.8)
       columnize (>= 0.3.1)
       debugger-linecache (~> 1.2.0)
+      debugger-ruby_core_source (~> 1.3.5)
+    debugger-linecache (1.2.0)
+    debugger-ruby_core_source (1.3.7)
     devise (3.3.0)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -210,7 +212,7 @@ PLATFORMS
 DEPENDENCIES
   capybara
   coffee-rails (~> 4.0.0)
-  debugger2
+  debugger
   devise (= 3.3.0)
   dynamic_form
   exception_notification!

--- a/app/views/assessments/_submission_history_table.html.erb
+++ b/app/views/assessments/_submission_history_table.html.erb
@@ -1,3 +1,9 @@
+<script type="text/javascript">
+   // Auto-refreshes the page every 10 seconds
+   // Interval set in milliseconds 
+   setInterval('window.location.reload()', 10000);
+</script>
+
 <table class="prettyBorder" border=1 width=80%>
 
   <thead>

--- a/config/database.yml.template
+++ b/config/database.yml.template
@@ -1,8 +1,8 @@
 development:
   adapter: mysql2
-  database: <username>_autolab_development 
+  database: kelly_autolab_development 
   pool: 5
-  username: <username>
-  password: '<password>'
+  username: kelly
+  password: kelly
   socket: /var/run/mysqld/mysqld.sock
   host: localhost


### PR DESCRIPTION
Please ignore .gitignore, Gemfile, Gemfile.lock, and database.yml.template. I had trouble installing debugger2 so I had to make some changes to Gemfile. Also, I thought gitignore would ignore Gemfile, but it somehow still got added to the push. Sorry!

With that aside, I have added a script in _submission_history_table.html.erb that auto-refreshes the page every 10 seconds. This can easily be adjusted to other time intervals should this be inconvenient.

Thank you!