### PR TITLE
Update step for time picker to one second.

### DIFF
--- a/app/views/admins/confirmInstall.html.erb
+++ b/app/views/admins/confirmInstall.html.erb
@@ -31,10 +31,10 @@ function newCat() {
     <tr><td><b>Handin filename:</b></td>
       <td><%= f.text_field :handin_filename %></td></tr>
 
-    <tr><td><b>Visible on date:</b></td><td><%= f.datetime_select :visible_at %></td></tr>
-    <tr><td><b>Start at:</b></td><td><%= f.datetime_select :start_at %></td></tr>
-    <tr><td><b>Due at:</b></td><td><%= f.datetime_select :due_at %></td></tr>
-    <tr><td><b>End at:</b></td><td><%= f.datetime_select :end_at %></td></tr>
+    <tr><td><b>Visible on date:</b></td><td><%= f.datetime_select :visible_at, step: 1 %></td></tr>
+    <tr><td><b>Start at:</b></td><td><%= f.datetime_select :start_at, step: 1 %></td></tr>
+    <tr><td><b>Due at:</b></td><td><%= f.datetime_select :due_at, step: 1 %></td></tr>
+    <tr><td><b>End at:</b></td><td><%= f.datetime_select :end_at, step: 1 %></td></tr>
 
 
     <tr><td><b>Description:</b></td>

--- a/app/views/announcements/_announcementFields.html.erb
+++ b/app/views/announcements/_announcementFields.html.erb
@@ -9,11 +9,11 @@
   </tr>
   <tr>
     <th>Start Date:</th>
-    <td><%= f.datetime_select :start_date %></td>
+    <td><%= f.datetime_select :start_date, step: 1 %></td>
   </tr>
   <tr>
     <th>End Date:</th>
-    <td><%= f.datetime_select :end_date %></td>
+    <td><%= f.datetime_select :end_date, step: 1 %></td>
   </tr>
   <tr>
     <th>Persistent Announcement?</th>

--- a/app/views/assessments/_edit_handin.html.erb
+++ b/app/views/assessments/_edit_handin.html.erb
@@ -8,16 +8,16 @@
 <% end %>
 
 <%= f.label :start_at %><br>
-<%= f.datetime_local_field :start_at, help_text: "The time this assessment is released to students." %>
+<%= f.datetime_local_field :start_at, step: 1, help_text: "The time this assessment is released to students." %>
 <br><br>
 <%= f.label :due_at %><br>
-<%= f.datetime_local_field :due_at, help_text: "Students can submit before this time without being penalized or using grace days." %>
+<%= f.datetime_local_field :due_at, step: 1, help_text: "Students can submit before this time without being penalized or using grace days." %>
 <br><br>
 <%= f.label :end_at %><br>
-<%= f.datetime_local_field :end_at, help_text: "Last possible time that students can submit (except those granted extensions.)" %>
+<%= f.datetime_local_field :end_at, step: 1, help_text: "Last possible time that students can submit (except those granted extensions.)" %>
 <br><br>
 <%= f.label :grading_deadline %><br>
-<%= f.datetime_local_field :grading_deadline, help_text: "Time after which final scores are included in the gradebook" %>
+<%= f.datetime_local_field :grading_deadline, step: 1, help_text: "Time after which final scores are included in the gradebook" %>
 <br><br>
 <div class="form-group">
   <label for="disable_handins" class="suppress-bottom-margin">Disable Handins</label>

--- a/app/views/assessments/confirmInstall.html.erb
+++ b/app/views/assessments/confirmInstall.html.erb
@@ -31,10 +31,10 @@ function newCat() {
     <tr><td><b>Handin filename:</b></td>
       <td><%= f.text_field :handin_filename %></td></tr>
 
-    <tr><td><b>Visible on date:</b></td><td><%= f.datetime_select :visible_at %></td></tr>
-    <tr><td><b>Start at:</b></td><td><%= f.datetime_select :start_at %></td></tr>
-    <tr><td><b>Due at:</b></td><td><%= f.datetime_select :due_at %></td></tr>
-    <tr><td><b>End at:</b></td><td><%= f.datetime_select :end_at %></td></tr>
+    <tr><td><b>Visible on date:</b></td><td><%= f.datetime_select :visible_at, step: 1 %></td></tr>
+    <tr><td><b>Start at:</b></td><td><%= f.datetime_select :start_at, step: 1 %></td></tr>
+    <tr><td><b>Due at:</b></td><td><%= f.datetime_select :due_at, step: 1 %></td></tr>
+    <tr><td><b>End at:</b></td><td><%= f.datetime_select :end_at, step: 1 %></td></tr>
 
 
     <tr><td><b>Description:</b></td>

--- a/app/views/schedulers/edit.html.erb
+++ b/app/views/schedulers/edit.html.erb
@@ -9,7 +9,7 @@
   </tr>
   <tr>
     <th>Next</th>
-    <td><%= f.datetime_select :next %></td>
+    <td><%= f.datetime_select :next, step: 1 %></td>
   </tr>
   <tr>
     <th>Interval (Seconds)</th>

--- a/app/views/schedulers/new.html.erb
+++ b/app/views/schedulers/new.html.erb
@@ -9,7 +9,7 @@
   </tr>
   <tr>
     <th>Next</th>
-    <td><%= f.datetime_select :next %></td>
+    <td><%= f.datetime_select :next, step: 1 %></td>
   </tr>
   <tr>
     <th>Interval (Seconds)</th>


### PR DESCRIPTION
Fixes #119.

Note: This is probably a temporary solution, because we will switch out of `datetime-local` soon.