### PR TITLE
Updated Nickname Restrictions

### DIFF
--- a/app/models/course_user_datum.rb
+++ b/app/models/course_user_datum.rb
@@ -61,11 +61,8 @@ class CourseUserDatum < ActiveRecord::Base
   def valid_nickname?
     if not nickname
       true
-    elsif not nickname.ascii_only? then
-      errors.add("nickname", "must consist of only ASCII characters")
-      false
-    elsif nickname.length > 20 then 
-      errors.add("nickname", "is too long (maximum is 20 characters)")
+    elsif nickname.length > 32 then 
+      errors.add("nickname", "is too long (maximum is 32 characters)")
       false
     else
       true


### PR DESCRIPTION
This was tested and works on my Mac OS X.  I don't know if settings for the DB need to be changed, but I think this should be fine. (the nickname column actually has 255 characters, so we can allow longer names.)