### PR TITLE
Fix formatRawJob

### DIFF
--- a/app/controllers/jobs_controller.rb
+++ b/app/controllers/jobs_controller.rb
@@ -184,9 +184,8 @@ class JobsController < ApplicationController
     
     if rjob["notifyURL"] then
       params =  rjob["notifyURL"].split('/')
-      job[:submission] = params[-2]
-      job[:assessment] = params[-4]
-      job[:course] = params[-6]
+      job[:assessment] = params[-2]
+      job[:course] = params[-4]
     end
 
     # Determine whether to expose the job name.


### PR DESCRIPTION
Fixes #324
The issue was that notifyURL changed with the autograding changes, and no longer includes a submission id.  I can't even see that we were using it though...