### PR TITLE
Migrating nicknames with non-ASCII characters

### DIFF
--- a/db/migrate/20150403173410_add_has_joined_to_cud.rb
+++ b/db/migrate/20150403173410_add_has_joined_to_cud.rb
@@ -10,6 +10,12 @@ class AddHasJoinedToCud < ActiveRecord::Migration
 
     CourseUserDatum.find_each do |cud|
       cud.has_joined = true
+
+      if !cud.nickname.nil? then
+        # if there is a non-ascii nickname, we migrate it too
+        cud.nickname.gsub!(/\P{ASCII}/, '')
+      end
+
       cud.save!
     end
 


### PR DESCRIPTION
This stops the migration since we have started asserting that the nicknames are non-ascii with this version. I'm not good at regexp, so I'm open to improvements but this worked on production and everything is functional now.