### PR TITLE
Tidy up FormBuilderWithDateTimeInput labels

### DIFF
--- a/app/assets/stylesheets/style.css.scss
+++ b/app/assets/stylesheets/style.css.scss
@@ -643,6 +643,11 @@ input[type="password"]:focus {
   outline: none;
 }
 
+input[type="checkbox"] {
+  // For spacing between this and an adjacent label
+  margin-right: 10px;
+}
+
 .page-wrapper {
   min-height: 100%;
   /* equal to footer height */

--- a/app/form_builders/form_builder_with_date_time_input.rb
+++ b/app/form_builders/form_builder_with_date_time_input.rb
@@ -38,10 +38,12 @@ class FormBuilderWithDateTimeInput < ActionView::Helpers::FormBuilder
   def check_box(name, *args)
     options = args.extract_options!
 
+    display_name = options[:display_name]
+
     field = super name, *(args + [ options ])
 
     @template.content_tag :div, class: "form-group" do
-       field + label(name, class: "control-label") +
+       field + label(name, display_name, class: "control-label") +
           help_text(name, options[:help_text])
     end
   end

--- a/app/views/assessments/_edit_basic.html.erb
+++ b/app/views/assessments/_edit_basic.html.erb
@@ -1,25 +1,40 @@
-<%= f.text_field :name, disabled: true, class: "form-control", help_text: "The unique (for this course) name of the assessment. Must be lowercase alphanumeric (no punctuation). E.g., <kbd>malloclab</kbd>".html_safe %>
+<%= f.text_field :name, disabled: true, class: "form-control",
+  help_text: "The unique (for this course) name of the assessment. Must be
+  lowercase alphanumeric (no punctuation). E.g.,
+  <kbd>malloclab</kbd>".html_safe %>
 
-<%= f.text_field :display_name, help_text: "Name that will be displayed on the course home page. E.g., 'Malloc Lab'" %>
+<%= f.text_field :display_name,
+  help_text: "Name that will be displayed on the course home page. E.g.,
+  'Malloc Lab'" %>
 
 <div class="form-group">
   <%= f.label :category_id %>
   <%= f.collection_select :category_id, @course.assessment_categories, :id, :name, {selected: @assessment.category.id}, {class: "form-control"} %>
   <p class="help-block">You can create a new category <%= link_to "here", new_course_assessment_category_path %>.</p>
 </div>
-<hr>
-<h4>Modules Used</h4>
-<%= f.check_box :has_autograde%>
-<label for="assessment_has_autograde">Autograde</label><br>
-<%= f.check_box :has_partners %>
-<label for="assessment_has_partners">Partners</label><br>
-<%= f.check_box :has_svn %>
-<label for="assessment_has_svn">SVN</label><br>
-<%= f.check_box :has_scoreboard %>
-<label for="assessment_has_scoreboard">Scoreboard</label><br>
-<hr>
-<%= f.text_area  :description %>
 
+<hr>
+
+<h4>Modules Used</h4>
+<%= f.check_box :has_autograde,
+  display_name: "Enable autograding?",
+  help_text: "Whether this assignment will be autograded." %>
+
+<%= f.check_box :has_partners,
+  display_name: "Partner assignment?",
+  help_text: "Is this a group or partner assignment?" %>
+
+<%= f.check_box :has_svn,
+  display_name: "Use SVN?",
+  help_text: "Whether to use SVN in conjunction with this assignment." %>
+
+<%= f.check_box :has_scoreboard,
+  display_name: "Enable scoreboard?",
+  help_text: "Should there be a publically-visible scoreboard?" %>
+
+<hr>
+
+<%= f.text_area  :description %>
 
 <%= f.text_field :handout, help_text: "File in the assessment directory containing materials that the instructor hands out to students or URL to redirect to. E.g., 'malloclab-handout.tar', 'http://school.edu/class/malloclab.zip'" %>
 

--- a/app/views/assessments/_edit_handin.html.erb
+++ b/app/views/assessments/_edit_handin.html.erb
@@ -22,9 +22,9 @@
   greater_than: "assessment_start_at assessment_due_at assessment_end_at" %>
 
 <div class="form-group">
-  <label for="disable_handins" class="suppress-bottom-margin">Disable Handins</label>
-  <%= f.check_box :disable_handins %>
-  <p class="help-block">Check this to disallow handins through Autolab. E.g., paper exams, problem sets</p>
+  <%= f.check_box :disable_handins,
+    help_text: "Check this to disallow handins through Autolab. E.g., paper
+    exams, problem sets" %>
 </div>
 
 <%= content_tag :div, id: "handin", class: (f.object.disable_handins ? "disabled" : "") + " form-group" do %>

--- a/app/views/courses/_courseFields.html.erb
+++ b/app/views/courses/_courseFields.html.erb
@@ -75,7 +75,6 @@
   <% end %>
 <% end %>
 
-<b>Exam in Progress?</b>
 <%= f.check_box :exam_in_progress,
   help_text: "While checked, students are not allowed to view their previous
   submissions for any assessment in this class." %>
@@ -86,7 +85,6 @@
 <%= f.date_select :end_date, help_text: "When the course becomes inactive.",
   greater_than: "course_start_date" %>
 
-<b>Disabled?</b>
 <%= f.check_box :disabled,
   help_text: "If this box is checked, then students won't be able download labs
   or upload submissions." %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,10 +6,10 @@
     <%= favicon_link_tag 'autolab.ico' %>
 
     <%= stylesheet_link_tag 'application' %>
-    <%= stylesheet_link_tag 'style' %>
     <%= stylesheet_link_tag 'animate' %>
 
     <%= external_stylesheet_link_tag "bootstrap", "3.0.0" %>
+    <%= stylesheet_link_tag 'style' %>
 
     <%= external_javascript_include_tag "jquery", "2.1.1" %>
     <%= external_javascript_include_tag "bootstrap", "3.0.0" %>

--- a/app/views/layouts/home.html.erb
+++ b/app/views/layouts/home.html.erb
@@ -5,10 +5,10 @@
     <%= csrf_meta_tag %>
     <%= favicon_link_tag 'autolab.ico' %>
 
-    <%= stylesheet_link_tag 'style' %>
     <%= stylesheet_link_tag 'animate' %>
 
     <%= external_stylesheet_link_tag "bootstrap", "3.0.0" %>
+    <%= stylesheet_link_tag 'style' %>
 
     <%= external_javascript_include_tag "jquery", "2.1.1" %>
     <%= external_javascript_include_tag "bootstrap", "3.0.0" %>


### PR DESCRIPTION
Addresses @dlbucci's comment in #181.

One of the things I needed to do to get this to work was to swap the Boostrap
CSS link tag with our style.css link in the base layout files. This might have
some negative effects, but I didn't notice any.