### PR TITLE
Fix table sorting in Manage Accounts page. #1

### DIFF
--- a/app/assets/javascripts/sorttable.js
+++ b/app/assets/javascripts/sorttable.js
@@ -1,16 +1,16 @@
-/* 
+/*
     sorttable.js
     Enables the sorting of tables on a per column basis.
     Sorting is stable and does not modify the elements being
     sorted in any way other than their relative position.
-    
+
     Usage:
         Give a table the class "sortable" and make sure that
         all of the elements you want sorted are wrapped
         in a <tbody> tag, it will take care
         of the rest. Whenever a user clicks on a particular
         heading, the table will be sorted based on that column.
-    
+
     Includes the sortElements jQuery plugin:
     https://github.com/padolsey/jQuery-Plugins/blob/master/sortElements/jquery.sortElements.js
 */
@@ -24,34 +24,34 @@
  * --------------
  * @param Function comparator:
  *   Exactly the same behaviour as [1,2,3].sort(comparator)
- *   
+ *
  * @param Function getSortable
  *   A function that should return the element that is
  *   to be sorted. The comparator will run on the
  *   current collection, but you may want the actual
  *   resulting sort to occur on a parent or another
  *   associated element.
- *   
+ *
  *   E.g. $('td').sortElements(comparator, function(){
- *      return this.parentNode; 
+ *      return this.parentNode;
  *   })
- *   
+ *
  *   The <td>'s parent (<tr>) will be sorted instead
  *   of the <td> itself.
  */
 jQuery.fn.sortElements = (function(){
-    
+
 	var sort = [].sort;
-    
+
 	return function(comparator, getSortable) {
-        
+
 	    getSortable = getSortable || function(){return this;};
-        
+
 	    var placements = this.map(function(){
-            
+
 		    var sortElement = getSortable.call(this),
 		    parentNode = sortElement.parentNode,
-                
+
 		    // Since the element itself will change position, we have
 		    // to have some way of storing it's original position in
 		    // the DOM. The easiest way is to have a 'flag' node:
@@ -59,28 +59,28 @@ jQuery.fn.sortElements = (function(){
 							  document.createTextNode(''),
                     sortElement.nextSibling
 							  );
-            
+
 		    return function() {
-                
+
 			if (parentNode === this) {
 			    throw new Error(
                         "You can't sort elements if any one is a descendant of another."
 					    );
 			}
-                
+
 			// Insert before flag:
 			parentNode.insertBefore(this, nextSibling);
 			// Remove flag:
 			parentNode.removeChild(nextSibling);
-                
+
 		    };
-            
+
 		});
-       
+
 	    return sort.call(this, comparator).each(function(i){
 		    placements[i].call(getSortable.call(this));
 		});
-        
+
 	};
 })();
 
@@ -92,8 +92,8 @@ var sorttables = (function($) { return function() {
 			var $th = $(this);
 			var thIndex = $th.index();
 			var inverse = false;
-      
-			/** 
+
+			/**
 			 * This looks complex and slow (it's both!)
 			 * but the underlying concept is simple.
 			 *
@@ -111,7 +111,7 @@ var sorttables = (function($) { return function() {
 				var a = $.trim($(nodeA).text()).toLowerCase();
 				var b = $.trim($(nodeB).text()).toLowerCase();
 				var result;
-        
+
 				// Deal with invalid values.
 				if (!a && !b) {
 					return 0;
@@ -120,7 +120,7 @@ var sorttables = (function($) { return function() {
 				} else if (!b) {
 					return -1;
 				}
-        
+
 				// Deal with strings.
 				else if (!$.isNumeric(a) && !$.isNumeric(b)) {
 					result =  a.localeCompare(b);
@@ -128,8 +128,8 @@ var sorttables = (function($) { return function() {
 					return 1;
 				} else if (!$.isNumeric(b)) {
 					return -1;
-				} 
-        
+				}
+
 				// Deal with numbers.
 				else {
 					var valueA = parseFloat(a);
@@ -144,7 +144,7 @@ var sorttables = (function($) { return function() {
 				}
 
 				result = inverse ? -result : result;
-				
+
 				// This is a hack to make sorting stable.
 				// The idea is that if the two values are
 				// equal, we sort them based on the positions

--- a/app/views/admins/users.html.erb
+++ b/app/views/admins/users.html.erb
@@ -1,6 +1,11 @@
-<%= external_javascript_include_tag "prototype", "1.6.0.3" %>
 <%= javascript_include_tag "sorttable" %>
+<!--
+  TODO: Fix table floating headers (absolute positioning)
+  NOTE: I think this problem can be solved almost entirely with CSS, with
+        minimal JS (to apply a CSS class once the element hits the top of the
+        screen). The current "solution" is overkill. -JZ
 <%= javascript_include_tag "table_floating_header" %>
+-->
 <h2>Manage Accounts</h2>
 
 <hr>
@@ -18,7 +23,14 @@ Search: <%= text_field_tag 'search', nil, onkeyup:'filterRows(this.value)' %>
 <div id='ajaxTable'>
 <%= render :partial=>'usersTable' %>
 </div>
+
 <script type="text/javascript">
+  // Once the DOM is loaded, add sorting functionality to the columns
+  jQuery(document).ready(function() {
+    sorttables();
+  });
+
+  // Triggered on keyup in the search field
   function filterRows(name) {
     var rows = document.getElementsByClassName("user-row"),
         i = 0, L = rows.length, r;


### PR DESCRIPTION
I removed Prototype.js, which was shadowing jQuery, and then made a call
to the `sorttables` function, which adds listeners on the table headings
to toggle sorting.

Prototype.js doesn't look like it has a place in our code, from what I
can tell. Correct me if I'm wrong. I'll be attempting to remove it in
favor of jQuery whenever I get the chance. Until it's "safe," I'll be
preferring `jQuery(...)` over `$(...)`, even though this is generally
not the best style.

I also disabled the functionality to float table headers at the top of
the screen, because it was causing errors and the current "solution" was
really hacky. I might look into enabling this feature later.