### PR TITLE
Autolab full round-trip test working!

### DIFF
--- a/spec/features/autograding_roundtrip_spec.rb
+++ b/spec/features/autograding_roundtrip_spec.rb
@@ -1,4 +1,6 @@
 require "tempfile"
+require "uri"
+require "httparty"
 
 RSpec.describe "autograding", type: :feature do
   it "runs through successfully" do
@@ -21,11 +23,31 @@ RSpec.describe "autograding", type: :feature do
     attach_file("submission_file", tmp_file.path)
     click_button "fake-submit"
     expect(page).to have_content "Refresh the page to see the results."
+    asmt_page = URI.parse(current_url).request_uri
 
     # Verify job status page
     sleep(15)
     first("#flash_success a").click
     expect(page).to have_content "AutoPopulated_labtemplate"
     expect(page).to have_content "Success: Autodriver returned normally"
+
+    # Generate random score
+    score = (0...2).map { (0x31 + rand(9)).chr }.join
+
+    # Send a callback to local endpoint
+    callback_url = first("li", text: "autograde_done").text.split[1]
+    callback_path = URI.parse(callback_url).request_uri
+    tmp_feedback = Tempfile.new("feedback.txt")
+    tmp_feedback << "{\"scores\": {\"autograded\": #{score}}}"
+    tmp_feedback.flush
+    tmp_feedback.close
+    page.driver.post(callback_path,
+                     file: Rack::Test::UploadedFile.new(tmp_feedback.path,
+                                                        "application/octet-stream"))
+
+    # Verify that grade has been populated
+    sleep 5
+    visit asmt_page
+    expect(page).to have_content score
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -28,6 +28,9 @@ RSpec.configure do |config|
 
   # Before hooks for initialization
   config.before(:suite) do
+    Capybara.app_host = "http://localhost:8200"
+    Capybara.run_server = true
+    Capybara.server_port = 8200
   end
 
   # After hooks for cleanup


### PR DESCRIPTION
How the round-trip test works:
- `Capybara` logs in user, goes to assessment, and submits a file;
- Verifies that the jobs page contains the job, and 15 seconds later the job completes;
- Since Travis CI is an isolated environment, callback from Tango cannot be directly issued -- now Capybara grabs the callback URL on the jobs page and manually sends a POST request with a feedback file we created;
- Within five seconds the new score should be on "Submission History" page.

The issue that blocked me for a week was to send the feedback file by multi-part POST request via Capybara. After reading countless number of pages, [this one](http://seejohncode.com/2012/04/29/quick-tip-testing-multipart-uploads-with-rspec/) saved my life. Thanks @seejohnrun!!
.