### PR TITLE
Fixed getjob feedback and times

### DIFF
--- a/app/controllers/assessment/autograde.rb
+++ b/app/controllers/assessment/autograde.rb
@@ -237,7 +237,7 @@ module AssessmentAutograde
     callBackURL = if RESTFUL_USE_POLLING then
       ""
     else
-      "#{hostname}/courses/#{course.id}/assessments/#{assessment.id}/autograde_done?dave=#{dave}" 
+      "#{hostname}/courses/#{course.id}/assessments/#{assessment.id}/autograde_done?dave=#{dave}&submission_id=#{submissions[0].id}" 
     end
 
     COURSE_LOGGER.log("Callback: #{callBackURL}") 

--- a/app/controllers/jobs_controller.rb
+++ b/app/controllers/jobs_controller.rb
@@ -1,5 +1,8 @@
-class JobsController < ApplicationController
+require 'cgi'
+require 'uri'
 
+class JobsController < ApplicationController
+  
   autolabRequire Rails.root.join('config', 'autogradeConfig.rb')
 
   # 
@@ -123,15 +126,23 @@ class JobsController < ApplicationController
     # assign it to the @feedback_str instance variable for later
     # use by the view
     if rjob["notifyURL"] then 
-
+      uri = URI(rjob["notifyURL"])
+      
       # Parse the notify URL from the autograder
-      params =  rjob["notifyURL"].split('/')
-      url_submission = params[-2]
-      url_assessment = params[-4]
-      url_course = params[-6]
+      path_parts =  uri.path.split('/')
+      url_course = path_parts[2]
+      url_assessment = path_parts[4]
+      
+      # create a hash of keys pointing to value arrays
+      params = CGI::parse(uri.query) 
    
       # Grab all of the scores for this submission
-      scores = Score.where(:submission_id=>url_submission)
+      begin
+        submission = Submission.find(params["submission_id"][0])
+      rescue # submission not found, tar tar sauce!
+        return 
+      end
+      scores = submission.scores
 
       # We don't have any information about which problems were
       # autograded, so search each problem until we find one
@@ -183,9 +194,10 @@ class JobsController < ApplicationController
     job[:name] = rjob["name"]
     
     if rjob["notifyURL"] then
-      params =  rjob["notifyURL"].split('/')
-      job[:assessment] = params[-2]
-      job[:course] = params[-4]
+      uri = URI(rjob["notifyURL"])
+      path_parts = uri.path.split('/')
+      job[:course] = path_parts[2]
+      job[:assessment] = path_parts[4]
     end
 
     # Determine whether to expose the job name.

--- a/app/views/jobs/getjob.html.erb
+++ b/app/views/jobs/getjob.html.erb
@@ -41,16 +41,15 @@
 
 <h2>Runtime Trace</h2>
 <ul>
-<% for item in @job[:rjob]["trace"] do %>
-  <li> <%= item %>
-<% end %>
+  <% for item in @job[:rjob]["trace"] do %>
+    <% poo = item.split("|") %>
+    <li><%= DateTime.parse(poo[0]).to_time.localtime.to_s(:db) %> | <%= poo[1] %></li>
+  <% end %>
 </ul>
 
 <h2>Most Recent Autograder Feedback for this Submission</h2>
 <% if @feedback_str == nil || @feedback_str == "" then %>
-None available
+  <pre>No Feedback Available</pre>
 <% else %>
-<pre>
-<%= @feedback_str %>
-</pre>
+  <pre><%= @feedback_str %></pre>
 <% end %>


### PR DESCRIPTION
Fixes trace times to be local, not UTC, and should display feedback on the page again.