### PR TITLE
Add some uniqueness checks to models

### DIFF
--- a/app/models/assessment_user_datum.rb
+++ b/app/models/assessment_user_datum.rb
@@ -12,6 +12,7 @@ class AssessmentUserDatum < ActiveRecord::Base
   belongs_to :latest_submission, class_name: "Submission"
   belongs_to :group
 
+  validates_uniqueness_of :course_user_datum_id, scope: :assessment_id
   # attr_accessible :grade_type
 
   # * when a new submission is made, it is possible that the number of grace days used increased

--- a/app/models/authentication.rb
+++ b/app/models/authentication.rb
@@ -3,4 +3,6 @@
 #
 class Authentication < ActiveRecord::Base
   belongs_to :user
+
+  validates_uniqueness_of :uid, scope: :provider
 end

--- a/app/models/autograder.rb
+++ b/app/models/autograder.rb
@@ -11,6 +11,7 @@ class Autograder < ActiveRecord::Base
   validates :autograde_timeout, numericality: { greater_than: 10, less_than: 600 }
   validates :autograde_image, :autograde_timeout, presence: true
   validates :autograde_image, length: { maximum: 64 }
+  validates_uniqueness_of :assessment_id
 
   after_save -> { assessment.dump_yaml }
 

--- a/app/models/course_user_datum.rb
+++ b/app/models/course_user_datum.rb
@@ -27,6 +27,7 @@ class CourseUserDatum < ActiveRecord::Base
   accepts_nested_attributes_for :tweak, allow_destroy: true
   accepts_nested_attributes_for :user, allow_destroy: false
   validate :valid_nickname?
+  validates_uniqueness_of :user_id, scope: :course_id
   after_create :create_AUDs_modulo_callbacks
 
   def self.conditions_by_like(value, *columns)

--- a/app/models/problem.rb
+++ b/app/models/problem.rb
@@ -10,7 +10,7 @@ class Problem < ActiveRecord::Base
   belongs_to :assessment, touch: true
   has_many :annotations
 
-  validates :name, presence: true
+  validates :name, presence: true, uniqueness: {scope: :assessment_id}
   validates_associated :assessment
 
   after_save -> { assessment.dump_yaml }

--- a/app/models/scoreboard.rb
+++ b/app/models/scoreboard.rb
@@ -7,6 +7,7 @@ class Scoreboard < ActiveRecord::Base
   trim_field :banner, :colspec
 
   validate :colspec_is_well_formed
+  validates_uniqueness_of :assessment_id
 
   after_save -> { assessment.dump_yaml }
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,6 +17,7 @@ class User < ActiveRecord::Base
 
   trim_field :school
   validates :first_name, :last_name, :email, presence: true
+  validates_uniqueness_of :email
 
   # check if user is instructor in any course
   def instructor?


### PR DESCRIPTION
Several models should have uniqueness constraints. Missing uniqueness
constraints can trigger mysql errors when the database has unique keys
for some columns.
