### PR TITLE
Added new section in Tango Dashboard

### DIFF
--- a/app/controllers/jobs_controller.rb
+++ b/app/controllers/jobs_controller.rb
@@ -182,7 +182,7 @@ class JobsController < ApplicationController
         @upcoming_asmt << asmt
       end
     end
-    @upcoming_asmt.sort! { |a, b| a.start_at <=> b.start_at }
+    @upcoming_asmt.sort! { |a, b| a.due_at <=> b.due_at }
   end
 
   action_auth_level :tango_data, :instructor

--- a/app/controllers/jobs_controller.rb
+++ b/app/controllers/jobs_controller.rb
@@ -175,6 +175,14 @@ class JobsController < ApplicationController
     @tango_live_jobs = TangoClient.jobs
     @tango_dead_jobs = TangoClient.jobs(deadjobs = 1)
     @plot_data = tango_plot_data(live_jobs = @tango_live_jobs, dead_jobs = @tango_dead_jobs)
+    # Get a list of current and upcoming assessments
+    @upcoming_asmt = []
+    Assessment.find_each do |asmt|
+      if asmt.has_autograder? && asmt.due_at > Time.now
+        @upcoming_asmt << asmt
+      end
+    end
+    @upcoming_asmt.sort! { |a, b| a.start_at <=> b.start_at }
   end
 
   action_auth_level :tango_data, :instructor

--- a/app/views/jobs/tango_status.html.erb
+++ b/app/views/jobs/tango_status.html.erb
@@ -150,7 +150,7 @@
   </ul>
 </div>
 
-<h3>Current & Upcoming Autograded Assessments</h3>
+<h3>Current &amp; Upcoming Autograded Assessments</h3>
 <table class="navigatable prettyBorder">
   <thead>
     <tr>

--- a/app/views/jobs/tango_status.html.erb
+++ b/app/views/jobs/tango_status.html.erb
@@ -7,6 +7,7 @@
 <% end %>
 
 <% content_for :javascripts do %>
+  <%= javascript_include_tag "sorttable" %>
   <%= javascript_include_tag "d3.v3.min" %>
   <%= javascript_include_tag "eventdrops" %>
   <%= javascript_include_tag "metricsgraphics.min" %>
@@ -16,7 +17,7 @@
 
 <h2>Tango Status</h2>
 <h3>Currently Running Jobs</h3>
-<table class="navigatable prettyBorder">
+<table class="navigatable prettyBorder sortable">
   <thead>
     <tr>
       <th>Job ID:</th>
@@ -41,7 +42,7 @@
 </table>
 
 <h3>Jobs Waiting to Run</h3>
-<table class="navigatable prettyBorder">
+<table class="navigatable prettyBorder sortable">
   <thead>
     <tr>
       <th>Job ID:</th>
@@ -75,7 +76,7 @@
   <li>Tango Threads: <%= @tango_info["num_threads"] %></li>
 </ul>
 <h3>VM Pools</h3>
-<table class="navigatable prettyBorder">
+<table class="navigatable prettyBorder sortable">
   <thead>
     <tr>
       <th>Pool Name:</th>
@@ -97,7 +98,7 @@
   </tbody>
 </table>
 <h3>Autograding Images in Use</h3>
-<table class="navigatable prettyBorder">
+<table class="navigatable prettyBorder sortable">
   <thead>
     <tr>
       <th>VM Image Name:</th>
@@ -151,11 +152,11 @@
 </div>
 
 <h3>Current &amp; Upcoming Autograded Assessments</h3>
-<table class="navigatable prettyBorder">
+<table class="navigatable prettyBorder sortable">
   <thead>
     <tr>
-      <th>Start Date:</th>
       <th>Due Date:</th>
+      <th>Start Date:</th>
       <th>Course Name:</th>
       <th>Assessment Name:</th>
       <th>VM Pool:</th>
@@ -165,8 +166,8 @@
   <tbody>
     <% @upcoming_asmt.each do |asmt| %>
     <tr>
-      <td><%= asmt.start_at %></td>
       <td><%= asmt.due_at %></td>
+      <td><%= asmt.start_at %></td>
       <td><%= asmt.course.name %></td>
       <td><%= asmt.name %></td>
       <td><%= asmt.autograder.autograde_image %></td>

--- a/app/views/jobs/tango_status.html.erb
+++ b/app/views/jobs/tango_status.html.erb
@@ -20,10 +20,10 @@
   <thead>
     <tr>
       <th>Job ID:</th>
-      <th>Job Name</th>
+      <th>Job Name:</th>
       <th>VM Name:</th>
-      <th>Submitted At</th>
-      <th>Elapsed (s)</th>
+      <th>Submitted At:</th>
+      <th>Elapsed (s):</th>
     </tr>
   </thead>
   <tbody>
@@ -39,15 +39,16 @@
     <% end %>
   </tbody>
 </table>
+
 <h3>Jobs Waiting to Run</h3>
 <table class="navigatable prettyBorder">
   <thead>
     <tr>
       <th>Job ID:</th>
-      <th>Job Name</th>
+      <th>Job Name:</th>
       <th>VM Name:</th>
-      <th>Submitted At</th>
-      <th>Elapsed (s)</th>
+      <th>Submitted At:</th>
+      <th>Elapsed (s):</th>
     </tr>
   </thead>
   <tbody>
@@ -63,6 +64,7 @@
     <% end %>
   </tbody>
 </table>
+
 <h3>Global Statistics</h3>
 <p> In current Tango session:</p>
 <ul>
@@ -88,7 +90,8 @@
       <td><%= k %></td>
       <td><%= p["total"].join(", ") %></td>
       <td><%= p["free"].join(", ") %></td>
-      <td><%= number_to_percentage(p["free"].length.to_f / p["total"].length * 100, precision: 1) %></td>
+      <td><%= p["total"].length == 0 ? number_to_percentage(0, precision: 1)
+                                     : number_to_percentage(p["free"].length.to_f / p["total"].length * 100, precision: 1) %></td>
     </tr>
     <% end %>
   </tbody>
@@ -146,3 +149,29 @@
     <li><b>Status:</b> <span id="job_status">Not selected</span>
   </ul>
 </div>
+
+<h3>Current & Upcoming Autograded Assessments</h3>
+<table class="navigatable prettyBorder">
+  <thead>
+    <tr>
+      <th>Start Date:</th>
+      <th>Due Date:</th>
+      <th>Course Name:</th>
+      <th>Assessment Name:</th>
+      <th>VM Pool:</th>
+      <th># of Students:</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @upcoming_asmt.each do |asmt| %>
+    <tr>
+      <td><%= asmt.start_at %></td>
+      <td><%= asmt.due_at %></td>
+      <td><%= asmt.course.name %></td>
+      <td><%= asmt.name %></td>
+      <td><%= asmt.autograder.autograde_image %></td>
+      <td><%= asmt.course.course_user_data.count %></td>
+    </tr>
+    <% end %>
+  </tbody>
+</table>


### PR DESCRIPTION
Fixes #497, adding "Current & Upcoming Assessments List" to Tango Dashboard.

---

Dave (@droh), According to your original request, I think it also makes sense to put `start_date` of an assessment in the table, and sort the table by `start_date`, which is what I'm doing now.

EDIT: I edited the table so it now sorts by `due_date`.