### PR TITLE
Configurable announcement partial for '/'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ tags
 .DS_Store
 .idea/
 /docker/nginx.conf
+app/views/home/_topannounce.html.erb

--- a/app/views/courses/index.html.erb
+++ b/app/views/courses/index.html.erb
@@ -31,8 +31,4 @@
   <% end %>
 <% end %>
 
-<h1>Older Courses</h1>
-
-<p>Courses on Autolab prior to Spring 2015 are viewable at oldautolab.cs.cmu.edu.</p>
-
-<%= link_to 'Old Autolab Courses', 'https://oldautolab.cs.cmu.edu', class: 'btn main' %>
+<%= render partial: "home/topannounce" rescue nil %>

--- a/app/views/home/_topannounce.html.erb.template
+++ b/app/views/home/_topannounce.html.erb.template
@@ -1,0 +1,20 @@
+<%#
+  Use this file as an opportunity to broadcast a permanent message on
+  the root '/' path at the bottom of the page. This is normally the page
+  with a list of all courses.
+
+  For example, at CMU we use it to provide students and instructors with
+  a convenient link to an older deployment of Autolab that exists solely
+  for archival purposes. Uncomment the below, rename this file to drop
+  the `.template` suffix, and nagivate to Autolab in your browser to see
+  the effect.
+%>
+
+<%# REMOVE THIS LINE TO UNCOMMENT
+
+<h1>Older Courses</h1>
+<p>Courses on Autolab prior to Spring 2015 are viewable at oldautolab.cs.cmu.edu.</p>
+<%= link_to 'Old Autolab Courses', 'https://oldautolab.cs.cmu.edu', class: 'btn main' %>
+
+REMOVE THIS LINE TO UNCOMMENT %>
+

--- a/app/views/home/no_user.html.erb
+++ b/app/views/home/no_user.html.erb
@@ -115,3 +115,6 @@ Here are some resources to get you started.
     </div>
   </div><!-- row -->
 </div><!-- container -->
+
+<%= render partial: "topannounce" rescue nil %>
+

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -1,10 +1,7 @@
 <div id="footer">
     <a href="http://autolabproject.com">Autolab Project</a>
     · <a href="/contact">Contact</a>
+    · <a href="https://github.com/autolab/Autolab">GitHub</a>
+    · <a href="https://www.facebook.com/autolabproject">Facebook</a>
     · <%= link_to "Logout", destroy_user_session_path, method: :delete %>
-
-    <span class="pull-right">
-    <a class="github-button" href="https://github.com/autolab/Autolab" data-count-href="/autolab/Autolab/stargazers" data-count-api="/repos/autolab/Autolab#stargazers_count" data-count-aria-label="# stargazers on GitHub" aria-label="Star autolab/Autolab on GitHub">Github</a>
-    <div class="fb-like" data-href="https://www.facebook.com/autolabproject" data-width="300" data-layout="standard" data-action="like" data-show-faces="false" data-share="false"></div>
-    </span>
 </div>


### PR DESCRIPTION
This lets people configure what shows up on the courses index at a
per-deployment level. This solves what we need for both
autolab.cs.cmu.edu as well as autolab.andrew.cmu.edu in a way that's
flexible enough to be used by others.

__Summary__:

- Based off of @cg2v's original PR (#551)
  - Thanks for the initial work!

- Rename topannounce partial to .template, add to gitignore

- Remove `@mysite` variable
  - Instead of having the `@mysite` variable keep track of what should
    be displayed, we'll just always show the _topannounce message, and
    write a different one on every host where it's necessary.

    If the template doesn't exist, we don't render a message on that host.

- Remove social buttons from _footer

  - We can move these to the CMU-specific _topannounce file so that
    people can opt into having these on their site. Also, it restricts
    it to the courses page, so it's less intrusive on the user
    experience.


__TODO (after landing)__:

- [ ] Remember to add this to CMU _topannounce after landing:

  ```html
  <h1>Think Autolab's awesome?</h1>
  <p>Help spread the word!</p>
  <div>
    <a class="github-button" href="https://github.com/autolab/Autolab" data-count-href="/autolab/Autolab/stargazers" data-count-api="/repos/autolab/Autolab#stargazers_count" data-count-aria-label="# stargazers on GitHub" aria-label="Star autolab/Autolab on GitHub">Github</a>
    <br>
    <div class="fb-like" data-href="https://www.facebook.com/autolabproject" data-width="300" data-layout="standard" data-action="like" data-show-faces="false" data-share="false"></div>
  </div>
  ```

- [ ] Update documentation in wiki showing how to use _topannounce