### PR TITLE
Fix the redirect on submissions#destroy

### DIFF
--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -162,7 +162,7 @@ class SubmissionsController < ApplicationController
   def destroy
     load_submission() or return false
     @submission.destroy
-    redirect_to history_course_assessment_path(@submission.course_user_datum.course, @submission.assessment) and return
+    redirect_to course_assessment_submissions_path(@submission.course_user_datum.course, @submission.assessment) and return
   end
 
   # this is good


### PR DESCRIPTION
It now goes to Manage Submissions, instead of handin history.
Fixes #95