### PR TITLE
Autograde_done url should use https

### DIFF
--- a/app/controllers/assessment/autograde.rb
+++ b/app/controllers/assessment/autograde.rb
@@ -252,7 +252,11 @@ module AssessmentAutograde
   #
   def get_callback_url(course, assessment, submission, dave)
     begin
-      hostname = request.base_url
+      if Rails.env.development?
+        hostname = request.base_url
+      else
+        hostname = "https://" + request.host
+      end
     rescue
       hostname = `hostname`
       hostname = "https://" + hostname.strip


### PR DESCRIPTION
if the submission came in over http (i.e. local_submit), then the generated autograde_done url will be http, and tango's request will be rejected by the ssl enforcer. (the development thing is there so that if you are running the whole thing on thin, you can use http)

Alternatively, the url could be generated with url_for or autograde_done_course_assesment_url:

url_for([:autograde_done, course, assessment, :submission_id=>submission, :dave =>dave, :protocol => "https"] )
or

autograde_done_course_assessment_url(course, assessment, :submission_id=>submission, :dave => dave, :protocol => "https")
