### PR TITLE
Add some uniqueness checks to models

### DIFF
--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -20,19 +20,19 @@ class Assessment < ActiveRecord::Base
   has_one :scoreboard, dependent: :destroy
 
   # Validations
-  validates_uniqueness_of :name, scope: :course_id
-  validates_length_of :display_name, minimum: 1
+  validates :name, uniqueness: { scope: :course_id }
+  validates :display_name, length: { minimum: 1 }
   validate :verify_dates_order
   validate :handin_directory_and_filename_or_disable_handins, if: :active?
   validate :handin_directory_exists_or_disable_handins, if: :active?
-  validates_numericality_of :max_size, :max_submissions
-  validates_numericality_of :version_threshold, only_integer: true,
-                                                greater_than_or_equal_to: -1, allow_nil: true
-  validates_numericality_of :max_grace_days, only_integer: true,
-                                             greater_than_or_equal_to: 0, allow_nil: true
-  validates_numericality_of :group_size, only_integer: true, greater_than_or_equal_to: 1, allow_nil: true
-  validates_presence_of :name, :display_name, :due_at, :end_at, :start_at,
-                        :grading_deadline, :category_name, :max_size, :max_submissions
+  validates :max_size, :max_submissions, numericality: true
+  validates :version_threshold, numericality: { only_integer: true,
+                                                greater_than_or_equal_to: -1, allow_nil: true }
+  validates :max_grace_days, numericality: { only_integer: true,
+                                             greater_than_or_equal_to: 0, allow_nil: true }
+  validates :group_size, numericality: { only_integer: true, greater_than_or_equal_to: 1, allow_nil: true }
+  validates :name, :display_name, :due_at, :end_at, :start_at, :grading_deadline,
+            :category_name, :max_size, :max_submissions, presence: true
 
   # Callbacks
   trim_field :name, :display_name, :handin_filename, :handin_directory, :handout, :writeup

--- a/app/models/assessment_user_datum.rb
+++ b/app/models/assessment_user_datum.rb
@@ -12,7 +12,7 @@ class AssessmentUserDatum < ActiveRecord::Base
   belongs_to :latest_submission, class_name: "Submission"
   belongs_to :group
 
-  validates_uniqueness_of :course_user_datum_id, scope: :assessment_id
+  validates :course_user_datum_id, uniqueness: { scope: :assessment_id }
   # attr_accessible :grade_type
 
   # * when a new submission is made, it is possible that the number of grace days used increased

--- a/app/models/assessment_user_datum.rb
+++ b/app/models/assessment_user_datum.rb
@@ -12,6 +12,7 @@ class AssessmentUserDatum < ActiveRecord::Base
   belongs_to :latest_submission, class_name: "Submission"
   belongs_to :group
 
+  validates_uniqueness_of :course_user_datum_id, scope: :assessment_id
   # attr_accessible :grade_type
 
   # * when a new submission is made, it is possible that the number of grace days used increased

--- a/app/models/authentication.rb
+++ b/app/models/authentication.rb
@@ -3,4 +3,6 @@
 #
 class Authentication < ActiveRecord::Base
   belongs_to :user
+
+  validates_uniqueness_of :uid, scope: :provider
 end

--- a/app/models/authentication.rb
+++ b/app/models/authentication.rb
@@ -4,5 +4,5 @@
 class Authentication < ActiveRecord::Base
   belongs_to :user
 
-  validates_uniqueness_of :uid, scope: :provider
+  validates :uid, uniqueness: { scope: :provider }
 end

--- a/app/models/autograder.rb
+++ b/app/models/autograder.rb
@@ -11,7 +11,7 @@ class Autograder < ActiveRecord::Base
   validates :autograde_timeout, numericality: { greater_than: 10, less_than: 900 }
   validates :autograde_image, :autograde_timeout, presence: true
   validates :autograde_image, length: { maximum: 64 }
-  validates_uniqueness_of :assessment_id
+  validates :assessment_id, uniqueness: true
 
   after_save -> { assessment.dump_yaml }
 

--- a/app/models/autograder.rb
+++ b/app/models/autograder.rb
@@ -11,6 +11,7 @@ class Autograder < ActiveRecord::Base
   validates :autograde_timeout, numericality: { greater_than: 10, less_than: 900 }
   validates :autograde_image, :autograde_timeout, presence: true
   validates :autograde_image, length: { maximum: 64 }
+  validates_uniqueness_of :assessment_id
 
   after_save -> { assessment.dump_yaml }
 

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -3,12 +3,11 @@ require "fileutils"
 
 class Course < ActiveRecord::Base
   trim_field :name, :semester, :display_name
-  validates_uniqueness_of :name
-  validates_presence_of :display_name, :start_date, :end_date
-  validates_presence_of :late_slack, :grace_days, :late_penalty, :version_penalty
-  validates_numericality_of :grace_days, greater_than_or_equal_to: 0
-  validates_numericality_of :version_threshold, only_integer: true, greater_than_or_equal_to: -1
-  validates :name, format: { with: /\A[^0-9].*/, message: "can't have leading numeral" }
+  validates :name, format: { with: /\A[^0-9].*/, message: "can't have leading numeral" }, :name, uniqueness: true
+  validates :display_name, :start_date, :end_date, presence: true
+  validates :late_slack, :grace_days, :late_penalty, :version_penalty, presence: true
+  validates :grace_days, numericality: { greater_than_or_equal_to: 0 }
+  validates :version_threshold, numericality: { only_integer: true, greater_than_or_equal_to: -1 }
   validate :order_of_dates
 
   has_many :course_user_data, dependent: :destroy

--- a/app/models/course_user_datum.rb
+++ b/app/models/course_user_datum.rb
@@ -27,6 +27,7 @@ class CourseUserDatum < ActiveRecord::Base
   accepts_nested_attributes_for :tweak, allow_destroy: true
   accepts_nested_attributes_for :user, allow_destroy: false
   validate :valid_nickname?
+  validates_uniqueness_of :user_id, scope: :course_id
   after_create :create_AUDs_modulo_callbacks
 
   def self.conditions_by_like(value, *columns)

--- a/app/models/course_user_datum.rb
+++ b/app/models/course_user_datum.rb
@@ -27,7 +27,7 @@ class CourseUserDatum < ActiveRecord::Base
   accepts_nested_attributes_for :tweak, allow_destroy: true
   accepts_nested_attributes_for :user, allow_destroy: false
   validate :valid_nickname?
-  validates_uniqueness_of :user_id, scope: :course_id
+  validates :user_id, uniqueness: { scope: :course_id }
   after_create :create_AUDs_modulo_callbacks
 
   def self.conditions_by_like(value, *columns)

--- a/app/models/extension.rb
+++ b/app/models/extension.rb
@@ -1,10 +1,10 @@
 class Extension < ActiveRecord::Base
   belongs_to :assessment
   belongs_to :course_user_datum
-  validates_presence_of :course_user_datum_id
+  validates :course_user_datum_id, presence: true
   validate :days_or_infinite
-  validates_uniqueness_of :course_user_datum_id, scope: :assessment_id,
-                                                 message: "already has an extension."
+  validates :course_user_datum_id, uniqueness: { scope: :assessment_id,
+                                                 message: "already has an extension." }
 
   after_save :invalidate_cgdubs_for_assessments_after
   after_destroy :invalidate_cgdubs_for_assessments_after

--- a/app/models/penalty.rb
+++ b/app/models/penalty.rb
@@ -1,6 +1,6 @@
 class Penalty < ScoreAdjustment
   # penalties should always be positive
-  validates_numericality_of :value, greater_than_or_equal_to: 0
+  validates :value, numericality: { greater_than_or_equal_to: 0 }
 
   SERIALIZABLE = Set.new %w(kind value)
   def serialize

--- a/app/models/problem.rb
+++ b/app/models/problem.rb
@@ -10,7 +10,7 @@ class Problem < ActiveRecord::Base
   belongs_to :assessment, touch: true
   has_many :annotations
 
-  validates :name, presence: true, uniqueness: {scope: :assessment_id}
+  validates :name, presence: true, uniqueness: { scope: :assessment_id }
   validates_associated :assessment
 
   after_save -> { assessment.dump_yaml }

--- a/app/models/problem.rb
+++ b/app/models/problem.rb
@@ -10,7 +10,7 @@ class Problem < ActiveRecord::Base
   belongs_to :assessment, touch: true
   has_many :annotations
 
-  validates :name, presence: true
+  validates :name, presence: true, uniqueness: {scope: :assessment_id}
   validates_associated :assessment
 
   after_save -> { assessment.dump_yaml }

--- a/app/models/scheduler.rb
+++ b/app/models/scheduler.rb
@@ -3,7 +3,7 @@ class Scheduler < ActiveRecord::Base
   self.table_name = :scheduler
   belongs_to :course
 
-  validates_numericality_of :interval
-  validates_presence_of :action
+  validates :interval, numericality: true
+  validates :action, presence: true
   validates_associated :course
 end

--- a/app/models/score.rb
+++ b/app/models/score.rb
@@ -16,8 +16,8 @@ class Score < ActiveRecord::Base
 
   # Verifies that we will only ever have one score per problem per submission
   # This is what allows us to use submission.scores.maximum(:score,:group=>:problem_id) later on
-  validates_uniqueness_of(:problem_id, scope: :submission_id)
-  validates_presence_of :grader_id
+  validates :problem_id, uniqueness: { scope: :submission_id }
+  validates :grader_id, presence: true
 
   after_save :log_entry
 

--- a/app/models/score_adjustment.rb
+++ b/app/models/score_adjustment.rb
@@ -1,8 +1,8 @@
 class ScoreAdjustment < ActiveRecord::Base
   # attr_accessible :kind, :value
 
-  validates_presence_of :value, :kind
-  validates_numericality_of :value
+  validates :value, :kind, presence: true
+  validates :value, numericality: true
 
   # constants for the kind of score_adjustment
   POINTS = 0

--- a/app/models/scoreboard.rb
+++ b/app/models/scoreboard.rb
@@ -7,6 +7,7 @@ class Scoreboard < ActiveRecord::Base
   trim_field :banner, :colspec
 
   validate :colspec_is_well_formed
+  validates_uniqueness_of :assessment_id
 
   after_save -> { assessment.dump_yaml }
 

--- a/app/models/scoreboard.rb
+++ b/app/models/scoreboard.rb
@@ -7,7 +7,7 @@ class Scoreboard < ActiveRecord::Base
   trim_field :banner, :colspec
 
   validate :colspec_is_well_formed
-  validates_uniqueness_of :assessment_id
+  validates :assessment_id, uniqueness: true
 
   after_save -> { assessment.dump_yaml }
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,6 +17,7 @@ class User < ActiveRecord::Base
 
   trim_field :school
   validates :first_name, :last_name, :email, presence: true
+  validates_uniqueness_of :email
 
   # check if user is instructor in any course
   def instructor?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,7 +17,7 @@ class User < ActiveRecord::Base
 
   trim_field :school
   validates :first_name, :last_name, :email, presence: true
-  validates_uniqueness_of :email
+  validates :email, uniqueness: true
 
   # check if user is instructor in any course
   def instructor?


### PR DESCRIPTION
Several models should have uniqueness constraints. Missing uniqueness
constraints can trigger mysql errors when the database has unique keys
for some columns.
