### PR TITLE
Don't return deleted annotation

### DIFF
--- a/app/controllers/annotations_controller.rb
+++ b/app/controllers/annotations_controller.rb
@@ -32,7 +32,7 @@ class AnnotationsController < ApplicationController
   action_auth_level :destroy, :course_assistant
   def destroy
     @annotation.destroy
-    respond_with(@course, @assessment, @submission, @annotation)
+    head :no_content
   end
 
 private


### PR DESCRIPTION
When an annotation is deleted, don't return the deleted object, just
an HTTP 204 response