### PR TITLE
Fixed Navbar Bug

### DIFF
--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -82,7 +82,7 @@
 			<%= link_to @course.display_name, course_path(@course), :id=>"courseTitle" %>
 			<% if @course.disabled? %> (Course Disabled)<% end %>
 		</span>
-		<% if @assessment %>
+		<% if @assessment and @assessment.id %>
 		<span class="item">
 			<span class="arrow">»</span>
 			<%= current_assessment_link %>


### PR DESCRIPTION
Not tested, but if @assessment is new, it does not have an id, thus it cannot use current_assessment_link.  This should fix that.