### PR TITLE
Patch devise links view

### DIFF
--- a/app/views/devise/shared/_links.erb
+++ b/app/views/devise/shared/_links.erb
@@ -21,9 +21,9 @@
 <%- if devise_mapping.omniauthable? %>
   <%- resource_class.omniauth_providers.each do |provider| %>
 		<% if provider.to_s.titleize == "Shibboleth" %>
-			<b><%= link_to "Sign in with your CMU account", omniauth_authorize_path(resource_name, provider) %></b><br />
+			<b><%= link_to "Sign in with your CMU account", user_omniauth_authorize_path(provider) %></b><br />
 		<% else %>
-			<%= link_to "Sign in with #{provider.to_s.titleize}", omniauth_authorize_path(resource_name, provider) %><br />
+			<%= link_to "Sign in with #{provider.to_s.titleize}", user_omniauth_authorize_path(provider) %><br />
 		<% end %>
   <% end -%>
 <% end -%>


### PR DESCRIPTION
This should fix the following user-reported error:

> I can start the rails server, but when I bring up the main page in my browser
> and it redirects to `/auth/users/sign_in`, I get a “NoMethodError in
> Devise::Sessions#new” for omniauth_authorize_path.