### PR TITLE
Spruced up landing page styles

### DIFF
--- a/app/views/home/_signUp.html.erb
+++ b/app/views/home/_signUp.html.erb
@@ -1,6 +1,0 @@
-<h2>Interested in Autolab?</h2>
-
-<p>Are you an instructor who is interested in autograding, or a TA who wants a
-better way to handle submissions? Autolab might be the tool you've been looking
-for. You can read more about Autolab's purpose on our
-<a href="http://greatwhite.ics.cs.cmu.edu/">public page</a>.</p>

--- a/app/views/home/no_user.html.erb
+++ b/app/views/home/no_user.html.erb
@@ -1,11 +1,117 @@
-<br>
-<h2>Sorry, we didn't find your account in any course on this server.</h2>
 
-<p>Please contact your professor or course 
-staff to be added to your course. The course rosters are not synced from the 
-HUB, so this error is very common (and easily fixed) if you were added to the 
-course recently or are on a waitlist.</p>
+<h1>Welcome to Autolab!</h1>
 
-<div id="publicCourse">
-<%= render :partial => "signUp", :layout => false %>
-</div>
+<p class="lead">
+Hey there! We noticed that you're not currently associated with any courses.
+Here are some resources to get you started.
+</p>
+
+<h2>For students</h2>
+
+<div class="container">
+  <div class="row">
+    <div class="col-md-6">
+      <h3>How can I join a course?</h3>
+      <p>
+      For most types of courses, students can't enroll themselves. Fire off an
+      email to your instructor and they can make sure that you get added.
+      </p>
+    </div>
+  </div><!-- row -->
+</div><!-- container -->
+
+
+<h2>For instructors</h2>
+
+<div class="container">
+  <div class="row">
+    <div class="col-md-6">
+      <h3>How can I create my course?</h3>
+      <p>
+      You should ask your system administrator to create your course for you. If
+      you're also the system administrator, see the section below!
+      </p>
+    </div>
+
+    <div class="col-md-6">
+      <h3>How do I manage my course?</h3>
+      <p>
+      We've got a bunch of documentation for how to create documentation online
+      at <a href="http://docs.autolab.cs.cmu.edu/">http://docs.autolab.cs.cmu.edu/</a>.
+      Specifically, you'll want to check out the
+      <a href="http://docs.autolab.cs.cmu.edu/document/view/25">Instructor
+      Guide</a>.
+      </p>
+    </div>
+  </div><!-- row -->
+
+  <div class="row">
+    <div class="col-md-6">
+      <h3>How do I write an assessment autograder?</h3>
+      <p>
+      The instructions for creating labs, autograders, and assessments are also
+      online at
+      <a href="http://docs.autolab.cs.cmu.edu/">http://docs.autolab.cs.cmu.edu/</a>,
+      in the section called
+      <a href="http://docs.autolab.cs.cmu.edu/document/view/18">Lab Author Guide</a>.
+      </p>
+    </div>
+  </div><!-- row -->
+</div><!-- container -->
+
+
+<h2>For administrators</h2>
+
+<div class="container">
+  <div class="row">
+    <div class="col-md-6">
+      <h3>I just set up Autolab. How can I make myself an admin?</h3>
+      <p>
+      We have a Rake task that you can run where your app is deployed to promote
+      any user to the admin level. Just run <code>rake
+      'promote_to_admin[you@example.com]'</code> to give a user administrative
+      priviledges. Note that the user has to exist already.
+      </p>
+    </div>
+
+    <div class="col-md-6">
+      <h3>Where can I keep up to date on releases and updates?</h3>
+      <p>
+      You can see information about each official release of Autolab
+      <a href="https://github.com/autolab/Autolab/releases">on GitHub</a>.
+      </p>
+    </div>
+  </div><!-- row -->
+
+  <div class="row">
+    <div class="col-md-6">
+      <h3>Where is the Autolab documentation?</h3>
+      <p>
+      We're in the progress of refactoring our documentation, so documentation is
+      available in two places right now:
+      <ul>
+        <li><a href="http://docs.autolab.cs.cmu.edu/">http://docs.autolab.cs.cmu.edu/</a></li>
+        <li><a href="https://github.com/autolab/Autolab/wiki">Autolab Wiki</a></li>
+      </ul>
+      </p>
+    </div>
+
+    <div class="col-md-6">
+      <h3>Can I get in contact with the Autolab developers?</h3>
+      <p>
+      Yes, we love hearing from our users!
+      <ul>
+        <li>
+        If you have feature suggestions or are experiencing a minor bug, use our
+        <a href="https://github.com/autolab/Autolab/issues/">issue tracker</a>.
+        </li>
+        <li>
+        If you need help troubleshooting something related to Autolab that
+        doens't belong on our issue tracker, you can email us at <b>autolab-dev
+        [at] andrew.cmu.edu</b>.
+        </li>
+      </ul>
+      </p>
+    </div>
+  </div><!-- row -->
+</div><!-- container -->


### PR DESCRIPTION
When a new user creates an account, now they see some helpful "Getting
Started" information, instead of the "You aren't in any classes"
nonsense.

Fixes #453.