### PR TITLE
Possibly added more info to Error Emails

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -248,7 +248,7 @@ private
   # Shows good ol' Donkey Kong to students
   def render_error(exception)
     # use the exception_notifier gem to send out an e-mail to the notification list specified in config/environment.rb
-    ExceptionNotifier.notify_exception(exception)
+    ExceptionNotifier.notify_exception(exception, env: request.env, data: {message: "was doing something wrong"})
 
     # stack traces are only shown to instructors and administrators
     # by leaving @error undefined, students and CAs do not see stack traces


### PR DESCRIPTION
So I'm not certain, but I hope that adding these settings will force
exception_notification to run in the foreground and thus include more
useful information about the request and controller, etc.

http://smartinez87.github.io/exception_notification/#background-notifications