### PR TITLE
Fixed some navbar links

### DIFF
--- a/app/assets/stylesheets/style.css.scss
+++ b/app/assets/stylesheets/style.css.scss
@@ -163,6 +163,7 @@ div.main-header img {
   width: 100%;
   border-bottom: 1px solid rgba(223, 220, 220, 1);
   margin-bottom: 15px;
+  padding: 0 15px;
 }
 .sub-navigation .left-nav,
 .sub-navigation .right-nav {
@@ -173,6 +174,7 @@ div.main-header img {
   color: rgb(183, 180, 180);
   font-size: 16px;
   line-height: 22px;
+  cursor: pointer;
 }
 
 .sub-navigation .item a,

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -14,65 +14,60 @@
     <ul class="nav navbar-nav navbar-right action-links" role="navigation">
 
       <% if session[:sudo] && @cud then %>
-      <li>
-        <%= link_to "(#{@cud.display_name}) Reset user", [:unsudo, @course, @cud] %>
-      </li>
+        <li><%= link_to "(#{@cud.display_name}) Reset user", [:unsudo, @course, @cud] %></li>
       <% end %>
 
-      <li>
-        <a href="/">Courses</a>
-      </li>
+      <li><a href="/">Courses</a></li>
 
       <% if @cud %>
-      <li>
-        <% link = (@cud.course_assistant? && !@cud.section.blank?) ? "Section #{@cud.section} Gradebook" : "Gradebook" %>
-        <%= link_to link, course_course_user_datum_gradebook_path(@cud.course, @cud), :title => "View your gradebook" %>
-      </li>
-      <li>
-        <%= link_to "Jobs", [@course, :jobs], :title => "View a history of autograding jobs" %>
-      </li>
+        <% if @cud.course_assistant? && !@cud.section.blank? %>
+          <li><%= link_to "Section #{@cud.section} Gradebook", [:view, @course, @cud, :gradebook, section: @cud.section], title: "View your gradebook" %></li>
+        <% end %>
 
-      <% if @cud.instructor? %>
-      <li>
-        <%= link_to "Manage Course", [:manage, @course], :title => "Perform course-wise administrative actions" %>
-      </li>
-      <% end %>
+        <% if @cud.instructor? || !(@cud.course_assistant? && !@cud.section.blank?) %>
+          <li><%= link_to "Gradebook", [@course, @cud, :gradebook], title: "View your gradebook" %></li>
+        <% end %>
+
+        <li><%= link_to "Jobs", [@course, :jobs], title: "View a history of autograding jobs" %></li>
+
+        <% if @cud.instructor? %>
+          <li><%= link_to "Manage Course", [:manage, @course], title: "Perform course-wise administrative actions" %></li>
+        <% end %>
       <% end %>
 
-      <% if !@cud && current_user && current_user.administrator? %>
-      <li>
-        <%= link_to "Autolab Admin", admin_path, :title => "Perform system-wise administrative actions" %>
-      </li>
+      <% if current_user && current_user.administrator? %>
+        <li><%= link_to "Manage Autolab", admin_path, title: "Perform system-wide administrative actions" %></li>
       <% end %>
 
       <!-- User -->
       <% if user_signed_in? %>
-      <li class="dropdown">
-        <div class="dropdown-toggle" id="dropdownMenu1" data-toggle="dropdown">
-          <%= current_user.display_name %>
-          <span class="caret"></span>
-        </div>
-        <ul class="dropdown-menu animated fadeInDown" role="menu" aria-labelledby="dropdownMenu1">
-          <% unless current_user.nil? %>
-          <li role="presentation">
-            <%= link_to "Account", edit_user_path(current_user), :title => "View your account info" %>
-          </li>
-          <% end %>
-          <% if @course and @cud %>
-          <li role="presentation">
-            <%= link_to "Course Profile", [@course, @cud], :title => "View your user profile for the current course" %>
-          </li>
-          <% end %>
-          <% if Rails.env.development? %>
-          <li role="presentation">
-            <a href='/home/developer_login'>Dev Login</a>
-          </li>
-          <% end %>
-          <li role="presentation" class="divider"></li><li role="presentation">
-            <%= link_to "Log out", destroy_user_session_path, :method => :delete  %>
-          </li>
-        </ul>
-      </li>
+        <li class="dropdown">
+          <div class="dropdown-toggle" id="dropdownMenu1" data-toggle="dropdown">
+            <%= current_user.display_name %>
+            <span class="caret"></span>
+          </div>
+          <ul class="dropdown-menu animated fadeInDown" role="menu" aria-labelledby="dropdownMenu1">
+            <% unless current_user.nil? %>
+              <li role="presentation">
+                <%= link_to "Account", edit_user_path(current_user), :title => "View your account info" %>
+              </li>
+            <% end %>
+            <% if @cud %>
+              <li role="presentation">
+                <%= link_to "Course Profile", [@course, @cud], :title => "View your user profile for the current course" %>
+              </li>
+            <% end %>
+            <% if Rails.env.development? %>
+              <li role="presentation">
+                <a href='/home/developer_login'>Dev Login</a>
+              </li>
+            <% end %>
+            <li role="presentation" class="divider"></li>
+            <li role="presentation">
+              <%= link_to "Log out", destroy_user_session_path, :method => :delete  %>
+            </li>
+          </ul>
+        </li>
       <% end %>
       <!-- End User -->
     </ul>

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -17,8 +17,6 @@
         <li><%= link_to "(#{@cud.display_name}) Reset user", [:unsudo, @course, @cud] %></li>
       <% end %>
 
-      <li><a href="/">Courses</a></li>
-
       <% if @cud %>
         <% if @cud.course_assistant? && !@cud.section.blank? %>
           <li><%= link_to "Section #{@cud.section} Gradebook", [:view, @course, @cud, :gradebook, section: @cud.section], title: "View your gradebook" %></li>
@@ -78,6 +76,9 @@
 <% unless @breadcrumbs.blank? then %>
   <div class="sub-navigation">
     <span class="left-nav">
+      <span class="item">
+        <a href="/"><i class="fa fa-home fa-lg"></i></a>
+      </span>
       <% @breadcrumbs.each do |b| %>
         <span class="item"><%= b %></span>
       <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,6 +10,8 @@
     <%= external_stylesheet_link_tag "bootstrap", "3.0.0" %>
     <%= stylesheet_link_tag 'style' %>
 
+
+
     <% if Rails.configuration.x.analytics_id %>
       <script type="text/javascript">
         window.heap=window.heap||[],heap.load=function(t,e){window.heap.appid=t,window.heap.config=e;var a=document.createElement("script");a.type="text/javascript",a.async=!0,a.src=("https:"===document.location.protocol?"https:":"http:")+"//cdn.heapanalytics.com/js/heap-"+t+".js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(a,n);for(var o=function(t){return function(){heap.push([t].concat(Array.prototype.slice.call(arguments,0)))}},p=["clearEventProperties","identify","setEventProperties","track","unsetEventProperty"],c=0;c<p.length;c++)heap[p[c]]=o(p[c])};
@@ -19,6 +21,7 @@
 
     <%= content_for :head %>
     <link href='//fonts.googleapis.com/css?family=Source+Sans+Pro:300,400' rel='stylesheet' type='text/css'>
+    <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
     <%= content_for :stylesheets %>
     <title><%= if @course then @course.display_name else "Autolab" end %></title>
 


### PR DESCRIPTION
Fixes #455 
Changes/"cleans" some of the logic.  Instructors who are course assistants now get two gradebook links, one for the section gradebook, and one for the course gradebook.  Autolab admins now have a "Manage Autolab" link on every page.

Do we need to have a "Courses" link when the Autolab header goes to the same place?