### PR TITLE
Fix icon alignment on Courses page. Fixes #106

### DIFF
--- a/app/views/layouts/home.html.erb
+++ b/app/views/layouts/home.html.erb
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
   <head>
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1.0, user-scalable=0">


### PR DESCRIPTION
Turns out it was an issue related to not having a `DOCTYPE` declared.