### PR TITLE
Fix Manage Submissions Toggle

### DIFF
--- a/app/assets/javascripts/manage_submissions.js
+++ b/app/assets/javascripts/manage_submissions.js
@@ -116,4 +116,13 @@ jQuery(function($) {
     e.stopPropagation();
   });
 
+  $('.regrade-override').click(function(e) {
+    // Because regrade requests are sent with `data-method="post"`, we need to
+    // trick the link into behaving... like a link. When holding down Ctrl or
+    // Cmd, the regrade should open in a new tab.
+    if (e.metaKey || e.ctrlKey) {
+      $(this).attr('target', '_blank');
+    }
+  });
+
 });

--- a/app/assets/javascripts/manage_submissions.js
+++ b/app/assets/javascripts/manage_submissions.js
@@ -100,9 +100,14 @@ jQuery(function($) {
   }
 
   $('#submissions').on("click", ".submission-row", function(e) {
-    var submissionId = parseInt(e.currentTarget.id.replace("row-", ""), 10);
-    toggleRow(submissionId);
-    return false;
+    // Don't toggle row if we originally clicked on an anchor tag
+    if(e.target.localName != 'a') {
+      // e.target: tightest element that triggered the event
+      // e.currentTarget: element the event has bubbled up to currently
+      var submissionId = parseInt(e.currentTarget.id.replace("row-", ""), 10);
+      toggleRow(submissionId);
+      return false;
+    }
   });
 
   $('#submissions').on("click", ".cbox", function(e) {

--- a/app/views/submissions/index.html.erb
+++ b/app/views/submissions/index.html.erb
@@ -11,12 +11,12 @@
 
   <%= javascript_include_tag "table_floating_header" %>
   <%= javascript_include_tag "manage_submissions" %>
-    
+
 <% end %>
 
 <hr>
 <p>
-<%= link_to "Create New Submission", new_course_assessment_submission_path(@course, @assessment), 
+<%= link_to "Create New Submission", new_course_assessment_submission_path(@course, @assessment),
     {:title=>"Create a new submission for a student, with an option to submit a handin file on their behalf",
      :class=>"btn"} %>
 <%= link_to "Download All Submissions",
@@ -28,23 +28,23 @@
     {:title=>"Download the most recent submission from each student",
      :class=>"btn"} %>
 <%= link_to "Missing Submissions",
-    missing_course_assessment_submissions_path(@course, @assessment), 
+    missing_course_assessment_submissions_path(@course, @assessment),
     {:title=>"List the students who have not submitted anything. You'll be given the option to create new submissions for the missing students",
      :class=>"btn"} %>
 </p>
 <p>
 <% if @autograded then %>
-<%= link_to "Regrade All", 
-    [:regradeAll, @course, @assessment], 
+<%= link_to "Regrade All",
+    [:regradeAll, @course, @assessment],
     { method: :post,
-     :title=>"Regrade the most recent submission from each student", 
+     :title=>"Regrade the most recent submission from each student",
      :confirm=>"Are you sure you want to do this? It will regrade the most recent submission from each student, which might take a while.",
      :class=>"btn"} %>
 
-<%= link_to "Regrade 0 Submissions", 
-    [:regradeBatch, @course, @assessment], 
+<%= link_to "Regrade 0 Submissions",
+    [:regradeBatch, @course, @assessment],
     { method: :post,
-     :title=>"Regrade the most recent submission from each student", 
+     :title=>"Regrade the most recent submission from each student",
      :class=>"btn",
      :id => "batch-regrade",
      :style => "display:none;"} %>
@@ -65,10 +65,10 @@
     </tr>
   </thead>
   <tbody>
-  <% for submission in @submissions %> 
+  <% for submission in @submissions %>
     <tr id="row-<%= submission.id %>" class="submission-row">
       <td><input class="cbox" type="checkbox" id="cbox-<%= submission.id %>"></td>
-      <td><%= link_to submission.course_user_datum.email,          
+      <td><%= link_to submission.course_user_datum.email,
                       history_course_assessment_path(@course, @assessment, cud_id: submission.course_user_datum_id, partial: true),
                       {remote: true, class: :trigger}
 
@@ -89,8 +89,8 @@
         <%= submission.submitter_ip %>
       </td>
       <td><% if @autograded and submission.version > 0 then %>
-            <%= link_to "Regrade", 
-                [:regrade, @course, @assessment, submission_id: submission.id], 
+            <%= link_to "Regrade",
+                [:regrade, @course, @assessment, submission_id: submission.id],
                 { method: :post,
                  :title=>"Rerun the autograder on this submission",
                  :class=>"btn small"} %>

--- a/app/views/submissions/index.html.erb
+++ b/app/views/submissions/index.html.erb
@@ -93,7 +93,7 @@
                 [:regrade, @course, @assessment, submission_id: submission.id],
                 { method: :post,
                  :title=>"Rerun the autograder on this submission",
-                 :class=>"btn small"} %>
+                 :class=>"btn small regrade-override"} %>
           <% end %>
           <%= link_to "Edit", [:edit, @course, @assessment, submission],
               {:title=>"Edit the grading properties of this submission",


### PR DESCRIPTION
> On March 6, 2015, Iliano Cervesato wrote:
>
> Hello,
>
> in the “Manage submissions” page (15-312Q: Foundations of Programming
> Languages (Qatar) (s15) » hw03 » Manage Submissions), if I click on the links
> or buttons inside the submission table, it toggles the checkbox rather than
> taking me to that link or performing the action associated with that button.
>
> That means that I cannot look at the submission of an individual student: I
> have to download them all and then look at that student’s code.
>
> Many thanks,
>   Iliano

Commit Summary
--------------

154cfa1 Strip whitespace

f6a5a4e Toggle only when an anchor tag wasn't clicked