### PR TITLE
Fix flash message for confirmation email sent

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -1,0 +1,10 @@
+class RegistrationsController < Devise::RegistrationsController
+  protected
+
+  # After hitting the 'Sign up' page, redirect users here so that they see the
+  # confirmation flash message ("check your email...")
+  def after_inactive_sign_up_path_for(resource)
+    # /auth/users/sign_in
+    new_user_session_path
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,8 @@
 Autolab3::Application.routes.draw do
   root "courses#index"
 
-  devise_for :users, controllers: { omniauth_callbacks: "users/omniauth_callbacks" },
+  devise_for :users, controllers: { omniauth_callbacks: "users/omniauth_callbacks",
+                                    registrations:      "registrations" },
                      path_prefix: "auth"
 
   get "contact", to: "home#contact"


### PR DESCRIPTION
When devise sends an email with a validation/confirmation link after a
new user registers using the email/password "Sign up" option, it used to
say "You must be sign in or sign up to continue"

It showed this message because we were redirecting to "/", which
requires that the user is authorized. Now, it redirects to the sign in
page so that the devise flash message discussing what to do next doesn't
get clobbered by a chain of redirects.

Most code taken from the documentation at

<https://github.com/plataformatec/devise/wiki/How-To:-Redirect-to-a-specific-page-on-successful-sign-up-%28registration%29>

Fixes #478

__Please don't use the GitHub merge button to merge this commit. Instead,
follow the instructions here:__

<https://github.com/edx/edx-platform/wiki/How-to-Rebase-a-Pull-Request>

to ensure that the commit is rebased against `develop` first, and then `git merge --no-ff` into develop.