### PR TITLE
Trim unnecessary routes.

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,7 @@ Autolab3::Application.routes.draw do
     get 'vmlist'
   end
 
-  resource :admin do
+  resource :admin, only: :show do
     match 'emailInstructors', via: [:get, :post]
   end
 


### PR DESCRIPTION
Trimming down the following unnecessary routes:
- `POST admins#create`
- `GET admins#new`
- `GET admin#edit`
- `PATCH/PUT admin#update`
- `DELETE admin#destroy`

Tested to work on my local dev environment.