### PR TITLE
Updated 500 page error message.

### DIFF
--- a/public/500.html
+++ b/public/500.html
@@ -18,8 +18,9 @@
             <div id="content">
                 <h2>500 - Internal error</h2>
 
-                <p><b>Oops!</b> Autolab seems to have done something wrong.  We have been notified about this and will look into it. If you would like to file a Bug Report, you may email us at: <a href="mailto:autolab-dev@andrew.cmu.edu">autolab-dev@andrew.cmu.edu</a>.
-                </p>
+                <p><b>Oops!</b> Autolab seems to have done something wrong.</p>
+                <p><b>We have NOT been notified about this.</b></p>
+                <p>Please email us at <a href="mailto:autolab-dev@andrew.cmu.edu">autolab-dev@andrew.cmu.edu</a> if you would like this bug to get fixed.</p>
                 <img src="/assets/DonkeyKong.jpg" width=200px />
             </div>
             <div id="footer">


### PR DESCRIPTION
Since we no longer get error messages when Rails fails and we go to the apache public page backup, we should let people know that they need to email us.