### PR TITLE
Temp Fix for some encoding errors

### DIFF
--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -137,7 +137,7 @@ class Submission < ActiveRecord::Base
     conditions[:position] = position if position
     annotations = self.annotations.where(conditions)
 
-    result = file.lines.map { |line| [line, nil] }
+    result = file.lines.map { |line| [line.force_encoding("UTF-8"), nil] }
 
     # annotation lines are one-indexed, so adjust for the zero-indexed array
     annotations.each { |a| result[a.line-1][1] = a}


### PR DESCRIPTION
I call this temporary because there are still some issues displaying
UTF-8 characters and, overall it just feels hacky.  That said,
submissions with UTF-8 characters won't break the page now, which is
progress on #251.

I'd suggest a more thorough examination of our current encoding
situation in the future.