### PR TITLE
Sort all columns with the sortable class.

### DIFF
--- a/app/assets/javascripts/sorttable.js
+++ b/app/assets/javascripts/sorttable.js
@@ -183,3 +183,8 @@ var sorttables = (function($) { return function() {
 		});
 	});
 }})(jQuery);
+
+// Once the DOM has loaded, make the table columns sortable
+jQuery(document).ready(function() {
+  sorttables();
+});

--- a/app/views/admins/users.html.erb
+++ b/app/views/admins/users.html.erb
@@ -25,11 +25,6 @@ Search: <%= text_field_tag 'search', nil, onkeyup:'filterRows(this.value)' %>
 </div>
 
 <script type="text/javascript">
-  // Once the DOM is loaded, add sorting functionality to the columns
-  jQuery(document).ready(function() {
-    sorttables();
-  });
-
   // Triggered on keyup in the search field
   function filterRows(name) {
     var rows = document.getElementsByClassName("user-row"),

--- a/app/views/assessments/scoreboard.html.erb
+++ b/app/views/assessments/scoreboard.html.erb
@@ -3,7 +3,7 @@
 <%= javascript_include_tag "sorttable" %>
 
 <% if @staticOverride  then %>
-  <%= f = File.new(@staticOverride,'r') 
+  <%= f = File.new(@staticOverride,'r')
       f.read()
   %>
 <% else %>
@@ -34,7 +34,7 @@
 	<div id="error_explanation">
 		<h2><%= pluralize(@cud.errors.count, "error") %>
       prohibited the data from being saved:</h2>
-			
+
 		<ul>
 			<% @cud.errors.full_messages.each do |msg| %>
 			<li><%= msg %></li>


### PR DESCRIPTION
Fixes #108.

I'm assuming that any tables that include the class="sortable" expect
their contents to be sorted. The way to do this is

  a) include the sorttable.js file
  b) call the function `sorttables();` once the DOM has loaded

I've added step (b) to the sorttable.js file, so that it is done
automatically on all pages that include the JavaScript file.

sorttables.js is an external library, so if we ever update it, this will
get overwritten. However, it is much simpler than pecking and hunting
through the source code to include the three lines required to sort
columns in all the files that require it.