### PR TITLE
Ensure that volume directories are app-writable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,13 @@ RUN bundle install
 # Add the rails app
 ADD . /home/app/webapp
 
+# Fixup permissions on courses folder
+RUN chown -R app:app /home/app/webapp/courses \
+    /home/app/webapp/assessmentConfig \
+    /home/app/webapp/courseConfig \
+    /home/app/webapp/gradebooks \
+    /home/app/webapp/tmp
+
 # Move the database configuration into place
 ADD config/database.docker.yml /home/app/webapp/config/database.yml
 


### PR DESCRIPTION
These are all the folders mounted as volumes that need to be able to
writable by the app.

This is linked with autolab/autolab-docker#2 which ensures that these
folders are always created and as such __must be merged after that PR
merges__.

Fixes #560. Fixes #579.