### PR TITLE
Renamed display_name helper to full_name

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -275,10 +275,10 @@ protected
     return unless @course
 
     if @course.disabled?
-      @breadcrumbs << (view_context.link_to "#{@course.display_name} (Course Disabled)",
+      @breadcrumbs << (view_context.link_to "#{@course.full_name} (Course Disabled)",
                                             [@course], id: "courseTitle")
     else
-      @breadcrumbs << (view_context.link_to @course.display_name, [@course], id: "courseTitle")
+      @breadcrumbs << (view_context.link_to @course.full_name, [@course], id: "courseTitle")
     end
   end
 

--- a/app/controllers/course_user_data_controller.rb
+++ b/app/controllers/course_user_data_controller.rb
@@ -46,7 +46,7 @@ class CourseUserDataController < ApplicationController
     else
       # check CUD existence
       unless user.course_user_data.where(course: @course).empty?
-        flash[:error] = "User #{email} is already in #{@course.display_name}"
+        flash[:error] = "User #{email} is already in #{@course.full_name}"
         redirect_to(action: "new") && return
       end
       @newCUD.user = user
@@ -54,7 +54,7 @@ class CourseUserDataController < ApplicationController
 
     # save CUD
     if @newCUD.save
-      flash[:success] = "Success: added user #{email} in #{@course.display_name}"
+      flash[:success] = "Success: added user #{email} in #{@course.full_name}"
       if @cud.user.administrator?
         redirect_to([:users, @course]) && return
       else

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -39,7 +39,7 @@ class HomeController < ApplicationController
     cud.instructor = params[:isInstructor] if course_id == PUBLIC_COURSE_ID
     if cud.save
       flash[:success] = "You have successfully registered for " +
-                        @course.display_name
+                        @course.full_name
       redirect_to(controller: "course", course: @course.name,
                   action: "index") && return
     else

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -62,7 +62,7 @@ class Course < ActiveRecord::Base
     assessments.where("start_at < :now AND end_at > :now", now: now)
   end
 
-  def display_name
+  def full_name
     if self[:semester].to_s.size > 0
       self[:display_name] + " (" + self[:semester] + ")"
     else

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -63,10 +63,10 @@ class Course < ActiveRecord::Base
   end
 
   def full_name
-    if self[:semester].to_s.size > 0
-      self[:display_name] + " (" + self[:semester] + ")"
+    if semester.to_s.size > 0
+      display_name + " (" +semester + ")"
     else
-      self[:display_name]
+      display_name
     end
   end
 

--- a/app/views/attachments/index.html.erb
+++ b/app/views/attachments/index.html.erb
@@ -1,7 +1,7 @@
 <% if @is_assessment then %> 
   <h2>Listing <%= link_to @assessment.display_name, [@course, @assessment] %> Attachments</h2>
 <% else %>
-  <h2>Listing <%= link_to @course.display_name, @course %> Attachments</h2>
+  <h2>Listing <%= link_to @course.full_name, @course %> Attachments</h2>
 <% end %>
 
 

--- a/app/views/course_mailer/bug_report.text.erb
+++ b/app/views/course_mailer/bug_report.text.erb
@@ -1,6 +1,6 @@
 BUG REPORT
 - - - - -
 User: <%= @user.email %>
-Course: <%= @course.display_name %>
+Course: <%= @course.full_name %>
 - - - - -
 <%= @text %>

--- a/app/views/course_user_data/show.html.erb
+++ b/app/views/course_user_data/show.html.erb
@@ -5,7 +5,7 @@
   <li> <b>About</b><br>
     Lecture <strong><%= @requestedUser.lecture %></strong><br>
     Section <strong><%= @requestedUser.section %></strong><br>
-    Course <strong><%= @requestedUser.course.display_name %></strong><br>
+    Course <strong><%= @requestedUser.course.full_name %></strong><br>
     <%= @requestedUser.school %> <%= @requestedUser.major %>, Class of <%= @requestedUser.year %></li>
   <% if @cud.instructor? then %>
   <li><b>Course Average Tweak</b> of <%=raw tweak(@requestedUser.tweak) %></li>

--- a/app/views/courses/edit.html.erb
+++ b/app/views/courses/edit.html.erb
@@ -32,5 +32,5 @@
 
 <% if current_user.administrator? %>
 <%= link_to "Delete Course", course_path(@course), method: :delete,
-	data: {confirm: "Are you sure to destroy #{@course.display_name}?"}, class: "btn" %>
+	data: {confirm: "Are you sure to destroy #{@course.full_name}?"}, class: "btn" %>
 <% end %>

--- a/app/views/courses/index.html.erb
+++ b/app/views/courses/index.html.erb
@@ -7,7 +7,7 @@
     <div class="rolodex">
       <% list.each do |course| %>
         <div class="card course">
-          <h1><%= link_to course.display_name, course_path(course) %></h1>
+          <h1><%= link_to course.full_name, course_path(course) %></h1>
 
           <div class="content">
             <ul>


### PR DESCRIPTION
In the edit course page, :display_name field was being filled by the display_name helper method instead of the display_name field. Therefore, the display_name field would get updated with the new suffix every time the edit for mis submitted. Renaming the helper method to `full_name` fixes this problem. That was the best name I could come up with... display_name_with_sem would have been too log. but lmk if you have a better idea.