### PR TITLE
Faster Gradesheet (on-demand feedback and deferred rendering)

### DIFF
--- a/app/assets/javascripts/gradesheet.js.erb
+++ b/app/assets/javascripts/gradesheet.js.erb
@@ -185,10 +185,9 @@ jQuery(function() {
 
     // always called when editor's closed, the hub for which is current_editor.reset()
     function _close_current_editor() {
-
+        $(current_editor).parent().removeClass("focus");
         close_current_popover();
         current_editor = null;
-
     }
 
     function close_current_editor() {
@@ -224,6 +223,10 @@ jQuery(function() {
         setTimeout(f, 0); 
     }
 
+    /* opens the score editor and feedback popover for a particular score
+     *
+     * @param {element} editable The div.editable element clicked on by the user
+     */
     function open_editor(editable) {
         // if we're already open, we're done
         if (current_editor == editable) return;
@@ -250,8 +253,14 @@ jQuery(function() {
         current_editor = editable;
     }
 
+
     function make_editable($editable) {
       // click/enter to edit cells
+
+      /* Calls the Jquery plugin Jeditable to set up the element for in-place editing.
+       * When done editing, a request to quickSetScore (on server) is called with the 
+       * following parameters.
+       */
       $editable.editable('quickSetScore', {
           name: 'score',
           event: "click",
@@ -278,6 +287,8 @@ jQuery(function() {
                   problem_id: get_enclosing_editor(this).data("problem-id")
               }
           },
+          /* This function is called after the feedback form has been submitted. 
+           * Updates the total score (last column) for this student. */
           callback: function(value, settings) {
               var editor = get_enclosing_editor(this);
               var total = editor.siblings(".total");
@@ -365,7 +376,7 @@ jQuery(function() {
                 // update score id
                 editor.data('score-id', data)
 
-                // code to update reloased score formatting
+                // code to update released score formatting
                 if (released) {
                     jQuery(editor).addClass("released");
                 } else {
@@ -397,10 +408,10 @@ jQuery(function() {
 
     jQuery('#grades_filter input').focus()
 
-      jQuery(document).click(function(event) {
-        close_current_editor_on_blur(event);
-        close_current_popover_on_blur(event);
-      });
+    jQuery(document).click(function(event) {
+      close_current_editor_on_blur(event);
+      close_current_popover_on_blur(event);
+    });
 
     // generic popover opening engine
     function show_popover(popover, at, arrow_at) {
@@ -441,44 +452,65 @@ jQuery(function() {
         data: { submission_id: link.parent().data("submission-id") },
         success: function(data, status, jqXHR) {
           popover.html(data)
-        show_popover(popover, {
-          my: "left center",
-        at: "right center",
-        of: link,
-        offset: "10px 0"
-        });
+          show_popover(popover, {
+            my: "left center",
+            at: "right center",
+            of: link,
+            offset: "10px 0"
+          });
         }
       });
     });
 
+    /* Open the popover for viewing/editing feedback for a particular score
+     *
+     *@param {element} e The editable element on which to show the feedback popover
+     */
     function open_score_popover(e) {
       var $editable = jQuery(e)
-        var $popover = $editable.siblings("div.popover")
-        var $td = $editable.parent()
-        var $score_details_tbody = jQuery(".score_details", $popover)
-        var score_id = $td.data("score-id")
+      var $popover = $editable.siblings("div.popover")
+      var $td = $editable.parent()
+      var $score_details_tbody = jQuery(".score_details", $popover)
+      var score_id = $td.data("score-id")
 
-        // lazy load grader
-        if (score_id) {
-          jQuery.ajax("score_grader_info", {
-            data: {
-              "score_id": score_id
-            },
-            success: function(data, status, jqXHR) {
-              jQuery(".grader-name").remove();
-              // TODO: wtf?
-              if (data != " ") {
-                $score_details_tbody.prepend("<div class='grader-name'>Grader: " + data + "</div>")
-              }
+      var grader_name_field = jQuery(".grader-name", $score_details_tbody);
+      var $feedback_textarea = jQuery(".feedback", $score_details_tbody);
+      $feedback_textarea.prop('disabled', true);  // disable feedback editing until ajax returns
+
+      // lazy load grader and feedback
+      if (score_id) {
+        jQuery.ajax("score_grader_info", {
+          data: {
+            "score_id": score_id
+          },
+          success: function(data, status, jqXHR) {
+            try {
+              var grader = data.grader;
+              var feedback = data.feedback;
+            } catch(err) {
+              // invalid response
+              console.log("Invalid response from server: " + data);
+              console.log(err);
+              return;
             }
-          });
-        }
+
+            if (grader_name_field.length != 0) {
+              grader_name_field.remove();
+            }
+            if (grader != " ") {
+              $score_details_tbody.prepend("<div class='grader-name'>Grader: " + grader + "</div>")
+            }
+            $feedback_textarea.html(feedback);
+            $feedback_textarea.prop('disabled', false);
+          }
+        });
+      }
 
       show_popover($popover, {
         my: "left center",
-      at: "right center",
-      of: $popover.parent(),
-      offset: "5px 0"
+        at: "right center",
+        of: $popover.parent(),
+        offset: "5px 0"
       });
     }
 

--- a/app/assets/javascripts/gradesheet.js.erb
+++ b/app/assets/javascripts/gradesheet.js.erb
@@ -91,10 +91,11 @@ jQuery(function() {
     // main score table
     var oTable = jQuery("#grades").dataTable({
         'sDom' : '<"tools"f>t', // '<"tools"fC>t', for individual problem column hide/show
-        'bPaginate': false,
+        'bPaginate': true,
         'bInfo': false,
         'oLanguage': { "sSearch": "" },
         'iTabIndex': -1,
+        'iDisplayLength': rows_on_display,
         'aoColumnDefs': [
           { "bSortable": false, "aTargets": [ 0 ] },
           { "bSearchable": false, "aTargets": non_searchable_columns },
@@ -115,6 +116,30 @@ jQuery(function() {
         // "aaSorting": [[ email_col, 'asc' ]] -- this is slowww
     }).fnSetFilteringDelay();
 
+    // dynamically change # of rows to display
+    function incrementDisplayLength(n) {
+      console.log('rendering ' + n + ' more rows');
+      rows_on_display += n;
+      oTable.fnSettings()._iDisplayLength = rows_on_display;
+      oTable.fnDraw();
+    }
+
+    function loadMoreRows() {
+      if (rows_on_display + increment_rows_by >= total_rows) {
+        incrementDisplayLength(total_rows - rows_on_display);
+        // unbind the event handler
+        $(window).unbind('scroll');
+        return;
+      }
+      incrementDisplayLength(increment_rows_by);
+    }
+
+    $(window).on('scroll', function() {
+      // check if the user has scrolled to near the bottom, if so, add more rows.
+      if($(window).scrollTop() + $(window).height() > $(document).height() - 150) {
+        loadMoreRows();
+      }
+    })
 
     // placeholder text in Search field
     jQuery("#grades_filter input").attr("placeholder", "Search");

--- a/app/assets/javascripts/gradesheet.js.erb
+++ b/app/assets/javascripts/gradesheet.js.erb
@@ -462,7 +462,6 @@ jQuery(function() {
         score_details_dirty(editor, "saving");
     }
 
-    // var $editables = jQuery("#grades td.edit div.editable");
     jQuery("#grades").on('click', 'div.editable', function(event) {
         open_editor(this);
     });
@@ -513,7 +512,7 @@ jQuery(function() {
     }
 
     // to show the the ID column popovers
-    jQuery('#grades td.id a.email').on('click', function() {
+    jQuery('#grades').on('click', 'td.id a.email', function() {
       jQuery('div.popover').hide();
 
       var link = jQuery(this)

--- a/app/assets/javascripts/gradesheet.js.erb
+++ b/app/assets/javascripts/gradesheet.js.erb
@@ -133,11 +133,12 @@ jQuery(function() {
     var oTable = jQuery("#grades").dataTable({
         'data' : table_data,
         'sDom' : '<"tools"f>t', // '<"tools"fC>t', for individual problem column hide/show
-        'bPaginate': true,
         'bInfo': false,
+        'bPaginate': true,
         'oLanguage': { "sSearch": "" },
         'iTabIndex': -1,
         'iDisplayLength': rows_on_display,
+        'iDisplayStart': 0,
         'deferRender': true,
         'aoColumnDefs': [
           { "bSortable": false, "aTargets": [ 0 ] },
@@ -157,8 +158,8 @@ jQuery(function() {
               });
             });
           }
-        }
-        // "aaSorting": [[ email_col, 'asc' ]] -- this is slowww
+        },
+        "aaSorting": [[ email_col, 'asc' ]]
     }).fnSetFilteringDelay();
 
     // dynamically change # of rows to display
@@ -166,7 +167,7 @@ jQuery(function() {
       console.log('rendering ' + n + ' more rows');
       rows_on_display += n;
       oTable.fnSettings()._iDisplayLength = rows_on_display;
-      oTable.fnDraw();
+      oTable.fnDraw(false);
     }
 
     function loadMoreRows() {

--- a/app/assets/javascripts/gradesheet.js.erb
+++ b/app/assets/javascripts/gradesheet.js.erb
@@ -88,21 +88,66 @@ jQuery(function() {
         return this;
     };
 
+    // add necessary classes and data to rows after creation but before rendering
+    function completeRow(row, data, index) {
+      var submission = aux_data[index];
+      row.className = submission['r_class'];
+
+      // set up name & email column
+      $td_name = $('.id', row);
+      $td_name.attr('data-submission-id', submission['submission-id']);
+      $name_col = $col_name_template.clone();
+      $email_tag = $('.email', $name_col);
+      $email_tag.html(submission['email']);
+      if ('file' in submission) {
+        jQuery(submission['file']).insertAfter($email_tag);
+      }
+      $name_col.children().appendTo($td_name);
+
+      // set up problem columns
+      $problems = jQuery('.problem',row);
+      for (var i = 0; i < $problems.length; i++) {
+        var prob_data = submission['problems'][i];
+
+        $prob_col = $col_prob_template.clone();
+        jQuery('.editable',$prob_col).html(prob_data['score']);
+
+        $td_prob = $($problems[i]);
+        if (prob_data['released']) {
+          $td_prob.addClass('released');
+          jQuery('.released',$prob_col).prop('checked',true);
+        }
+        $td_prob.addClass('edit');
+
+        if ('score-id' in prob_data) {
+          $td_prob.attr('data-score-id', prob_data['score-id']);
+        }
+        $td_prob.attr('data-submission-id', submission['submission-id']);
+        $td_prob.attr('data-problem-id', prob_data['problem-id']);
+
+        $prob_col.children().appendTo($td_prob);
+      }
+    }
+
     // main score table
     var oTable = jQuery("#grades").dataTable({
+        'data' : table_data,
         'sDom' : '<"tools"f>t', // '<"tools"fC>t', for individual problem column hide/show
         'bPaginate': true,
         'bInfo': false,
         'oLanguage': { "sSearch": "" },
         'iTabIndex': -1,
         'iDisplayLength': rows_on_display,
+        'deferRender': true,
         'aoColumnDefs': [
           { "bSortable": false, "aTargets": [ 0 ] },
           { "bSearchable": false, "aTargets": non_searchable_columns },
           { "sType": "html", "aTargets": [ email_col ] },
           { "sType": "num-html", "aTargets": numeric_columns }, 
         ],
-        "fnDrawCallback": function(oSettings) {
+        'columns' : columns,
+        'createdRow' : completeRow,
+        'fnDrawCallback': function(oSettings) {
           var that = this;
           // Need to redo the counters if filtered or sorted
           if (oSettings.bSorted || oSettings.bFiltered) {
@@ -112,7 +157,7 @@ jQuery(function() {
               });
             });
           }
-        },
+        }
         // "aaSorting": [[ email_col, 'asc' ]] -- this is slowww
     }).fnSetFilteringDelay();
 

--- a/app/assets/stylesheets/gradesheet.css.scss
+++ b/app/assets/stylesheets/gradesheet.css.scss
@@ -135,7 +135,8 @@ td.focus {
     font: inherit;
 }
 
-#grades td.id > a {
+#grades td.id > a.email {
+    margin-right: 4px;
 }
 
 #grades .tweak a:hover {
@@ -263,4 +264,8 @@ td.id {
 #grades td .popover .score_details span.save_box span.error {
     display: none;
     color: red;
+}
+
+.template {
+    display: none;
 }

--- a/app/controllers/assessment/grading.rb
+++ b/app/controllers/assessment/grading.rb
@@ -289,11 +289,14 @@ public
   def score_grader_info
     score = Score.find(params[:score_id])
     grader = (if score then score.grader else nil end)
+    grader_info = ""
     if grader
-      render text: "#{grader.first_name} #{grader.last_name} (#{grader.email})"
-    else
-      render nothing: true
+      grader_info = "#{grader.first_name} #{grader.last_name} (#{grader.email})"
     end
+
+    feedback = score.feedback
+    response = {"grader" => grader_info, "feedback" => feedback}
+    render json: response
   end
 
   def viewGradesheet

--- a/app/views/assessments/_gradesheet.html.erb
+++ b/app/views/assessments/_gradesheet.html.erb
@@ -9,6 +9,9 @@
   <%= javascript_include_tag "jquery.jeditable" %>
 
   <script type="text/javascript">
+    total_rows = <%= @submissions.length %>;
+    rows_on_display = 40;
+    increment_rows_by = 20;
     email_col = 1;
     problem_count = <%= @assessment.problems.length %>;
     first_problem_column = 4;
@@ -74,7 +77,7 @@
                     <div>
                       <b>Feedback</b>
                       <br>
-                      <textarea class="feedback">loading...</textarea>
+                      <textarea class="feedback"><%= p_score ? p_score.feedback : "" %></textarea>
                     </div>
                     <div>
                       <b>Released</b>

--- a/app/views/assessments/_gradesheet.html.erb
+++ b/app/views/assessments/_gradesheet.html.erb
@@ -9,6 +9,7 @@
   <%= javascript_include_tag "jquery.jeditable" %>
 
   <script type="text/javascript">
+    // global constants
     total_rows = <%= @submissions.length %>;
     rows_on_display = 40;
     increment_rows_by = 20;
@@ -16,96 +17,148 @@
     problem_count = <%= @assessment.problems.length %>;
     first_problem_column = 4;
     first_non_searchable_column = 2;
+    first_row_ready = true;
+
+    /* table data */
+    // header classes
+    hclasses = ["enumerator", "id", "lec", "sec", 
+                <% for p in @assessment.problems do %>
+                  "problem",
+                <% end %>
+                <% if @cud.instructor? %>
+                  "late_penalty",
+                  <% if @assessment.version_penalty? %>
+                    "version_penalty",
+                  <% end %>
+                  "tweak",
+                <% end %>
+                "total"];
+    problems = [<% for p in @assessment.problems do %>
+                  {
+                    name: "<%= p.name %>",
+                    max_score: "<%= p.max_score %>"
+                  },
+                <% end %>];
+
+    // raw data for each row
+    table_data = [
+      <% for s in @submissions do %>
+          [ "",
+            "<%= s.course_user_datum.last_name %>, <%= s.course_user_datum.first_name %>",
+            "<%= s.course_user_datum.lecture %>",
+            "<%= s.course_user_datum.section %>",
+            <% p_scores = s.problems_to_scores %>
+            <% for p in @assessment.problems do %>
+              "",
+            <% end %>
+            <% if @cud.instructor? %>
+              "<%= computed_score(history_url s.course_user_datum) { s.late_penalty @cud } %>",
+              <% if @assessment.version_penalty? %>
+                "<%= computed_score(history_url s.course_user_datum) { s.version_penalty @cud } %>",
+              <% end %>
+                `<%= link_to raw(tweak(s.tweak)), 
+                  edit_course_assessment_submission_path(@course, @assessment, s),
+                  tabindex: -1 %>`,
+            <% end %>
+            "<%= computed_score(history_url s.course_user_datum) { s.final_score @cud } %>"
+          ],
+      <% end %>
+    ];
+
+    // additional data for each row
+    aux_data = [
+      <% for s in @submissions do %>
+        {
+          "submission-id": "<%= s.id.to_s %>",
+          r_class: "<%= aud_special_grade_type?(s.aud) && @cud.instructor? ? "special_submission" : "" %>",
+          email: "<%= s.course_user_datum.email %>",
+          <% if s.filename %>
+          file: `<%=raw(view_file(s, go_img(-1), go_img(-1), go_img(-1))) %>`,
+          <% end %>
+          problems: [
+            <% p_scores = s.problems_to_scores %>
+            <% for p in @assessment.problems do %>
+              <% p_score = p_scores[p.id] %>
+              <% id = s.id.to_s + "_" + p.id.to_s %>
+              <% released = p_score && p_score.released ? "true" : "false" %>
+              {
+                released: <%= released %>,
+                score: '<%= p_score && p_score.score ? p_score.score : raw("&ndash;") %>',
+                <% if p_score %>
+                  "score-id": "<%= "#{p_score.id}" %>",
+                <% end %>
+                "problem-id": "<%= p.id.to_s %>"
+              },
+            <% end %>
+          ]
+        },
+      <% end %>
+    ];
+
+    // column spec
+    columns = [
+      { title: "#", className: "enumerator" },
+      { title: "Email & Name", className: "id" },
+      { title: "Lec", className: "lec" },
+      { title: "Sec", className: "sec" },
+      <% for p in @assessment.problems do %>
+        { title: `<%= p.name %>
+            <span class="max_score">(<%= p.max_score %>)</span>`, 
+          className: "problem"},
+      <% end %>
+      <% if @cud.instructor? %>
+        { title: "Late\nPenalty", className: "late_penalty" },
+        <% if @assessment.version_penalty? %>
+          { title: "Version\nPenalty", className: "version_penalty" },
+        <% end %>
+        { title: "Tweak", className: "tweak" },
+      <% end %>
+      { title: "Total", className: "total" }
+    ];
+
+    // templates
+    $col_name_template = jQuery('#col_name_template');
+    $col_prob_template = jQuery('#col_prob_template');
   </script>
 
   <%= javascript_include_tag "gradesheet" %>
 <% end %>
 
+
 <div id="table_container" style="text-align: center">
+  <table id="grades"></table>
+</div>
 
-<table id="grades">
 
-<thead>
-    <tr class="sortable">
-        <th class="enumerator">#</th>
-        <th class="id">Email &amp; Name</th>
-        <th class="lec">Lec</th>
-        <th class="sec">Sec</th>
-        <% for p in @assessment.problems do %>
-        <th class="problem">
-                <%= p.name %>
-                <span class="max_score">(<%= p.max_score %>)</span>
-            </th>
-        <% end %>
-        <% if @cud.instructor? %>
-            <th class="late_penalty">Late<br>Penalty</th>
-            <% if @assessment.version_penalty? %>
-              <th class="version_penalty">Version<br>Penalty</th>
-            <% end %>
-            <th class="tweak">Tweak</th>
-        <% end %>
-        <th class="total">Total</th>
-    </tr>
-</thead>
+<!-- templates -->
+<div id="col_name_template" class="template">
+  <!-- name goes here -->
+  <br>
+  <a tabindex="-1" class="email"><!-- email address go here --></a>
 
-<% for s in @submissions do %>
-<tr class="<%= aud_special_grade_type?(s.aud) && @cud.instructor? ? "special_submission" : "" %>">
-  <td class="enumerator"></td>
-  <td class="id" data-submission-id="<%= s.id.to_s %>">
-        <%= s.course_user_datum.last_name %>, <%= s.course_user_datum.first_name %>
-        <br>
-        <a tabindex="-1" class="email"><%= s.course_user_datum.email %></a>
+  <!-- file link go here -->
+  <div class="popover"></div>
+</div>
 
-        <% if s.filename %>
-          <%=raw(view_file(s, go_img(-1), go_img(-1), go_img(-1))) %>
-        <% end %>
-        <div class="popover">
-        </div>
-  </td>
-  <td class="lec"><%= s.course_user_datum.lecture %></td>
-    <td class="sec"><%= s.course_user_datum.section %></td>
-    <% p_scores = s.problems_to_scores %>
-    <% for p in @assessment.problems do %>
-        <% p_score = p_scores[p.id] %>
-        <% id = s.id.to_s + "_" + p.id.to_s %>
-        <% released = p_score && p_score.released ? "released" : "" %>
-      <td <%= p_score ? "data-score-id=#{p_score.id}" : "" %> data-submission-id="<%= s.id.to_s %>" data-problem-id="<%= p.id.to_s %>" class="edit <%= released %>">
-            <div class="editable"><%= p_score && p_score.score ? p_score.score : raw("&ndash;") %></div>
-            <div class="popover">
-                <div class="arrow"></div>
-                <div class="score_details">
-                    <div>
-                      <b>Feedback</b>
-                      <br>
-                      <textarea class="feedback"><%= p_score ? p_score.feedback : "" %></textarea>
-                    </div>
-                    <div>
-                      <b>Released</b>
-                        <input class="released" type="checkbox" <%= (p_score && p_score.released) ? "checked" : "" %>></input>
-                        <span class="save_box">
-                            <span class="saving">Saving...</span>
-                            <span class="save btn small primary" tabindex="1">Save</span>
-                            <span class="error" tabindex="1">Try again?</span>
-                        </span>
-                    </div>
-                </div>
-            </div>
-        </td>
-    <% end %>
-    <% if @cud.instructor? %>
-    <td class="late_penalty"><%= computed_score(history_url s.course_user_datum) { s.late_penalty @cud } %></td>
-    <% if @assessment.version_penalty? %>
-      <td class="version_penalty"><%= computed_score(history_url s.course_user_datum) { s.version_penalty @cud } %></td>
-    <% end %>
-    <td class="tweak">
-      <%= link_to raw(tweak(s.tweak)), 
-                  edit_course_assessment_submission_path(@course, @assessment, s),
-                  tabindex: -1 %>
-    </td>
-    <% end %>
-    <td class="total"><%= computed_score(history_url s.course_user_datum) { s.final_score @cud } %></td>
-</tr>
-<% end %>
-
-</table>
+<div id="col_prob_template" class="template">
+  <div class="editable"><!-- score goes here --></div>
+  <div class="popover">
+      <div class="arrow"></div>
+      <div class="score_details">
+          <div>
+            <b>Feedback</b>
+            <br>
+            <textarea class="feedback">loading...</textarea>
+          </div>
+          <div>
+            <b>Released</b>
+              <input class="released" type="checkbox"></input>
+              <span class="save_box">
+                  <span class="saving">Saving...</span>
+                  <span class="save btn small primary" tabindex="1">Save</span>
+                  <span class="error" tabindex="1">Try again?</span>
+              </span>
+          </div>
+      </div>
+  </div>
 </div>

--- a/app/views/assessments/_gradesheet.html.erb
+++ b/app/views/assessments/_gradesheet.html.erb
@@ -22,7 +22,7 @@
     /* table data */
     // header classes
     hclasses = ["enumerator", "id", "lec", "sec", 
-                <% for p in @assessment.problems do %>
+                <% for i in 0..(@assessment.problems.length - 1) do%>
                   "problem",
                 <% end %>
                 <% if @cud.instructor? %>
@@ -43,25 +43,28 @@
     // raw data for each row
     table_data = [
       <% for s in @submissions do %>
-          [ "",
-            "<%= s.course_user_datum.last_name %>, <%= s.course_user_datum.first_name %>",
-            "<%= s.course_user_datum.lecture %>",
-            "<%= s.course_user_datum.section %>",
+          { "id": "",
+            "name": {
+              name: "<%= s.course_user_datum.last_name %>, <%= s.course_user_datum.first_name %>",
+              email: "<%= s.course_user_datum.email %>"
+            },
+            "lec": "<%= s.course_user_datum.lecture %>",
+            "sec": "<%= s.course_user_datum.section %>",
             <% p_scores = s.problems_to_scores %>
-            <% for p in @assessment.problems do %>
-              "",
+            <% for i in 0..(@assessment.problems.length - 1) %>
+              "problem<%= i %>": "",
             <% end %>
             <% if @cud.instructor? %>
-              "<%= computed_score(history_url s.course_user_datum) { s.late_penalty @cud } %>",
+              "late_penalty": "<%= computed_score(history_url s.course_user_datum) { s.late_penalty @cud } %>",
               <% if @assessment.version_penalty? %>
-                "<%= computed_score(history_url s.course_user_datum) { s.version_penalty @cud } %>",
+                "version_penalty": "<%= computed_score(history_url s.course_user_datum) { s.version_penalty @cud } %>",
               <% end %>
-                `<%= link_to raw(tweak(s.tweak)), 
+                "tweak": `<%= link_to raw(tweak(s.tweak)), 
                   edit_course_assessment_submission_path(@course, @assessment, s),
                   tabindex: -1 %>`,
             <% end %>
-            "<%= computed_score(history_url s.course_user_datum) { s.final_score @cud } %>"
-          ],
+            "total": "<%= computed_score(history_url s.course_user_datum) { s.final_score @cud } %>"
+          },
       <% end %>
     ];
 
@@ -97,23 +100,28 @@
 
     // column spec
     columns = [
-      { title: "#", className: "enumerator" },
-      { title: "Email & Name", className: "id" },
-      { title: "Lec", className: "lec" },
-      { title: "Sec", className: "sec" },
-      <% for p in @assessment.problems do %>
+      { title: "#", className: "enumerator", data: "id" },
+      { title: "Email & Name", className: "id", data: "name",
+        render: {
+          _: "name",
+          sort: "email"
+        } },
+      { title: "Lec", className: "lec", data: "lec" },
+      { title: "Sec", className: "sec", data: "sec" },
+      <% @assessment.problems.each_with_index do |p,i| %>
         { title: `<%= p.name %>
             <span class="max_score">(<%= p.max_score %>)</span>`, 
-          className: "problem"},
+          className: "problem",
+          data: "problem<%= i %>"},
       <% end %>
       <% if @cud.instructor? %>
-        { title: "Late\nPenalty", className: "late_penalty" },
+        { title: "Late\nPenalty", className: "late_penalty", data: "late_penalty" },
         <% if @assessment.version_penalty? %>
-          { title: "Version\nPenalty", className: "version_penalty" },
+          { title: "Version\nPenalty", className: "version_penalty", data: "version_penalty" },
         <% end %>
-        { title: "Tweak", className: "tweak" },
+        { title: "Tweak", className: "tweak", data: "tweak" },
       <% end %>
-      { title: "Total", className: "total" }
+      { title: "Total", className: "total", data: "total" }
     ];
 
     // templates

--- a/app/views/assessments/_gradesheet.html.erb
+++ b/app/views/assessments/_gradesheet.html.erb
@@ -74,7 +74,7 @@
                     <div>
                       <b>Feedback</b>
                       <br>
-                      <textarea class="feedback"><%= p_score ? p_score.feedback : "" %></textarea>
+                      <textarea class="feedback">loading...</textarea>
                     </div>
                     <div>
                       <b>Released</b>


### PR DESCRIPTION
Aims to resolve #635.

1. On-demand feedback
Feedback is no longer embedded in the gradesheet html. Individual feedback is fetched from server automatically when user clicks on a score.

2. Deferred rendering
To make the page load faster, only the first 40 rows will be displayed initially. Whenever the user scrolls near the bottom, more rows are appended to the table. The non-visible rows are not even inserted into the DOM until it is needed for display.

An added bonus of deferring rendering is the initial html can be even smaller. Previously, all raw data was generated into the table as html, which means the same structure is being repeated over and over for each row, only differing in a few values. Now the data is stored in JS arrays, so we don't need to repeat the html structure for each row (It doesn't sound much but it turns out to be a lot => 77% size decrease for each row).

Overall Performance:
Performing this on a regular 122-size class decreased the size of the initial page from ~13MB to <500KB, which is much more realistic. The js for loading the table also finishes in an instant.