### PR TITLE
Made Course Logger more robust

### DIFF
--- a/app/models/course_logger.rb
+++ b/app/models/course_logger.rb
@@ -11,7 +11,12 @@ class CourseLogger
   end
 
   def setCourse(course)
-    @logger = Logger.new("#{Rails.root}/courses/#{course.name}/autolab.log",'monthly')
+    # if this can't grab the file, Autolab should still function
+    begin
+      @logger = Logger.new("#{Rails.root}/courses/#{course.name}/autolab.log",'monthly')
+    rescue
+      @logger = nil
+    end
   end
 
   def log(message,severity=Logger::INFO)


### PR DESCRIPTION
If Course Logger cannot grab the log file, it now silently fails, which should help with the Permissions issues the CMU site has been having.