### PR TITLE
Don't create duplicate AUD for lab template

### DIFF
--- a/lib/tasks/autolab.rake
+++ b/lib/tasks/autolab.rake
@@ -305,10 +305,6 @@ namespace :autolab do
 
     # Reload config file
     asmt.construct_config_file
-
-    # create all auds
-    asmt.create_AUDs_modulo_callbacks
-
   end
 
   task :populate, [:name] => :environment do |t, args|


### PR DESCRIPTION
Lab template is created after users are populated, so AUD are already created.