### PR TITLE
Revert "Adds small margin-top to submit buttons"

### DIFF
--- a/app/controllers/course_user_data_controller.rb
+++ b/app/controllers/course_user_data_controller.rb
@@ -1,11 +1,11 @@
 class CourseUserDataController < ApplicationController
-  
+
   action_auth_level :index, :student
   def index
     @requestedUser = @cud
     render :action=>:show
   end
-  
+
   action_auth_level :new, :instructor
   def new
     @newCUD = @course.course_user_data.new
@@ -16,7 +16,7 @@ class CourseUserDataController < ApplicationController
   action_auth_level :create, :instructor
   def create
     @newCUD = @course.course_user_data.new(cud_params)
-    
+
     # check user existence
     email = params[:course_user_datum][:user_attributes][:email]
     user = User.where(email: email).first
@@ -28,13 +28,13 @@ class CourseUserDataController < ApplicationController
       auth.save!
       @newUser = User.new(cud_params[:user_attributes])
       @newUser.authentications << auth
-      
+
       temp_pass = Devise.friendly_token[0, 20]    # generate a random token
       @newUser.password = temp_pass
 
       if @newUser.save then
          @newCUD.user = @newUser
-      else 
+      else
         @newUser.errors.each do |msg|
           print msg
         end
@@ -50,7 +50,7 @@ class CourseUserDataController < ApplicationController
       end
       @newCUD.user = user
     end
-    
+
     # save CUD
     if @newCUD.save then
       flash[:success] = "Success: added user #{email} in #{@course.display_name}"
@@ -85,15 +85,15 @@ class CourseUserDataController < ApplicationController
     if @editCUD == nil then
       flash[:error] = "Can't find user in the course."
       redirect_to :action=>"index" and return
-    end 
+    end
 
-    if (@editCUD.id != @cud.id) and (!@cud.instructor?) and 
+    if (@editCUD.id != @cud.id) and (!@cud.instructor?) and
         (!@cud.user.administrator?) then
       flash[:error] = "Permission denied."
       redirect_to :action=>"index" and return
     end
- 
-    @editCUD.tweak ||= Tweak.new 
+
+    @editCUD.tweak ||= Tweak.new
   end
 
   action_auth_level :update, :student
@@ -104,7 +104,7 @@ class CourseUserDataController < ApplicationController
     @editCUD = @course.course_user_data.find(params[:id])
     if @editCUD == nil then
       redirect_to :action=>"index" and return
-    end 
+    end
 
     if (@editCUD.id != @cud.id) and (!@cud.instructor?) then
       redirect_to :action=>"index" and return
@@ -143,9 +143,9 @@ class CourseUserDataController < ApplicationController
       redirect_to users_course_admin_path(@course) and return
     end
   end
-  
+
   # Non-RESTful paths below
-  
+
   # this GET page confirms that the instructor wants to destroy the user
   action_auth_level :destroyConfirm, :instructor
   def destroyConfirm
@@ -200,7 +200,7 @@ class CourseUserDataController < ApplicationController
   end
 
 private
-  
+
   def cud_params
     if @cud.administrator? then
       params.require(:course_user_datum).permit(:school, :major, :year,

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -12,7 +12,7 @@
 
 	<div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
 		<ul class="nav navbar-nav navbar-right action-links" role="navigation">
-            
+
 			<% if session[:sudo] && @cud then %>
 			<li>
 				<%= link_to "(#{@cud.display_name}) Reset user",
@@ -23,7 +23,7 @@
 			<li>
 				<a href="/">Courses</a>
 			</li>
-						
+
 			<% if @cud %>
 			<li>
 				<% link = (@cud.course_assistant? && !@cud.section.blank?) ? "Section #{@cud.section} Gradebook" : "Gradebook" %>
@@ -32,20 +32,20 @@
 			<li>
 				<%= link_to "Jobs", course_jobs_path(@cud.course), :title => "View a history of autograding jobs" %>
 			</li>
-            
+
 			<% if @cud.instructor? %>
 			<li>
 				<%= link_to "Course Admin", course_admin_path(@cud.course), :title => "Perform course-wise administrative actions" %>
 			</li>
 			<% end %>
 			<% end %>
-					
+
 			<% if !@cud && current_user && current_user.administrator? %>
 			<li>
 				<%= link_to "Autolab Admin", user_admin_path(current_user), :title => "Perform system-wise administrative actions" %>
 			</li>
 			<% end %>
-						
+
 			<!-- User -->
 			<% if user_signed_in? %>
 			<li class="dropdown">
@@ -57,6 +57,11 @@
 					<% unless current_user.nil? %>
 					<li role="presentation">
 						<%= link_to "Account", edit_user_path(current_user), :title => "View your account info" %>
+					</li>
+					<% end %>
+					<% if @course %>
+					<li role="presentation">
+						<%= link_to "Course Profile", course_course_user_datum_path(@course, @cud), :title => "View your user profile for the current course" %>
 					</li>
 					<% end %>
 					<% if Rails.env.development? %>
@@ -95,6 +100,6 @@
 		</span>
 		<% end %>
 	</span>
-	
+
 </div>
 <% end %>


### PR DESCRIPTION
This reverts commit 2762e78ad21874e925673cee30d1664911814d8a.

I only tested this change on the Change Password form. There are other
forms where this change doesn't work correctly, for example the Edit
Assessment form when the Delete this Assignment button is also present.

The issue I was trying to fix (in one fell swoop rather than looking at
each case separately), was that sometimes the submission button is two
close to the end of the form (i.e., touching the last input). Rather
than pushing the button down uniformly, all the inputs should have
margins after them forcing things that come later to be in a more
appropriate place. I'll look into making these changes, but things look
better with this change reverted.