### PR TITLE
Don't return HTML errors to non-html requests

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -30,8 +30,14 @@ class ApplicationController < ActionController::Base
     rescue_from Exception, with: :render_error
     rescue_from CourseUserDatum::AuthenticationFailed do |e|
       COURSE_LOGGER.log("AUTHENTICATION FAILED: #{e.user_message}, #{e.dev_message}")
-      flash[:error] = e.user_message
-      redirect_to root_path
+      respond_to do |format| 
+         format.html {
+            flash[:error] = e.user_message
+            redirect_to root_path
+         }
+         format.json { head :forbidden }
+         format.js { head :forbidden }
+      end
     end
   end
 
@@ -319,21 +325,27 @@ private
     ExceptionNotifier.notify_exception(exception, env: request.env,
                                                   data: { message: "was doing something wrong" })
 
-    # stack traces are only shown to instructors and administrators
-    # by leaving @error undefined, students and CAs do not see stack traces
-    if (!current_user.nil?) && (current_user.instructor? || current_user.administrator?)
-      @error = exception
+    respond_to do |format|
+       format.html {
+          # stack traces are only shown to instructors and administrators
+          # by leaving @error undefined, students and CAs do not see stack traces
+          if (!current_user.nil?) && (current_user.instructor? || current_user.administrator?)
+            @error = exception
 
-      # Generate course id and assesssment id objects
-      @course_name = params[:course_name] ||
-                     (params[:controller] == "courses" ? params[:name] : nil)
-      if @course_name
-        @assessment_name = params[:assessment_name] ||
-                           (params[:controller] == "assessments" ? params[:name] : nil)
+            # Generate course id and assesssment id objects
+            @course_name = params[:course_name] ||
+                           (params[:controller] == "courses" ? params[:name] : nil)
+            if @course_name
+              @assessment_name = params[:assessment_name] ||
+                                 (params[:controller] == "assessments" ? params[:name] : nil)
 
-      end
+            end
+          end
+
+          render "home/error"
+       }
+       format.json { head :internal_server_error }
+       format.js { head :internal_server_error }
     end
-
-    render "home/error"
   end
 end


### PR DESCRIPTION
API requests (e.g. annotations) should not try to display
donkey kong when they fail, since that just triggers another
error
