### PR TITLE
Adds the ability to display PDF files residing in tar/tgz submissions

### DIFF
--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -211,9 +211,12 @@ class SubmissionsController < ApplicationController
 
           value = "N/A"
           if !annotation.value.blank? then value = annotation.value end
-          problem = "General"
+
           if annotation.problem then problem = annotation.problem end
-          comment = "#{annotation.comment}\n\nProblem: #{problem.name}\nScore:#{value}"
+          problem_name = "General"
+          if !problem.nil? then problem_name = problem.name end
+
+          comment = "#{annotation.comment}\n\nProblem: #{problem_name}\nScore:#{value}"
 
           pdf.stroke_color "ff0000"
           pdf.stroke_rectangle [xCord, yCord], width, height
@@ -301,7 +304,12 @@ class SubmissionsController < ApplicationController
       @annotations.sort! { |a, b| a.line <=> b.line }
 
     else
-      @annotations = @submission.annotations.to_a
+      # fix for tar files
+      if params[:header_position]
+        @annotations = @submission.annotations.where(position: params[:header_position]).to_a
+      else
+        @annotations = @submission.annotations.to_a
+      end
     end
 
     @problemSummaries = {}

--- a/app/views/submissions/viewPDF.html.erb
+++ b/app/views/submissions/viewPDF.html.erb
@@ -31,9 +31,9 @@
     var annotations = <%=raw @annotations.to_json %>;
     var fileNameStr = "<%= @filename %>";
     <% if @preview_mode then %>
-    var fileLink    = "<%= download_course_assessment_submission_path(@course, @assessment, @submission, :annotated => true) %>";
+    var fileLink    = "<%= url_for [:download, @course, @assessment, @submission, header_position: params[:header_position], annotated: true] %>";
     <% else %>
-    var fileLink    = "<%= download_course_assessment_submission_path(@course, @assessment, @submission) %>";
+    var fileLink    = "<%= url_for [:download, @course, @assessment, @submission, header_position: params[:header_position]] %>";
     <% end %>
     var cudEmailStr = "<%= @cud.email %>";
     // a json list of problems for this assessment
@@ -129,11 +129,11 @@
         Preview
       </a>
       <% end %>
-      <a style="width:100%; margin-top: 6px;" href="<%= download_file_url(@submission) %>" title="Download Submission" class="btn"> 
+      <a style="width:100%; margin-top: 6px;" href="<%= url_for [:download, @course, @assessment, @submission, header_position: params[:header_position]] %>" title="Download Submission" class="btn"> 
         <span class="glyphicon glyphicon-download-alt pull-left" aria-hidden="true"></span>
         Original
       </a>
-      <a style="width:100%; margin-top: 6px;" href="<%= download_file_url(@submission) %>?annotated=true" title="Download Submission" class="btn">
+      <a style="width:100%; margin-top: 6px;" href="<%= url_for [:download, @course, @assessment, @submission, header_position: params[:header_position], annotated: true] %>" title="Download Submission" class="btn">
         <span class="glyphicon glyphicon-download-alt pull-left" aria-hidden="true"></span>
         Annotated
       </a>


### PR DESCRIPTION
This corrects the fileLink we use to get the PDF file when we want to display a PDF file on the browser.

- Tested with one level deep tar submission.
- Tested that normal .pdf submissions still work as expected.

