### PR TITLE
Moved Course routes into Member Block

### DIFF
--- a/app/controllers/course_user_data_controller.rb
+++ b/app/controllers/course_user_data_controller.rb
@@ -56,7 +56,7 @@ class CourseUserDataController < ApplicationController
     if @newCUD.save
       flash[:success] = "Success: added user #{email} in #{@course.display_name}"
       if @cud.user.administrator?
-        redirect_to(course_users_path) && return
+        redirect_to([:users, @course]) && return
       else
         redirect_to(action: "new") && return
       end
@@ -142,7 +142,7 @@ class CourseUserDataController < ApplicationController
     if @destroyCUD && @destroyCUD != @cud && params[:yes1] && params[:yes2] && params[:yes3]
       @destroyCUD.destroy # awwww!!!
     end
-    redirect_to(course_users_path(@course)) && return
+    redirect_to([:users, @course]) && return
   end
 
   # Non-RESTful paths below
@@ -150,7 +150,7 @@ class CourseUserDataController < ApplicationController
   # this GET page confirms that the instructor wants to destroy the user
   action_auth_level :destroyConfirm, :instructor
   def destroyConfirm
-    @destroyCUD = @course.course_user_data.find(params[:course_user_datum_id])
+    @destroyCUD = @course.course_user_data.find(params[:id])
   end
 
   action_auth_level :sudo, :instructor
@@ -202,7 +202,7 @@ private
 
   def add_users_breadcrumb
     if @cud.instructor
-      @breadcrumbs << (view_context.link_to "Users", [@course, :users])
+      @breadcrumbs << (view_context.link_to "Users", [:users, @course])
     end
   end
 

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -217,12 +217,6 @@ class CoursesController < ApplicationController
     end
   end
 
-  action_auth_level :sudo, :instructor
-  def sudo
-    session[:sudo] = nil
-    redirect_to([:sudo, @course, @cud]) && return
-  end
-
   action_auth_level :reload, :instructor
   def reload
     if @course.reload_course_config

--- a/app/views/course_user_data/edit.html.erb
+++ b/app/views/course_user_data/edit.html.erb
@@ -102,7 +102,7 @@
   <input id="user_submit" name="commit" type="submit" class="btn primary" value="Save Changes" onclick="formvalidation(this.parentNode); return false;">
   <!--<%= f.submit 'Save Changes' , {:class=>"btn primary"} %>-->
   <%= if @cud.instructor? then
-        link_to raw('<span class="btn">Delete User</span>'), course_course_user_datum_destroyConfirm_path(@course, @editCUD), data: {confirm: "Are you sure!?"}
+        link_to raw('<span class="btn">Delete User</span>'), [:destroyConfirm, @course, @editCUD]
   end %>
 
 <%end %>

--- a/app/views/course_user_data/new.html.erb
+++ b/app/views/course_user_data/new.html.erb
@@ -9,7 +9,7 @@
       var email_input = document.getElementById("course_user_datum_user_attributes_email").value;
       if (!email_input || email_input == "") return;
 
-      $.get('<%= url_for :controller=>"courses", :action=>"userLookup", :remote=>true  %>',  { email: email_input }, function( data ) {
+      $.get('<%= url_for [:userLookup, @course, remote: true]  %>',  { email: email_input }, function( data ) {
 
         if (!data)  {
           $('#course_user_datum_user_attributes_first_name').prop('disabled', false);

--- a/app/views/courses/manage.html.erb
+++ b/app/views/courses/manage.html.erb
@@ -17,27 +17,27 @@
 
     <li><%= link_to "Course settings", [:edit, @course], 
         { title: "Modify the properties for this course" } %></li>
-    <li><%= link_to "Manage students", course_users_path(@course), 
+    <li><%= link_to "Manage students", [:users, @course],
         { title: "Create, modify, and delete user accounts" } %></li>
-    <li><%= link_to "Install assessment", installAssessment_course_assessments_path(@course), 
+    <li><%= link_to "Install assessment", [:installAssessment, @course, :assessments], 
         { title: "Create an assessment from scratch or install one from an existing directory" } %></li>
-    <li><%= link_to "Install quiz", installQuiz_course_assessments_path(@course), 
+    <li><%= link_to "Install quiz", [:installQuiz, @course, :assessments],
         { title: "Create a quiz" } %></li>
-    <li><%= link_to "Send bulk email", course_email_path, 
+    <li><%= link_to "Send bulk email", [:email, @course],
         { title: "Send an email to everyone in the class" } %></li>
-    <li><%= link_to "Manage course attachments", course_attachments_path(@course), 
+    <li><%= link_to "Manage course attachments", [@course, :attachments],
         { title: "Distribute files to your students" } %></li>
-    <li><%= link_to "Manage announcements", course_announcements_path(@course), 
+    <li><%= link_to "Manage announcements", [@course, :announcements],
         { title: "Manage announcements via banners on either front page or all pages (persistent)." } %></li>
-    <li><%= link_to "Release all grades", bulkRelease_course_course_user_datum_gradebook_path(@course, @cud), 
+    <li><%= link_to "Release all grades", [:bulkRelease, @course, @cud, :gradebook],
         { title: "Release all grades for all assessments" } %></li>
-    <li><%= link_to "Manage schedulers", course_schedulers_path(@course), 
+    <li><%= link_to "Manage schedulers", [@course, :schedulers], 
         { title: "Set and update scheduler for log submissions. (Advanced feature)"} %></li>
-    <li><%= link_to "Act as user", course_sudo_path(@course), 
+    <li><%= link_to "Act as user", [:sudo, @course, @cud], 
         { title: "Temporarily become another user" } %></li>
-    <li><%= link_to "Run Moss cheat checker", course_moss_path(@course), 
+    <li><%= link_to "Run Moss cheat checker", [:moss, @course],
         { title: "Use the Stanford Moss server to detect copying" } %></li>
-    <li><%= link_to "Reload course config file", course_reload_path(@course), 
+    <li><%= link_to "Reload course config file", [:reload, @course],
         { title: "Do this each time your modify the course.rb file" } %></li>
   </ul>
 

--- a/app/views/courses/moss.html.erb
+++ b/app/views/courses/moss.html.erb
@@ -30,7 +30,7 @@
 
 <h2><b>Step 1:</b> Click on course names to see their assessments, then check box all of the assessments you want Moss to compare against.</h2>
 <h3 style="display:inline">Filter Courses (Keywords Separated by Space): </h3><input type="text" onkeyup="filterCourses(this.value.toLowerCase())" />
-<%= form_tag([@course, :runMoss], multipart: true) do %>
+<%= form_tag([:runMoss, @course], multipart: true) do %>
   <ul class="moss-list">
   <% for course in @courses %>
     <li class="filterableCourse" id="<%= course.display_name %>">

--- a/app/views/courses/users.html.erb
+++ b/app/views/courses/users.html.erb
@@ -41,8 +41,7 @@
 
 <hr>
 <p>
-<%= link_to raw('<span class="btn">Add User to Course</span>'),
-  new_course_course_user_datum_path %>
+<%= link_to raw('<span class="btn">Add User to Course</span>'), [:new, @course, :course_user_datum] %>
 <%= link_to raw('<span class="btn">Import Roster/Users</span>'), {:action=>"uploadRoster"} %>
 <%= link_to raw('<span class="btn">Export Roster</span>'), {:action=>"downloadRoster"} %>
 </p>

--- a/app/views/home/error.html.erb
+++ b/app/views/home/error.html.erb
@@ -13,7 +13,7 @@
   <p><i>Remember that if you modify any config files, you'll need to  reload them for the changes to take effect.</i><br>
     <% if @course_id then %>
       <b><%= link_to "Reload Course Config",
-              course_reload_path(course_id: @course_id) %></b><br>
+              reload_course_path(course_id: @course_id) %></b><br>
       <% if @assessment_id then %>
         <b><%= link_to "Reload Assessment Config",
                 reload_course_assessment_path(course_id: @course_id,

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -15,8 +15,7 @@
 
       <% if session[:sudo] && @cud then %>
       <li>
-        <%= link_to "(#{@cud.display_name}) Reset user",
-        course_course_user_datum_unsudo_path(course_user_datum_id: current_user.id) %>
+        <%= link_to "(#{@cud.display_name}) Reset user", [:unsudo, @course, @cud] %>
       </li>
       <% end %>
 
@@ -30,12 +29,12 @@
         <%= link_to link, course_course_user_datum_gradebook_path(@cud.course, @cud), :title => "View your gradebook" %>
       </li>
       <li>
-        <%= link_to "Jobs", course_jobs_path(@cud.course), :title => "View a history of autograding jobs" %>
+        <%= link_to "Jobs", [@course, :jobs], :title => "View a history of autograding jobs" %>
       </li>
 
       <% if @cud.instructor? %>
       <li>
-        <%= link_to "Manage Course", course_manage_path(@cud.course), :title => "Perform course-wise administrative actions" %>
+        <%= link_to "Manage Course", [:manage, @course], :title => "Perform course-wise administrative actions" %>
       </li>
       <% end %>
       <% end %>
@@ -61,7 +60,7 @@
           <% end %>
           <% if @course and @cud %>
           <li role="presentation">
-            <%= link_to "Course Profile", course_course_user_datum_path(@course, @cud), :title => "View your user profile for the current course" %>
+            <%= link_to "Course Profile", [@course, @cud], :title => "View your user profile for the current course" %>
           </li>
           <% end %>
           <% if Rails.env.development? %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -58,7 +58,7 @@
         <a href="http://autolabproject.com">Autolab Project</a>
         · <a href="/contact">Contact</a>
         <% if @course %>
-        · <%= link_to "Need Help?", course_report_bug_path(@course) %>
+        · <%= link_to "Need Help?", [:report_bug, @course] %>
         <% end %>
         </div>
         <!-- End Footer -->

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Autolab3::Application.routes.draw do
   get "contact", to: "home#contact"
 
   namespace :home do
-    match "developer_login", via: [:post, :get]
+    match "developer_login", via: [:get, :post]
     get "error"
     get "no_user"
     get "vmlist"
@@ -22,9 +22,6 @@ Autolab3::Application.routes.draw do
   end
 
   resources :courses, param: :name do
-    match "report_bug", via: [:post, :get]
-    get "userLookup"
-
     resources :schedulers
     resources :jobs, only: :index do
       get "getjob", on: :member
@@ -42,18 +39,21 @@ Autolab3::Application.routes.draw do
           post "join"
           post "leave"
         end
+
         post "import", on: :collection
       end
       resources :problems, except: [:index, :show]
       resources :submissions do
         resources :annotations, only: [:create, :update, :destroy]
         resources :scores, only: [:create, :show, :update]
+
         member do
           get "destroyConfirm"
           get "download"
           get "listArchive", as: :list_archive
           get "view"
         end
+
         collection do
           get "downloadAll"
           get "missing"
@@ -116,10 +116,6 @@ Autolab3::Application.routes.draw do
     end
 
     resources :course_user_data do
-      match "sudo", via: [:get, :post]
-      get "unsudo"
-      get "destroyConfirm"
-
       resource :gradebook, only: :show do
         get "bulkRelease"
         get "csv"
@@ -128,18 +124,27 @@ Autolab3::Application.routes.draw do
         get "student"
         get "view"
       end
+
+      member do
+        get "destroyConfirm"
+        match "sudo", via: [:get, :post]
+        get "unsudo"
+      end
     end
 
-    get "manage"
-    get "bulkRelease"
-    get "downloadRoster"
-    match "email", via: [:get, :post]
-    get "moss"
-    post "uploadRoster"
-    get "uploadRoster"
-    get "users"
-    get "reload"
-    get "sudo"
-    post "runMoss"
+    member do
+      get "bulkRelease"
+      get "downloadRoster"
+      match "email", via: [:get, :post]
+      get "manage"
+      get "moss"
+      get "reload"
+      match "report_bug", via: [:get, :post]
+      post "runMoss"
+      get "sudo"
+      match "uploadRoster", via: [:get, :post]
+      get "userLookup"
+      get "users"
+    end
   end
 end


### PR DESCRIPTION
This puts the route name at the beginning of the path instead of the end, which is more consistent with the rest of our routes. I grepped for the actions, but could have possibly missed a few, so test thoroughly.