### PR TITLE
Allow for different site footers on home pages

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -18,7 +18,11 @@ class CoursesController < ApplicationController
     else
       redirect_to(home_no_user_path) && return
     end
-
+    begin
+      @mysite = request.host
+    rescue
+      @mysite = `hostname`
+    end
     render layout: "home"
   end
 

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -55,4 +55,12 @@ class HomeController < ApplicationController
     # --- empty ---
     # This route just renders the home#contact page, nothing special
   end
+
+  def no_user
+    begin
+      @mysite = request.host
+    rescue
+      @mysite = `hostname`
+    end
+  end
 end

--- a/app/views/courses/index.html.erb
+++ b/app/views/courses/index.html.erb
@@ -31,8 +31,29 @@
   <% end %>
 <% end %>
 
+<% if @mysite == "autolab.cs.cmu.edu" %>
 <h1>Older Courses</h1>
 
 <p>Courses on Autolab prior to Spring 2015 are viewable at oldautolab.cs.cmu.edu.</p>
 
 <%= link_to 'Old Autolab Courses', 'https://oldautolab.cs.cmu.edu', class: 'btn main' %>
+<% end %>
+
+<% if ["autolab.andrew.cmu.edu", "autolab-dev.andrew.cmu.edu"].include?(@mysite)  %>
+<h1>Other Courses</h1>
+<div class="container">
+<div class="col-md-6">
+<% if Time.now().year == 2015 %>
+<p>Most Autolab courses for Fall 2015 are hosted at autolab.cs.cmu.edu, not autolab.andrew.cmu.edu. Come back next spring for more content here!</p>
+<% else %>
+<p>Courses on Autolab for Spring and Fall 2015 are viewable at autolab.cs.cmu.edu.</p>
+<% end %>
+<%= link_to 'CS Autolab', 'https://autolab.cs.cmu.edu', class: 'btn main' %>
+</div>
+<div class="col-md-6">
+<p>Courses on Autolab prior to Spring 2015 are viewable at oldautolab.cs.cmu.edu.</p>
+
+<%= link_to 'Old CS Autolab', 'https://oldautolab.cs.cmu.edu', class: 'btn main' %>
+</div>
+</div>
+<% end %>

--- a/app/views/courses/index.html.erb
+++ b/app/views/courses/index.html.erb
@@ -31,29 +31,4 @@
   <% end %>
 <% end %>
 
-<% if @mysite == "autolab.cs.cmu.edu" %>
-<h1>Older Courses</h1>
-
-<p>Courses on Autolab prior to Spring 2015 are viewable at oldautolab.cs.cmu.edu.</p>
-
-<%= link_to 'Old Autolab Courses', 'https://oldautolab.cs.cmu.edu', class: 'btn main' %>
-<% end %>
-
-<% if ["autolab.andrew.cmu.edu", "autolab-dev.andrew.cmu.edu"].include?(@mysite)  %>
-<h1>Other Courses</h1>
-<div class="container">
-<div class="col-md-6">
-<% if Time.now().year == 2015 %>
-<p>Most Autolab courses for Fall 2015 are hosted at autolab.cs.cmu.edu, not autolab.andrew.cmu.edu. Come back next spring for more content here!</p>
-<% else %>
-<p>Courses on Autolab for Spring and Fall 2015 are viewable at autolab.cs.cmu.edu.</p>
-<% end %>
-<%= link_to 'CS Autolab', 'https://autolab.cs.cmu.edu', class: 'btn main' %>
-</div>
-<div class="col-md-6">
-<p>Courses on Autolab prior to Spring 2015 are viewable at oldautolab.cs.cmu.edu.</p>
-
-<%= link_to 'Old CS Autolab', 'https://oldautolab.cs.cmu.edu', class: 'btn main' %>
-</div>
-</div>
-<% end %>
+<%= render :partial => "home/topannounce" %>

--- a/app/views/home/_topannounce.html.erb
+++ b/app/views/home/_topannounce.html.erb
@@ -1,0 +1,26 @@
+<% if @mysite == "autolab.cs.cmu.edu" %>
+<h1>Older Courses</h1>
+
+<p>Courses on Autolab prior to Spring 2015 are viewable at oldautolab.cs.cmu.edu.</p>
+
+<%= link_to 'Old Autolab Courses', 'https://oldautolab.cs.cmu.edu', class: 'btn main' %>
+<% end %>
+
+<% if ["autolab.andrew.cmu.edu", "autolab-dev.andrew.cmu.edu"].include?(@mysite)  %>
+<h1>Other Courses</h1>
+<div class="container">
+<div class="col-md-6">
+<% if Time.now().year == 2015 %>
+<p>Most Autolab courses for Fall 2015 are hosted at autolab.cs.cmu.edu, not autolab.andrew.cmu.edu. Come back next spring for more content here!</p>
+<% else %>
+<p>Courses on Autolab for Spring and Fall 2015 are viewable at autolab.cs.cmu.edu.</p>
+<% end %>
+<%= link_to 'CS Autolab', 'https://autolab.cs.cmu.edu', class: 'btn main' %>
+</div>
+<div class="col-md-6">
+<p>Courses on Autolab prior to Spring 2015 are viewable at oldautolab.cs.cmu.edu.</p>
+
+<%= link_to 'Old CS Autolab', 'https://oldautolab.cs.cmu.edu', class: 'btn main' %>
+</div>
+</div>
+<% end %>

--- a/app/views/home/no_user.html.erb
+++ b/app/views/home/no_user.html.erb
@@ -6,6 +6,4 @@ staff to be added to your course. The course rosters are not synced from the
 HUB, so this error is very common (and easily fixed) if you were added to the 
 course recently or are on a waitlist.</p>
 
-<div id="publicCourse">
-<%= render :partial => "signUp", :layout => false %>
-</div>
+<%= render :partial => "topannounce" %>


### PR DESCRIPTION
Display messages describing other Carnegie Mellon autolab sites on both the courses index page and the no_user page. 

Use the applications hostname to decide what messages to display, since autolab.andrew.cmu.edu will need to include references to autolab.cs.cmu.edu

This change intentionally targets master, since (a) autolab.andrew.cmu.edu will not be running code based on develop this fall, and (b) develop has reworked the no_user page significantly.