### PR TITLE
Revert "Adds small margin-top to submit buttons"

### DIFF
--- a/app/assets/stylesheets/style.css.scss
+++ b/app/assets/stylesheets/style.css.scss
@@ -602,10 +602,6 @@ input[type="password"] {
   border: 1px solid #ccc;
 }
 
-input[type="submit"] {
-  margin-top: 15px;
-}
-
 input[type="text"]:disabled,
 input[type="email"]:disabled,
 input[type="password"]:disabled,


### PR DESCRIPTION
This reverts commit 2762e78ad21874e925673cee30d1664911814d8a.

I only tested this change on the Change Password form. There are other
forms where this change doesn't work correctly, for example the Edit
Assessment form when the Delete this Assignment button is also present.

The issue I was trying to fix (in one fell swoop rather than looking at
each case separately), was that sometimes the submission button is two
close to the end of the form (i.e., touching the last input). Rather
than pushing the button down uniformly, all the inputs should have
margins after them forcing things that come later to be in a more
appropriate place. I'll look into making these changes, but things look
better with this change reverted.