### PR TITLE
Added test for autograding (half-) round-trip.

### DIFF
--- a/lib/tasks/autolab.rake
+++ b/lib/tasks/autolab.rake
@@ -285,6 +285,14 @@ namespace :autolab do
       FileUtils.mkdir_p(File.join(course_dir, a.name, a.handin_directory))
     end
 
+    # Load autograding properties
+    autograde_prop = AutogradingSetup.new
+    autograde_prop.assessment_id = asmt.id
+    autograde_prop.autograde_image = "rhel.img"
+    autograde_prop.autograde_timeout = 180
+    autograde_prop.release_score = true
+    autograde_prop.save!
+
     # Load problem "autograded"
     asmt.problems.create(name: AUTOGRADE_TEMPLATE_PROBLEM_NAME,
                          max_score: AUTOGRADE_TEMPLATE_MAX_SCORE)

--- a/spec/features/autograding_roundtrip_spec.rb
+++ b/spec/features/autograding_roundtrip_spec.rb
@@ -1,0 +1,31 @@
+require 'tempfile'
+
+RSpec.describe "autograding", type: :feature do
+  it "runs through successfully" do
+    # Simulates user log in
+    visit "/auth/users/sign_in"
+    fill_in "user_email", with: "admin@foo.bar"
+    fill_in "user_password", with: "adminfoobar"
+    click_button "Sign in"
+    expect(page).to have_content "Signed in successfully."
+
+    # Goes into assessment submission page
+    click_link "AutoPopulated (SEM)"
+    click_link "Lab Template"
+
+    # Submit adder file
+    tmp_file = Tempfile.new('adder.py')
+    tmp_file << "def adder(x,y):\n\treturn x+y"
+    tmp_file.flush
+    tmp_file.close
+    attach_file("submission_file", tmp_file.path)
+    click_button "fake-submit"
+    expect(page).to have_content "Refresh the page to see the results."
+
+    # Verify job status page
+    sleep(15)
+    first('#flash_success a').click
+    expect(page).to have_content "AutoPopulated_labtemplate"
+    expect(page).to have_content "Success: Autodriver returned normally"
+  end
+end

--- a/spec/features/user_log_in_spec.rb
+++ b/spec/features/user_log_in_spec.rb
@@ -1,4 +1,3 @@
-# <<<<<<< HEAD
 RSpec.describe "home page", type: :feature do
   it "allows registered user to log in" do
     user = FactoryGirl.create(:user)


### PR DESCRIPTION
This test submits a file for the autograded assessment, and verifies that the job completes in a reasonable amount of time.

Note: Currently a full round-trip is not possible because the callback cannot reach the VMs for Travis CI.