### PR TITLE
Enhance annotations

### DIFF
--- a/app/assets/javascripts/annotations.js
+++ b/app/assets/javascripts/annotations.js
@@ -19,12 +19,13 @@ $("#highlightLongLines").click(function() {
 });
 
 var initializeAnnotationsForCode = function() {
-  
+  window.annotationMode = "Code";
+
   var block = document.getElementById('code-block');
   hljs.highlightBlock(block);
 
   // annotationsByLine: { 'lineNumber': [annotations_array ]}
-  var annotationsByLine = {};
+  annotationsByLine = {};
   _.each(annotations, function(annotationObj, ind) {
     var lineInd = annotationObj.line
     if (!annotationsByLine[lineInd]) {
@@ -438,8 +439,9 @@ var initializeAnnotationsForCode = function() {
       type: "text",
       name: "comment",
       placeholder: "Comments Here",
-      maxlength: "255"
-    }, commentStr);
+      maxlength: "255",
+      value: commentStr
+    });
 
     if (annotationMode === "PDF") {
       var commentInput = elt("textarea", {

--- a/app/assets/javascripts/annotations.js
+++ b/app/assets/javascripts/annotations.js
@@ -579,6 +579,9 @@ var initializeAnnotationsForPDF = function() {
 
     $(annotationEl).css({ "left": xCord + "px",  "top" : yCord + "px", "position" : "absolute" });
     $("#page-canvas-wrapper-"+pageInd).append(annotationEl);
+    console.log("making draggable")
+    $(annotationEl).draggable();
+    $(annotationEl).resizable();
 
   });
 

--- a/app/assets/javascripts/annotations.js
+++ b/app/assets/javascripts/annotations.js
@@ -496,6 +496,7 @@ var submitNewPDFAnnotation = function(comment, value, problem_id, pageInd, xRati
       var yCord = yRatio * $("#page-canvas-" + pageInd).attr('height');
       $(annotationEl).css({ "left": xCord + "px",  "top" : yCord + "px", "position" : "absolute" });
       $page.append(annotationEl);
+      makeAnnotationMovable(annotationEl, newAnnotation, pageInd);
       $(newForm).remove();
     },
     error: function(result, type) {
@@ -561,6 +562,25 @@ var submitNewAnnotation = function(comment, value, problem_id, lineInd, formEl) 
     });
   }
 
+var makeAnnotationMovable = function(annotationEl, annotationObj, pageInd) {
+    
+    $(annotationEl).draggable({
+      stop: function( event, ui ) {
+        var xRatio = ui.position.left / $("#page-canvas-" + pageInd).attr('width');
+        var yRatio = ui.position.top / $("#page-canvas-" + pageInd).attr('height');
+        annotationObj.coordinate = xRatio + "," + yRatio + "," + pageInd;
+        updateAnnotation(annotationObj, null, null);
+      }
+    });
+    
+    $(annotationEl).resizable({
+      stop: function( event, ui ) {
+        console.log("resized")
+      }
+    });
+
+}
+
 var initializeAnnotationsForPDF = function() {
 
   _.each(annotations, function(annotationObj, ind) {
@@ -579,9 +599,7 @@ var initializeAnnotationsForPDF = function() {
 
     $(annotationEl).css({ "left": xCord + "px",  "top" : yCord + "px", "position" : "absolute" });
     $("#page-canvas-wrapper-"+pageInd).append(annotationEl);
-    console.log("making draggable")
-    $(annotationEl).draggable();
-    $(annotationEl).resizable();
+    makeAnnotationMovable(annotationEl, annotationObj, pageInd);
 
   });
 

--- a/app/assets/javascripts/annotations.js
+++ b/app/assets/javascripts/annotations.js
@@ -636,20 +636,33 @@ var submitNewAnnotation = function(comment, value, problem_id, lineInd, formEl) 
     });
   }
 
-var makeAnnotationMovable = function(annotationEl, annotationObj, pageInd) {
+var makeAnnotationMovable = function(annotationEl, annotationObj) {
     
+    var positionArr = annotationObj.coordinate.split(',');
+
+    var curPageInd  = positionArr[2];
+    var $page =  $("#page-canvas-" + curPageInd);
+
+    var curXCord = parseFloat(positionArr[0]);
+    var curYCord = parseFloat(positionArr[1]);
+    var curWidth = (positionArr[3] || 120);
+    var curHeight = (positionArr[4] || 60);
+
     $(annotationEl).draggable({
       stop: function( event, ui ) {
-        var xRatio = ui.position.left / $("#page-canvas-" + pageInd).attr('width');
-        var yRatio = ui.position.top / $("#page-canvas-" + pageInd).attr('height');
-        annotationObj.coordinate = xRatio + "," + yRatio + "," + pageInd;
+        var xRatio = ui.position.left / $page.attr('width');
+        var yRatio = ui.position.top / $page.attr('height');
+        annotationObj.coordinate = [xRatio, yRatio, curPageInd, curWidth, curHeight].join(',');
         updateAnnotation(annotationObj, null, null);
       }
     });
     
     $(annotationEl).resizable({
       stop: function( event, ui ) {
-        console.log("resized")
+        var widthRatio = ui.size.width / $page.attr('width');
+        var heightRatio = ui.size.height / $page.attr('height');
+        annotationObj.coordinate = [curXCord, curYCord, curPageInd, widthRatio, heightRatio].join(',');
+        updateAnnotation(annotationObj, null, null);
       }
     });
 
@@ -669,17 +682,20 @@ var initializeAnnotationsForPDF = function() {
     var pageInd  = positionArr[2];
     var xCord = parseFloat(positionArr[0]) * $("#page-canvas-" + pageInd).attr('width');
     var yCord = parseFloat(positionArr[1]) * $("#page-canvas-" + pageInd).attr('height');
+    var width = (positionArr[3] || 0.4) * $("#page-canvas-" + pageInd).attr('width');
+    var height = (positionArr[4] || 0.2) * $("#page-canvas-" + pageInd).attr('height');
 
     var annotationEl = newAnnotationBoxForPDF(annotationObj);
 
-    $(annotationEl).css({ "left": xCord + "px",  "top" : yCord + "px", "position" : "absolute" });
+    $(annotationEl).css({ "left": xCord + "px",  "top" : yCord + "px", "position" : "absolute",
+                          "width": width, "height": height });
+
     $("#page-canvas-wrapper-"+pageInd).append(annotationEl);
     makeAnnotationMovable(annotationEl, annotationObj, pageInd);
 
   });
 
   $(".page-canvas").on("click", function(e) {
-
     if ($(e.target).hasClass("page-canvas")) {
       var pageCanvas = e.currentTarget;
       var pageInd = parseInt(pageCanvas.id.replace('page-canvas-',''), 10);

--- a/app/assets/stylesheets/annotations.css
+++ b/app/assets/stylesheets/annotations.css
@@ -149,7 +149,6 @@ pre code {
   font-family: 'Source Sans Pro', sans-serif;
   padding: 6px;
   background-color: #fff;
-  margin-top: 6px;
 }
 
 .annotation-form hr {
@@ -161,3 +160,43 @@ pre code {
   padding-top: 0;
   padding-bottom: 0;
 }
+
+#pdf-doc .annotation-form {
+  position: absolute;
+  width: 400px;
+  -webkit-box-shadow: rgba(0, 0, 0, 0.137255) 0px 0px 4px 0px, rgba(0, 0, 0, 0.278431) 0px 4px 8px 0px;
+  box-shadow: rgba(0, 0, 0, 0.137255) 0px 0px 4px 0px, rgba(0, 0, 0, 0.278431) 0px 4px 8px 0px;
+}
+
+#pdf-doc .ann-box {
+  -webkit-box-shadow: rgba(0, 0, 0, 0.137255) 0px 0px 4px 0px, rgba(0, 0, 0, 0.278431) 0px 4px 8px 0px;
+  box-shadow: rgba(0, 0, 0, 0.137255) 0px 0px 4px 0px, rgba(0, 0, 0, 0.278431) 0px 4px 8px 0px;
+  width: 200px;
+  text-align: left;
+}
+
+#pdf-doc .ann-box .header {
+  cursor: move;  
+}
+
+#pdf-doc .ann-box .body {
+  color: #ff0000;
+}
+
+#pdf-doc .ann-box .score-box {
+  float: none;
+  background-color: transparent;
+  color: red;
+  border-radius: 2px;
+  font-size: 12px;
+  margin-right: 4px;
+  overflow: hidden;
+  display: block;
+  padding: 0.5em;
+  background-color: #fff;
+}
+
+#pdf-doc .ann-box .score-box span:first-child {
+  background-color: transparent;
+}
+

--- a/app/assets/stylesheets/annotations.css
+++ b/app/assets/stylesheets/annotations.css
@@ -172,6 +172,7 @@ pre code {
   -webkit-box-shadow: rgba(0, 0, 0, 0.137255) 0px 0px 4px 0px, rgba(0, 0, 0, 0.278431) 0px 4px 8px 0px;
   box-shadow: rgba(0, 0, 0, 0.137255) 0px 0px 4px 0px, rgba(0, 0, 0, 0.278431) 0px 4px 8px 0px;
   width: 200px;
+  background-color: #fff;
   text-align: left;
 }
 

--- a/app/assets/stylesheets/style.css.scss
+++ b/app/assets/stylesheets/style.css.scss
@@ -1024,25 +1024,3 @@ div.center {
   position: relative;
   display: inline-block;
 }
-
-#pdf-doc .annotation-form {
-  position: absolute;
-  width: 400px;
-  -webkit-box-shadow: rgba(0, 0, 0, 0.137255) 0px 0px 4px 0px, rgba(0, 0, 0, 0.278431) 0px 4px 8px 0px;
-  box-shadow: rgba(0, 0, 0, 0.137255) 0px 0px 4px 0px, rgba(0, 0, 0, 0.278431) 0px 4px 8px 0px;
-}
-
-#pdf-doc .ann-box {
-  -webkit-box-shadow: rgba(0, 0, 0, 0.137255) 0px 0px 4px 0px, rgba(0, 0, 0, 0.278431) 0px 4px 8px 0px;
-  box-shadow: rgba(0, 0, 0, 0.137255) 0px 0px 4px 0px, rgba(0, 0, 0, 0.278431) 0px 4px 8px 0px;
-  width: 200px;
-  text-align: left;
-}
-
-#pdf-doc .ann-box .header {
-  cursor: move;  
-}
-
-#pdf-doc .ann-box .body {
-  color: #ff0000;
-}

--- a/app/assets/stylesheets/style.css.scss
+++ b/app/assets/stylesheets/style.css.scss
@@ -1033,11 +1033,16 @@ div.center {
 }
 
 #pdf-doc .ann-box {
-  opacity: 0.4;
   -webkit-box-shadow: rgba(0, 0, 0, 0.137255) 0px 0px 4px 0px, rgba(0, 0, 0, 0.278431) 0px 4px 8px 0px;
   box-shadow: rgba(0, 0, 0, 0.137255) 0px 0px 4px 0px, rgba(0, 0, 0, 0.278431) 0px 4px 8px 0px;
+  width: 200px;
+  text-align: left;
 }
 
-#pdf-doc .ann-box:hover {
-  opacity: 1;
+#pdf-doc .ann-box .header {
+  cursor: move;  
+}
+
+#pdf-doc .ann-box .body {
+  color: #ff0000;
 }

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -201,11 +201,17 @@ class SubmissionsController < ApplicationController
           page  = position[2].to_i
           xCord = position[0].to_f * pdf.bounds.width
           yCord = pdf.bounds.height - (position[1].to_f * pdf.bounds.height)
+          
+          puts "XCord"
+          puts xCord
+          puts yCord
+          puts page
 
+          comment = "#{annotation.comment}\n\nProblem: General\nScore:#{annotation.value}"
           # + 1 since pages are indexed 1-based
           pdf.go_to_page(page + 1)
           pdf.fill_color "ff0000" 
-          pdf.text_box annotation.comment, 
+          pdf.text_box comment,
                       { :at => [xCord, yCord], 
                         :height => 100, 
                         :width => 160 }

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -143,9 +143,13 @@ module ApplicationHelper
 
   def external_stylesheet_link_tag(library, version)
     cloudflare = "//cdnjs.cloudflare.com/ajax/libs"
+    google = "//ajax.googleapis.com/ajax/libs"
+
     case library
     when "bootstrap"
       stylesheet_link_tag "#{cloudflare}/twitter-bootstrap/#{version}/css/bootstrap.css"
+    when "jquery-ui"
+      stylesheet_link_tag "#{google}/jqueryui/#{version}/themes/smoothness/jquery-ui.css"
     end
   end
 

--- a/app/views/submissions/viewPDF.html.erb
+++ b/app/views/submissions/viewPDF.html.erb
@@ -2,6 +2,8 @@
 
 <% content_for :stylesheets do %>
 <%= stylesheet_link_tag "annotations" %>
+<%= external_stylesheet_link_tag "jquery-ui", "1.11.4" %>
+
 
 <style type="text/css">
   #pdf-doc canvas {
@@ -15,6 +17,7 @@
 <% content_for :javascripts do %>
   <%= javascript_include_tag "pdf.js" %>
   <%= external_javascript_include_tag "lodash", "3.3.1" %>
+  <%= external_javascript_include_tag "jquery-ui", "1.11.4" %>
   <%= javascript_include_tag "highlight.pack.js" %>
 
   <script type="application/javascript">


### PR DESCRIPTION
Upon @droh's feedback, I've made some improvements to the PDF annotations that improves the UX of this feature. Although there is still a lot of room for improvement, I think it feels much better now.

- Makes annotations resizable, and adds a border around them
- Makes annotations draggable
- Removes the score, and problem from the chrome and adds it inside the comment box. This makes the - UI look less cluttered and also includes the score/problem information on the rendered PDF.
- Makes edit form larger so it's easier to edit longer comments