### PR TITLE
Fixed job feedback page

### DIFF
--- a/app/views/jobs/getjob.html.erb
+++ b/app/views/jobs/getjob.html.erb
@@ -15,9 +15,9 @@
 
 <h2>Job Parameters</h2>
 <ul>
-<li>VM image: <kbd><%= @job[:rjob]["vm"]["name"]%>.img</kbd>
-<li><kbd>timeout</kbd>: <%= @job[:rjob]["timeout"] %> secs
-<li><kbd>maxOutputFileSize</kbd>: <%= @job[:rjob]["maxOutputFileSize"] %> bytes.
+<li>VM image: <%= @job[:rjob]["vm"]["name"]%>
+<li>Job Timeout: <%= @job[:rjob]["timeout"] %> secs
+<li>Maximum Output File Size: <%= @job[:rjob]["maxOutputFileSize"] %> bytes
 <li>Input Files: 
 <table class=prettyBorder>
 <tr><th>Local File on Server (<kbd>localFile</kbd>)</th>
@@ -31,10 +31,10 @@
 </tr></table>
 
 <% if @cud.user.administrator?  then %>
-<li><kbd>notifyURL</kbd>: <kbd><%= @job[:rjob]["notifyURL"] %> </kbd>
+<li><kbd>notifyURL</kbd>: <%= @job[:rjob]["notifyURL"] %>
 <% end %>
 
-<li><kbd>outputFile</kbd>: <kbd><%= @job[:rjob]["outputFile"].sub(/\/afs\/cs.cmu.edu\/academic\/autolab\/autolab2/, "[autolab]") %></kbd>
+<li>Output File: <%= @job[:rjob]["outputFile"].sub(/\/afs\/cs.cmu.edu\/academic\/autolab\/autolab2/, "[autolab]") %>
 </ul>
 
 <h2>Runtime Trace</h2>


### PR DESCRIPTION
Fixes #84 by removing <tt>.img</tt> after VM Image Name.