### PR TITLE
AuthError's should not notify us anymore

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,21 +13,19 @@ class ApplicationController < ActionController::Base
   before_action :authenticate_for_action
   before_action :update_persistent_announcements
 
-  rescue_from CourseUserDatum::AuthenticationFailed do |e|
-    COURSE_LOGGER.log("AUTHENTICATION FAILED: #{e.user_message}, #{e.dev_message}")
-    flash[:error] = e.user_message
-    redirect_to :controller => "home", :action => "error"
-  end
-
   # this is where Error Handling is configured. this routes exceptions to
   # the error handler in the HomeController, unless we're in development mode
   #
   # the policy is basically a replica of Rails's default error handling policy
   # described in http://guides.rubyonrails.org/action_controller_overview.html#rescue
   unless Rails.env.development?
-    # this doesn't appear to be getting called -Dan
-    #rescue_from ActiveRecord::RecordNotFound, :with => :render_404
+    # going against all logic, handlers registered last get called first
     rescue_from Exception, with: :render_error
+    rescue_from CourseUserDatum::AuthenticationFailed do |e|
+      COURSE_LOGGER.log("AUTHENTICATION FAILED: #{e.user_message}, #{e.dev_message}")
+      flash[:error] = e.user_message
+      redirect_to root_path and return
+    end
   end  
 
   def self.autolabRequire(path)
@@ -266,12 +264,6 @@ private
     end
 
     render "home/error"
-  end
-
-  # called on ActiveRecord::RecordNotFound exception. 
-  # Redirect user to the 404 page without error notification
-  def render_404
-    render file: "public/404.html", layout: false
   end
 
 end


### PR DESCRIPTION
Instead, users will get redirected to the root_path, which should prompt them to log in again.