### PR TITLE
Fix autograding feedback files

### DIFF
--- a/app/controllers/assessment/autograde.rb
+++ b/app/controllers/assessment/autograde.rb
@@ -1,6 +1,6 @@
 module AssessmentAutograde
   require 'uri'
-  require Rails.root.join("config", "autogradeConfig.rb")
+  require_relative Rails.root.join("config", "autogradeConfig.rb")
 
   # method called when Tango returns the output
   # action_no_auth :autograde_done


### PR DESCRIPTION
Now the server actually starts, feedback is saved for every member of a group, and dave values are set to nil after a submission receives feedback, so multiple autograde_done's can't be called unless the same submission is graded multiple times.