### PR TITLE
SVN now affects submissions

### DIFF
--- a/app/controllers/assessment/handin.rb
+++ b/app/controllers/assessment/handin.rb
@@ -24,7 +24,11 @@ module AssessmentHandin
 
     # save the submissions
     begin
-      submissions = saveHandin(params[:submission])
+      if @assessment.has_svn
+        submissions = svn_create_sub(@cud) { |sub| saveHandin(sub) }
+      else
+        submissions = saveHandin(params[:submission])
+      end
     rescue
       submissions = nil
     end
@@ -309,7 +313,7 @@ private
 
   def save_single_submission(cud, sub)
     if @assessment.has_svn
-      svn_save_handin(cud)
+      svn_save_single_submission(cud, sub)
     else
       submission = @assessment.submissions.create(course_user_datum_id: cud.id,
                                                   submitter_ip: request.remote_ip)

--- a/app/controllers/assessment/handin.rb
+++ b/app/controllers/assessment/handin.rb
@@ -233,6 +233,8 @@ private
       return false
     end
 
+    return validate_for_svn && validate_for_groups if @assessment.has_svn
+
     # Check for if the submission is empty
     if params[:submission].nil?
       flash[:error] = "Submission was blank - please upload again."
@@ -293,32 +295,27 @@ private
   # this function returns a list of the submissions created by this handin.
 
   def saveHandin(sub)
-    unless @assessment.has_groups?
-      submission = @assessment.submissions.create(course_user_datum_id: @cud.id,
-                                                  submitter_ip: request.remote_ip)
-      submission.save_file(sub)
-      return [submission]
-    end
+    return [save_single_submission(@cud, sub)] unless @assessment.has_groups?
 
     aud = @assessment.aud_for @cud.id
     group = aud.group
-    if group.nil?
-      submission = @assessment.submissions.create(course_user_datum_id: @cud.id,
+    return [save_single_submission(@cud, sub)] if group.nil?
+
+    # transaction will return the value of the block, so the array will be returned
+    ActiveRecord::Base.transaction do
+      group.course_user_data.map { |cud| save_single_submission(cud, sub) }
+    end
+  end
+
+  def save_single_submission(cud, sub)
+    if @assessment.has_svn
+      svn_save_handin(cud)
+    else
+      submission = @assessment.submissions.create(course_user_datum_id: cud.id,
                                                   submitter_ip: request.remote_ip)
       submission.save_file(sub)
-      return [submission]
+      return submission
     end
-
-    submissions = []
-    ActiveRecord::Base.transaction do
-      group.course_user_data.each do |cud|
-        submission = @assessment.submissions.create(course_user_datum_id: cud.id,
-                                                    submitter_ip: request.remote_ip)
-        submission.save_file(sub)
-        submissions << submission
-      end
-    end
-    submissions
   end
 
   def set_handin

--- a/app/controllers/assessment/svn.rb
+++ b/app/controllers/assessment/svn.rb
@@ -49,14 +49,16 @@ protected
     flash[:error] = "Your repository has not been registered.  Please contact your course staff."
     false
   end
-
-  def svn_save_handin(cud)
-    @submission = @assessment.submissions.new(course_user_datum: cud,
-                                              submitter_ip: request.remote_ip)
-
+  
+  ##
+  # this function checks out the submitter's repo, saves the submissions as a tar on the server
+  # and yields a hash with one key, "svn_tar", which maps to the location of the tar file.
+  # it returns the result of the yield call.
+  #
+  def svn_create_sub(cud)
     # Checkout the svn directory and put it into a tar file
     repo = @assessment.aud_for(cud).repository
-    ass_dir = Rails.root("courses", @course.name, @assessment.name, @assessment.handin_directory)
+    ass_dir = @assessment.handin_directory_path
     svn_dir = File.join(ass_dir, cud.user.email + "_svn_checkout")
     svn_tar = File.join(ass_dir, cud.user.email + "_svn_checkout.tar.gz")
 
@@ -68,6 +70,7 @@ protected
 
     if !@assessment.overwrites_method?(:checkoutWork) ||
        !@assessment.config_module.checkoutWork(repo, svn_dir) then
+      flash[:error] = "There was an error checking out your work.  Please contact your instructor."
       # Clean up svn_dir
       `rm -r #{svn_dir}`
       return nil
@@ -80,12 +83,18 @@ protected
       flash[:error] = "There was a problem with checking out your work, please try again."
       return nil
     end
+  
+    sub = { "svn_tar" => svn_tar }
+    result = yield sub 
+  ensure
+    File.delete(svn_tar)
+    result
+  end
 
-    sub = {}
-    sub["tar"] = svn_tar
+  def svn_save_single_submission(cud, sub)
+    @submission = @assessment.submissions.new(course_user_datum: cud,
+                                              submitter_ip: request.remote_ip)
     @submission.save_file(sub) # this will also save the submission model if successful
-    `rm #{svn_tar}`
-
     @submission
   end
 end


### PR DESCRIPTION
I will test this more when it's not 3:18am, but Autolab will now do SVN validations and attempt to checkout work instead of just pretending that an SVN submission is a normal submission.

More work needs to be done, specifically for groups, which I'm 80% certain won't work quite the way users would expect them to (currently, they checkout every users own repository, vs sharing the repo of the submitting user).  I'll fix that at some point.