### PR TITLE
Update datetime picker in Edit Course. Closes #181

### DIFF
--- a/app/form_builders/form_builder_with_date_time_input.rb
+++ b/app/form_builders/form_builder_with_date_time_input.rb
@@ -10,7 +10,7 @@ class FormBuilderWithDateTimeInput < ActionView::Helpers::FormBuilder
       options[:class] = "form-control #{options[:class]}"
       field = super name, *(args + [ options ])
 
-      wrap_field name, field, options[:help_text]
+      wrap_field name, field, options[:help_text], options[:display_name]
     end
   end
 
@@ -33,6 +33,17 @@ class FormBuilderWithDateTimeInput < ActionView::Helpers::FormBuilder
     options[:class] = "btn btn-primary #{options[:class]}"
 
     super text, *(args + [ options ])
+  end
+
+  def check_box(name, *args)
+    options = args.extract_options!
+
+    field = super name, *(args + [ options ])
+
+    @template.content_tag :div, class: "form-group" do
+       field + label(name, class: "control-label") +
+          help_text(name, options[:help_text])
+    end
   end
 
   def date_select(name, options = {}, html_options = {})
@@ -64,9 +75,9 @@ private
     wrap_field name, field, options[:help_text]
   end
 
-  def wrap_field name, field, help_text
+  def wrap_field name, field, help_text, display_name=nil
     @template.content_tag :div, class: "form-group" do
-      label(name, class: "control-label") + field + help_text(name, help_text)
+      label(name, display_name, class: "control-label") + field + help_text(name, help_text)
     end
   end
 

--- a/app/views/courses/_courseFields.html.erb
+++ b/app/views/courses/_courseFields.html.erb
@@ -1,75 +1,97 @@
-<tr>
-  <th>Course Name</th>
-  <td><%= f.text_field :name %></td>
-  <td class=smallText>The course ID used in URLs and DB keys. This field <b>must</b> be unique and URL-able. Typically includes the course number and semester. Examples: <kbd>15213-f12</kbd>, <kbd>15110-s11</kbd></td>
-</tr>
-<tr>
-  <th>Semester</th>
-  <td><%= f.text_field :semester, :size=>3 %></td>
-  <td class=smallText>The current semester. Examples: <kbd>f12</kbd>, <kbd>s13</kbd>, <kbd>m13</kbd></td>
-</tr>
-<tr>
-  <th>Display Name</th>
-  <td><%= f.text_field :display_name %></td>
-  <td class=smallText>Descriptive course name for displaying. Example: <kbd>15-213: Intro to Comp Systems</kbd></td>
-</tr>
-<tr>
-  <th>Late Slack</th>
-  <td><%= f.text_field :late_slack %></td>
-  <td class=smallText>This is the number of seconds after a deadline that the server will
-still accept a submission and not count it as late. Example: <kbd>3600</kbd></td>
-</tr>
-<tr>
-  <th>Grace Days</th>
-  <td><%= f.text_field :grace_days %></td>
-  <td class=smallText>The total number of grace days for late submissions that students are allowed each semester. Example: <kbd>3</kbd></td>
-</tr>
-  <th>Default Late Penalty</th>
-  <td>
-    <%= f.fields_for :late_penalty, course.late_penalty do |p| %>
-      <%= p.text_field :value, :size => 18 %>
-      <%= p.select :kind, options_for_select({"points" => "points", "%" => "percent"}, :selected => (course.late_penalty ? course.late_penalty.kind : "points")) %>
+
+<%= f.text_field :name,
+  help_text: "The course ID used in URLs and DB keys. This field must be unique
+  and URL-able. Typically includes the course number and semester. Examples:
+  15213-f12, 15110-s11" %></td>
+
+<%= f.text_field :semester, size: 3,
+  help_text: "The current semester. Examples: f12, s13, m13" %>
+
+<%= f.text_field :display_name,
+  help_text: "Descriptive course name for displaying. Example: 15-213: Intro to
+  Computer Systems" %>
+
+<%= f.text_field :late_slack,
+  help_text: "This is the number of seconds after a deadline that the server
+  will still accept a submission and not count it as late. Example: 3600" %>
+
+<%= f.text_field :grace_days,
+  help_text: "The total number of grace days for late submissions that students
+  are allowed each semester. Example: 3" %>
+
+<%= f.fields_for :late_penalty, course.late_penalty do |p| %>
+  <%= content_tag :div, class: "form-group" do %>
+    <%= p.label :late_penalty, class: "control-label" %>
+
+    <%= content_tag :div, class: "row" do %>
+      <%= content_tag :div, class: "col-xs-8" do %>
+        <%= p.vanilla_text_field :value, class: "form-control" %>
+      <% end %>
+      <%= content_tag :div, class: "col-xs-4" do %>
+        <%= p.select :kind, options_for_select({"points" => "points", "%" => "percent"},
+                                               :selected => (course.late_penalty ? course.late_penalty.kind : "points")),
+                            {}, {class: "form-control"} %>
+      <% end %>
     <% end %>
-  </td>
-  <td class=smallText>The penalty applied to late submissions after a student runs out of grace days.  It represents an amount of points or a percentage of the total score removed per day, and must be a non-negative number. This field can be overriden on a per-assessment basis.</td>
-</tr>
-<tr>
-  <th>Default Version Threshold:</th>
-  <td><%= f.text_field :version_threshold %></td>
-  <td class=smallText>If a submission's version is greater than this threshold, it is penalized according to the <em>version penalty</em>. If set to -1, no submissions are penalized. This is required, but can be overridden on a per-assessment basis.</td>
-</tr>
-<tr>
-  <th>Default Version Penalty:</th>
-  <td>
-    <%= f.fields_for :version_penalty, course.version_penalty do |v| %>
-      <%= v.text_field :value, :size => 18 %>
-      <%= v.select :kind, options_for_select({"points" => "points", "%" => "percent"}, :selected => (course.version_penalty ? course.version_penalty.kind : "points")) %>
-    <% end %> 
-  </td>
-  <td class=smallText>The penalty applied to submissions with versions greater than the <em>version threshold</em>. It represents a number of points or percentage of the total score removed per version above the threshold, and must be a non-negative number. For example, if this is set to 1 point and the version threshold to 3, the fifth version of a student's submissions would be docked 2 points. This is required, but can be overridden on a per-assessment basis.</td>
-</tr>
-<tr>
-    <th>Exam In Progress:</th>
-    <td><%= f.check_box :exam_in_progress %></td>
-    <td class="smallText">While checked, students are not allowed to view their previous submissions for <em>any</em> assessment in this class.</td>
-</tr>
-<tr>
-  <th>Course Start Date</th>
-  <td><%= f.date_select :start_date %></td>
-  <td class=smallText>When the course becomes active.</td>
-</tr>
-<tr>
-  <th>Course End Date</th>
-  <td><%= f.date_select :end_date %></td>
-  <td class=smallText>When the course becomes inactive.</td>
-</tr>
-<tr>
-  <th>Disable Course</th>
-  <td><%= f.check_box :disabled %></td>
-  <td class=smallText>If this box is checked, then students won't be able download labs or upload submissions.</td>
-</tr>
-<tr>
-  <th>Student Gradebook Message</th>
-  <td><%= f.text_area :gb_message %></td>
-  <td class=smallText>An optional message that is displayed to students at the top of their gradebooks.  It can be used to explain grading criteria.</td>
-</tr>
+
+    <%= content_tag :p, class: "help-text" do %>
+      The penalty applied to late submissions after a student runs out of grace
+      days. It represents an amount of points or a percentage of the total score
+      removed per day, and must be a non-negative number. This field can be
+      overriden on a per-assessment basis.
+    <% end %>
+  <% end %>
+<% end %>
+
+<%= f.text_field :version_threshold,
+  help_text: "If a submission's version is greater than this threshold, it is
+  penalized according to the version penalty. If set to -1, no submissions are
+  penalized. This is required, but can be overridden on a per-assessment
+  basis." %>
+
+<%= f.fields_for :version_penalty, course.version_penalty do |p| %>
+  <%= content_tag :div, class: "form-group" do %>
+    <%= p.label :version_penalty, class: "control-label" %>
+
+    <%= content_tag :div, class: "row" do %>
+      <%= content_tag :div, class: "col-xs-8" do %>
+        <%= p.vanilla_text_field :value, class: "form-control" %>
+      <% end %>
+      <%= content_tag :div, class: "col-xs-4" do %>
+        <%= p.select :kind, options_for_select({"points" => "points", "%" => "percent"},
+                                               :selected => (course.version_penalty ? course.version_penalty.kind : "points")),
+                            {}, {class: "form-control"} %>
+      <% end %>
+    <% end %>
+
+    <%= content_tag :p, class: "help-text" do %>
+      The penalty applied to submissions with versions greater than the <em>version
+      threshold</em>. It represents a number of points or percentage of the total
+      score removed per version above the threshold, and must be a non-negative
+      number. For example, if this is set to 1 point and the version threshold to 3,
+      the fifth version of a student's submissions would be docked 2 points. This is
+      required, but can be overridden on a per-assessment basis.
+    <% end %>
+  <% end %>
+<% end %>
+
+<b>Exam in Progress?</b>
+<%= f.check_box :exam_in_progress,
+  help_text: "While checked, students are not allowed to view their previous
+  submissions for any assessment in this class." %>
+
+<%= f.date_select :start_date, help_text: "When the course becomes active.",
+  less_than: "course_end_date" %>
+
+<%= f.date_select :end_date, help_text: "When the course becomes inactive.",
+  greater_than: "course_start_date" %>
+
+<b>Disabled?</b>
+<%= f.check_box :disabled,
+  help_text: "If this box is checked, then students won't be able download labs
+  or upload submissions." %>
+
+<%= f.text_area :gb_message,
+  help_text: "An optional message that is displayed to students at the top of
+  their gradebooks.  It can be used to explain grading criteria.",
+  display_name: "Gradebook Message" %>

--- a/app/views/courses/edit.html.erb
+++ b/app/views/courses/edit.html.erb
@@ -1,11 +1,14 @@
+<% content_for :head do %>
+  <%= javascript_include_tag "initialize_datetimepickers" %>
+<% end %>
 <% @title = "Edit Course" %>
 
-<%= form_for @course, as: :editCourse, url: course_path(@course), method: :patch do |f| %>
+<%= form_for @course, as: :editCourse, url: course_path(@course), method: :patch, builder: FormBuilderWithDateTimeInput do |f| %>
 <% if @course.errors.any? %>
 	<div id="error_explanation">
 		<h2><%= pluralize(@course.errors.count, "error") %>
       prohibited this course from being saved:</h2>
-			
+
 		<ul>
 			<% @course.errors.full_messages.each do |msg| %>
 			<li><%= msg %></li>
@@ -14,9 +17,12 @@
 	</div>
 <% end %>
 
-<table width=70% class="verticalTable">
-  <%= render :partial=>"courseFields", :locals=>{:f=>f, :course=>@course} %>
-</table>
+
+<div class="row">
+  <div class="col-md-6">
+    <%= render :partial=>"courseFields", :locals=>{:f=>f, :course=>@course} %>
+  </div>
+</div>
 
 <br>
 <%= f.submit 'Update', { :class=> "btn primary" } %>
@@ -24,6 +30,6 @@
 <hr>
 
 <% if current_user.administrator? %>
-<%= link_to "Delete Course", course_path(@course), method: :delete, 
+<%= link_to "Delete Course", course_path(@course), method: :delete,
 	data: {confirm: "Are you sure to destroy #{@course.display_name}?"}, class: "btn" %>
-<% end %> 
+<% end %>


### PR DESCRIPTION
I'm pretty sure that this is all the datetime pickers. Obviously, if one
comes up that I've missed, let me know.

Also, as a part of the process of fixing the datetime pickers, I've been
restyling forms to look more like native Bootstrap. At some point, I
hope that we can just use the `FormBuilderWithDateTimeInput` as our
default form initializer, as it contains a bunch of convenience methods
for adding help text and similar things.