### PR TITLE
Expose linked relationships among datetimepickers

### DIFF
--- a/app/assets/javascripts/initialize_datetimepickers.js
+++ b/app/assets/javascripts/initialize_datetimepickers.js
@@ -1,11 +1,49 @@
-// Initialize all Bootstrap 3 Datetimepickers on the page
-$(document).ready(function() {
-  $('.datetimepicker').datetimepicker({
-    showTodayButton: true,
-    icons: {
-      time: 'glyphicon glyphicon-time time-btn',
-      date: 'glyphicon glyphicon-calendar date-btn',
-      today: 'glyphicon glyphicon-screenshot now-btn'
+// Initialize all Bootstrap 3 Datetime Pickers on the page
+;(function() {
+  function updateDatetimePickers(e) {
+    var ourDate = e.date;
+
+    // Harvest data-* attributes describing linked relationships
+    var lessThans = $(this).data('dateLessThan');
+    var greaterThans = $(this).data('dateGreaterThan');
+
+    // We are less than (older than) each of these elements
+    if (lessThans) {
+      lessThans.split(' ').forEach(function(dp_id, idx, arr) {
+        if (dp_id) {
+          var theirID = '#' + dp_id;
+          var theirDate = $(theirID).data('DateTimePicker').date();
+
+          $(theirID).data('DateTimePicker').date(moment.max(theirDate, ourDate));
+        }
+      });
     }
+
+    // We are greater than (younger than) each of these elements
+    if (greaterThans) {
+      greaterThans.split(' ').forEach(function(dp_id, idx, arr) {
+        if (dp_id) {
+          var theirID = '#' + dp_id;
+          var theirDate = $(theirID).data('DateTimePicker').date();
+
+          $(theirID).data('DateTimePicker').date(moment.min(theirDate, ourDate));
+        }
+      });
+    }
+  }
+
+  $(document).ready(function() {
+    $('.datetimepicker').each(function(idx) {
+      $(this).datetimepicker({
+        showTodayButton: true,
+        icons: {
+          time: 'glyphicon glyphicon-time time-btn',
+          date: 'glyphicon glyphicon-calendar date-btn',
+          today: 'glyphicon glyphicon-screenshot now-btn'
+        }
+      });
+    });
+
+    $('.datetimepicker').on('dp.change', updateDatetimePickers);
   });
-});
+})();

--- a/app/form_builders/form_builder_with_date_time_input.rb
+++ b/app/form_builders/form_builder_with_date_time_input.rb
@@ -36,24 +36,34 @@ class FormBuilderWithDateTimeInput < ActionView::Helpers::FormBuilder
   end
 
   def date_select(name, options = {}, html_options = {})
-    existing_date = @object.send(name)
-    formatted_date = existing_date.to_date.strftime("%F") if existing_date.present?
-    field = text_field(name, :value => formatted_date,
-                 :class => "form-control datepicker",
-                 :"data-date-format" => "YYYY-MM-DD")
-    wrap_field name, field, options[:help_text]
+    strftime = "%F"
+    date_format = "YYYY-MM-DD"
+    date_helper name, options, strftime, date_format
   end
 
   def datetime_select(name, options = {}, html_options = {})
-    existing_time = @object.send(name)
-    formatted_time = existing_time.to_time.strftime("%F %I:%M %p") if existing_time.present?
-    field = vanilla_text_field(name, :value => formatted_time,
-                 :class => "form-control datetimepicker",
-                 :"data-date-format" => "YYYY-MM-DD hh:mm A")
-    wrap_field name, field, options[:help_text]
+    strftime = "%F %I:%M %p"
+    date_format = "YYYY-MM-DD hh:mm A"
+    date_helper name, options, strftime, date_format
   end
 
 private
+  # Pass space-delimited list of IDs of datepickers on the :less_than and
+  # :greater_than properties to initialize relationships between datepicker
+  # fields.
+  def date_helper name, options, strftime, date_format
+    existing_time = @object.send(name)
+    formatted_datetime = existing_time.to_time.strftime(strftime) if existing_time.present?
+
+    field = vanilla_text_field(name, :value => formatted_datetime,
+        :class => "form-control datetimepicker",
+        :"data-date-format" => date_format,
+        :"data-date-less-than" => options[:less_than],
+        :"data-date-greater-than" => options[:greater_than])
+
+    wrap_field name, field, options[:help_text]
+  end
+
   def wrap_field name, field, help_text
     @template.content_tag :div, class: "form-group" do
       label(name, class: "control-label") + field + help_text(name, help_text)

--- a/app/views/assessments/_edit_handin.html.erb
+++ b/app/views/assessments/_edit_handin.html.erb
@@ -1,10 +1,25 @@
-<%= f.datetime_select :start_at, help_text: "The time this assessment is released to students." %>
+<% content_for :head do %>
+  <%= javascript_include_tag "initialize_datetimepickers" %>
+<% end %>
 
-<%= f.datetime_select :due_at, help_text: "Students can submit before this time without being penalized or using grace days." %>
+<%# Initialize datepickers by defining linked relationships (using IDs) %>
+<%= f.datetime_select :start_at,
+  help_text: "The time this assessment is released to students.",
+  less_than: "assessment_due_at assessment_end_at assessment_grading_deadline" %>
 
-<%= f.datetime_select :end_at, help_text: "Last possible time that students can submit (except those granted extensions.)" %>
+<%= f.datetime_select :due_at,
+  help_text: "Students can submit before this time without being penalized or using grace days.",
+  greater_than: "assessment_start_at",
+  less_than: "assessment_end_at assessment_grading_deadline" %>
 
-<%= f.datetime_select :grading_deadline, help_text: "Time after which final scores are included in the gradebook" %>
+<%= f.datetime_select :end_at,
+  help_text: "Last possible time that students can submit (except those granted extensions.)",
+  greater_than: "assessment_start_at assessment_due_at",
+  less_than: "assessment_grading_deadline" %>
+
+<%= f.datetime_select :grading_deadline,
+  help_text: "Time after which final scores are included in the gradebook",
+  greater_than: "assessment_start_at assessment_due_at assessment_end_at" %>
 
 <div class="form-group">
   <label for="disable_handins" class="suppress-bottom-margin">Disable Handins</label>

--- a/app/views/assessments/edit.html.erb
+++ b/app/views/assessments/edit.html.erb
@@ -1,6 +1,5 @@
 <% content_for :head do %>
   <%= stylesheet_link_tag "assessments/create_edit" %>
-  <%= javascript_include_tag "initialize_datetimepickers" %>
 <% end %>
 
 <%# For navigation breadcrumbs %>


### PR DESCRIPTION
Makes progress towards #181.

To use, simply enumerate the IDs of datetimepickers which should be
forced to be less than in the `:less_than` field on the FormBuilder, and
those which should be greater in the `:greater_than` field.

The `initialize_datepickers.js` file must be manually included on every
page that uses datetimepickers. We could easily make this a file that is
loaded by default for every page if that's preferable.