### PR TITLE
Better YAML updates and Assessment Editing

### DIFF
--- a/app/controllers/assessments_controller.rb
+++ b/app/controllers/assessments_controller.rb
@@ -592,8 +592,8 @@ class AssessmentsController < ApplicationController
     end
 
     # make sure the penalties are set up
-    @assessment.late_penalty ||= Penalty.new(value: 0, kind: "points")
-    @assessment.version_penalty ||= Penalty.new(value: 0, kind: "points")
+    @assessment.late_penalty ||= Penalty.new(kind: "points")
+    @assessment.version_penalty ||= Penalty.new(kind: "points")
   end
 
   action_auth_level :update, :instructor
@@ -731,6 +731,14 @@ private
   def edit_assessment_params
     ass = params.require(:assessment)
     ass[:category_name] = params[:new_category] unless params[:new_category].blank?
+    if ass[:late_penalty_attributes] && ass[:late_penalty_attributes][:value].blank?
+      ass.delete(:late_penalty_attributes)
+      @assessment.late_penalty.destroy
+    end
+    if ass[:version_penalty_attributes] && ass[:version_penalty_attributes][:value].blank?
+      ass.delete(:version_penalty_attributes)
+      @assessment.version_penalty.destroy
+    end
     ass.permit!
   end
 

--- a/app/controllers/assessments_controller.rb
+++ b/app/controllers/assessments_controller.rb
@@ -733,11 +733,11 @@ private
     ass[:category_name] = params[:new_category] unless params[:new_category].blank?
     if ass[:late_penalty_attributes] && ass[:late_penalty_attributes][:value].blank?
       ass.delete(:late_penalty_attributes)
-      @assessment.late_penalty.destroy
+      @assessment.late_penalty.destroy unless @assessment.late_penalty.nil?
     end
     if ass[:version_penalty_attributes] && ass[:version_penalty_attributes][:value].blank?
       ass.delete(:version_penalty_attributes)
-      @assessment.version_penalty.destroy
+      @assessment.version_penalty.destroy unless @assessment.version_penalty.nil?
     end
     ass.permit!
   end

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -377,10 +377,12 @@ private
     s["problems"] = problems.map(&:serialize)
     s["autograder"] = autograder.serialize if has_autograder?
     s["scoreboard"] = scoreboard.serialize if has_scoreboard?
+    s["late_penalty"] = late_penalty.serialize if late_penalty
+    s["version_penalty"] = version_penalty.serialize if version_penalty
     s
   end
 
-  GENERAL_SERIALIZABLE = Set.new %w(name display_name category_name description handin_filename handin_directory has_svn max_grace_days handout writeup max_submissions disable_handins max_size)
+  GENERAL_SERIALIZABLE = Set.new %w(name display_name category_name description handin_filename handin_directory has_svn max_grace_days handout writeup max_submissions disable_handins max_size version_threshold)
 
   def serialize_general
     Utilities.serializable attributes, GENERAL_SERIALIZABLE
@@ -397,6 +399,14 @@ private
     end
     if s["scoreboard"]
       Scoreboard.find_or_initialize_by(assessment_id: id).update(s["scoreboard"])
+    end
+    if s["late_penalty"]
+      late_penalty ||= Penalty.new
+      late_penalty.update(s["late_penalty"])
+    end
+    if s["version_penalty"]
+      version_penalty ||= Penalty.new
+      version_penalty.update(s["version_penalty"])
     end
   end
 

--- a/app/models/autograder.rb
+++ b/app/models/autograder.rb
@@ -12,6 +12,8 @@ class Autograder < ActiveRecord::Base
   validates :autograde_image, :autograde_timeout, presence: true
   validates :autograde_image, length: { maximum: 64 }
 
+  after_save -> { assessment.dump_yaml }
+
   SERIALIZABLE = Set.new %w(autograde_image autograde_timeout release_score)
   def serialize
     Utilities.serializable attributes, SERIALIZABLE

--- a/app/models/penalty.rb
+++ b/app/models/penalty.rb
@@ -2,6 +2,11 @@ class Penalty < ScoreAdjustment
   # penalties should always be positive
   validates_numericality_of :value, greater_than_or_equal_to: 0
 
+  SERIALIZABLE = Set.new %w(kind value)
+  def serialize
+    Utilities.serializable attributes, SERIALIZABLE
+  end
+
   def self.applied_penalty(penalty, score, multiplier)
     superclass.applied_value(penalty, score, multiplier)
   end

--- a/app/models/scoreboard.rb
+++ b/app/models/scoreboard.rb
@@ -3,8 +3,12 @@
 #
 class Scoreboard < ActiveRecord::Base
   belongs_to :assessment
+
   trim_field :banner, :colspec
+
   validate :colspec_is_well_formed
+
+  after_save -> { assessment.dump_yaml }
 
   SERIALIZABLE = Set.new %w(banner colspec)
   def serialize


### PR DESCRIPTION
* If changes are made to an assessment's autograder or scoreboard, those
  changes will be reflected in the assessment's yaml file.
  NOTE: if the autograder or scoreboard is deleted that WILL NOT be
  reflected in the YAML file.  Fixes #466
* Late penalties and Version Penalties are exported and imported.
  Fixes #228
* Assessment penalties can be blank again.  This let's you refer to the
  course default penalties.