### PR TITLE
Add Time Zone to Datepickers

### DIFF
--- a/app/form_builders/form_builder_with_date_time_input.rb
+++ b/app/form_builders/form_builder_with_date_time_input.rb
@@ -63,8 +63,8 @@ class FormBuilderWithDateTimeInput < ActionView::Helpers::FormBuilder
   end
 
   def datetime_select(name, options = {}, _html_options = {})
-    strftime = "%F %I:%M %p"
-    date_format = "YYYY-MM-DD hh:mm A"
+    strftime = "%F %I:%M %p %z"
+    date_format = "YYYY-MM-DD hh:mm A ZZ"
     date_helper name, options, strftime, date_format
   end
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -52,8 +52,8 @@ module Autolab3
     # config.active_record.observers = :cacher, :garbage_collector, :forum_observer
 
     # Set Time.zone default to the specified zone and make Active Record auto-convert to this zone.
-    # Run "rake -D time" for a list of tasks for finding time zone names. Default is UTC.
-    config.time_zone = 'Eastern Time (US & Canada)'
+    # Run "rake time:zones:all" for a list of tasks for finding time zone names. Default is UTC.
+    config.time_zone = "Eastern Time (US & Canada)"
 
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]


### PR DESCRIPTION
With this change, if the user's browser's time zone does not match the servers timezone, there shouldn't be skew in the date values the user sends to the server, so #576 should disappear.  The one downside is that the time zone value is now always present in the input box, which is a bit ugly, but is worth it.