### PR TITLE
Hotfix for MOSS Archive support

### DIFF
--- a/app/controllers/admins_controller.rb
+++ b/app/controllers/admins_controller.rb
@@ -345,6 +345,7 @@ e.to_s() + e.backtrace().join("<br>")
   def runMoss
     # Return if we have no files to process.
     unless request.post? and (params["assessments"] or params["external_tar"])
+      flash[:error] = "No input files provided for MOSS."
       redirect_to :action=>"moss" and return
     end
     assessmentIDs = params["assessments"]
@@ -428,7 +429,7 @@ e.to_s() + e.backtrace().join("<br>")
             pathname = entry.respond_to?(:full_name) ? entry.full_name : entry.name
 	    destination = "#{stuDir}/#{pathname}"
 	    begin
-	      open destination, 'wb', "664" do |out|
+	      open destination, 'wb' do |out|
                 out.write entry.read
                 out.fsync rescue nil # for filesystems without fsync(2)
               end

--- a/app/views/admins/moss.html.erb
+++ b/app/views/admins/moss.html.erb
@@ -61,9 +61,10 @@ function filterCourses(name) {
 <br>
 
 <h2><b>Step 2:</b> (Optional) Upload a tarball containing the additional submissions you'd like Moss to compare against.</h2>
-<h3>(Note: Each additional submission, tarball or single file, <b>must</b> be placed directly in the tar file.)</h3>
+<!--<h3>(Note: Each additional submission, tarball or single file, <b>must</b> be placed directly in the tar file.)</h3>-->
 
-<%= file_field_tag 'external_tar' %>
+<!--%= file_field_tag 'external_tar' %-->
+<h4><i>Currently, external tar uploads are not working. We hope to resolve this issue soon.</i></h4>
 
 <p>
 <br>

--- a/app/views/admins/moss.html.erb
+++ b/app/views/admins/moss.html.erb
@@ -71,6 +71,6 @@ function filterCourses(name) {
 <h2><b>Step 3:</b> Click "Go!" once to run Moss. This may take up to a minute, so be patient...</h2>
 
 <p>
-<%= submit_tag "Go!", :disable_with => "Please wait...", :class => "btn primary" %>
+<%= submit_tag "Go!", :data => { :disable_with => "Please wait..." }, :class => "btn primary" %>
 </p>
 </form>


### PR DESCRIPTION
Tested on local Autolab instance.

Note: MOSSing with external archives is still **not** working. The next PR is for refactoring out archive-related functions and making `runMoss` much cleaner.