### PR TITLE
Gradesheet save on change only

### DIFF
--- a/app/assets/javascripts/gradesheet.js.erb
+++ b/app/assets/javascripts/gradesheet.js.erb
@@ -364,7 +364,7 @@ jQuery(function() {
                 console.log("submitting changes to score");
                 return true;
               }
-              _close_current_editor();
+              close_current_editor();
               return false;
           },
           submitdata: function(value, settings) {
@@ -454,6 +454,9 @@ jQuery(function() {
 
         if (released_changed || old_feedback != curr_feedback) {
           console.log('submitting changes to feedback/released-state');
+
+          // reset released-state changed flag
+          jQuery('.score_details input.released', editor).data('changed', false);
 
           var released = jQuery('.score_details input.released', editor).is(':checked');
           jQuery.ajax("quickSetScoreDetails", {

--- a/app/assets/javascripts/gradesheet.js.erb
+++ b/app/assets/javascripts/gradesheet.js.erb
@@ -361,9 +361,9 @@ jQuery(function() {
               if (curr_score != old_score) {
                 // update cache
                 cache_insert(sub_id, prob_id, 'score', curr_score);
+                console.log("submitting changes to score");
                 return true;
               }
-              console.log("score didn't change, not submitting");
               _close_current_editor();
               return false;
           },
@@ -437,8 +437,12 @@ jQuery(function() {
       save_error.click(function(event) {
           jQuery('div.editable form', get_enclosing_editor(this)).submit();
       });
+
+      jQuery('.score_details input.released', editor).data('changed', false);
     }
 
+    /* submit feedback, released-state, (and implicitly, the grader) to server, but only
+     * if feedback or released-state has changed. */
     function submit_score_details(editor, not_score) {
         var sub_id = editor.data("submission-id");
         var prob_id = editor.data("problem-id");
@@ -446,8 +450,10 @@ jQuery(function() {
         var old_feedback = cache_get_item(sub_id, prob_id, 'feedback');
         var curr_feedback = jQuery('.score_details textarea.feedback', editor).val();
 
-        if (old_feedback != curr_feedback) {
-          console.log('submitting changes to feedback');
+        var released_changed = jQuery('.score_details input.released', editor).data('changed');
+
+        if (released_changed || old_feedback != curr_feedback) {
+          console.log('submitting changes to feedback/released-state');
 
           var released = jQuery('.score_details input.released', editor).is(':checked');
           jQuery.ajax("quickSetScoreDetails", {
@@ -484,6 +490,10 @@ jQuery(function() {
 
     jQuery("#grades").on('click', 'div.editable', function(event) {
         open_editor(this);
+    });
+
+    jQuery("#grades").on('change', 'div.popover .score_details input.released', function(event) {
+        $(event.target).data('changed', !$(event.target).data('changed'));
     });
 
 

--- a/app/assets/javascripts/gradesheet.js.erb
+++ b/app/assets/javascripts/gradesheet.js.erb
@@ -360,9 +360,11 @@ jQuery(function() {
               var curr_score = $('input',this).val();
               if (curr_score != old_score) {
                 // update cache
+                console.log('returning true!');
                 cache_insert(sub_id, prob_id, 'score', curr_score);
                 return true;
               }
+              console.log('returning false!');
               return false;
           },
           submitdata: function(value, settings) {
@@ -433,7 +435,7 @@ jQuery(function() {
       });
 
       save_error.click(function(event) {
-          submit_score_details(get_enclosing_editor(this));
+          jQuery('div.editable form', get_enclosing_editor(this)).submit();
       });
     }
 
@@ -444,46 +446,39 @@ jQuery(function() {
         var old_feedback = cache_get_item(sub_id, prob_id, 'feedback');
         var curr_feedback = jQuery('.score_details textarea.feedback', editor).val();
 
-        if (old_feedback == curr_feedback) {
-          return;
+        if (old_feedback != curr_feedback) {
+          console.log('submitting changes to feedback');
+
+          var released = jQuery('.score_details input.released', editor).is(':checked');
+          jQuery.ajax("quickSetScoreDetails", {
+              type: 'POST',
+              data: {
+                  submission_id: sub_id,
+                  problem_id: prob_id,
+                  feedback: curr_feedback,
+                  released: released,
+                  score: jQuery(".editable input", editor).val()  // currently unused -- tombug#50
+              },
+              success: function(data, status, jqXHR) {
+                  // update cache
+                  cache_insert(sub_id, prob_id, 'feedback', curr_feedback);
+          
+                  // update score id
+                  editor.data('score-id', data)
+
+                  // code to update released score formatting
+                  if (released) {
+                      jQuery(editor).addClass("released");
+                  } else {
+                      jQuery(editor).removeClass("released");
+                  }
+                  score_details_dirty(editor, "saved");
+              },
+              error: function() {
+                  score_details_dirty(editor, "error");
+              }
+          });
         }
-
-        var released = jQuery('.score_details input.released', editor).is(':checked');
-        jQuery.ajax("quickSetScoreDetails", {
-            type: 'POST',
-            data: {
-                submission_id: sub_id,
-                problem_id: prob_id,
-                feedback: curr_feedback,
-                released: released,
-                score: jQuery(".editable input", editor).val()  // currently unused -- tombug#50
-            },
-            success: function(data, status, jqXHR) {
-                if (!not_score) {
-                    console.log("submit_score_details: submitting editor as well");
-                    jQuery('div.editable form', editor).submit();
-                } else {
-                    console.log("submit_score_details: not submitting editor");
-                }
-
-                // update cache
-                cache_insert(sub_id, prob_id, 'feedback', curr_feedback);
-        
-                // update score id
-                editor.data('score-id', data)
-
-                // code to update released score formatting
-                if (released) {
-                    jQuery(editor).addClass("released");
-                } else {
-                    jQuery(editor).removeClass("released");
-                }
-                score_details_dirty(editor, "saved");
-            },
-            error: function() {
-                score_details_dirty(editor, "error");
-            }
-        });
         score_details_dirty(editor, "saving");
     }
 
@@ -655,9 +650,6 @@ jQuery(function() {
     /***************
      * local cache *
      ***************/
-    // original score and feedback used to check diff
-    cache = {};
-
     // forcefully inserts an item into cache
     function cache_insert(sub_id, prob_id, item_name, value) {
         if (!(sub_id in cache)) {

--- a/app/assets/javascripts/gradesheet.js.erb
+++ b/app/assets/javascripts/gradesheet.js.erb
@@ -360,11 +360,11 @@ jQuery(function() {
               var curr_score = $('input',this).val();
               if (curr_score != old_score) {
                 // update cache
-                console.log('returning true!');
                 cache_insert(sub_id, prob_id, 'score', curr_score);
                 return true;
               }
-              console.log('returning false!');
+              console.log("score didn't change, not submitting");
+              _close_current_editor();
               return false;
           },
           submitdata: function(value, settings) {
@@ -586,7 +586,8 @@ jQuery(function() {
             success: function(data, status, jqXHR) {
               try {
                 var grader = data.grader;
-                var feedback = data.feedback;
+                var feedback = data.feedback || "";
+                var score = data.score;
               } catch(err) {
                 // invalid response
                 console.log("Invalid response from server: " + data);
@@ -597,6 +598,7 @@ jQuery(function() {
               // update cache
               cache_insert(sub_id, prob_id, 'grader', grader);
               cache_insert(sub_id, prob_id, 'feedback', feedback);
+              cache_insert(sub_id, prob_id, 'score', score);
 
               // update interface
               if (grader_name_field.length != 0) {

--- a/app/assets/javascripts/gradesheet.js.erb
+++ b/app/assets/javascripts/gradesheet.js.erb
@@ -347,12 +347,25 @@ jQuery(function() {
               jQuery(current_editor).effect('highlight', { color: 'red' }, 400);
               close_current_editor();
           },
-          submitdata: function(value, settings) {
-
+          onsubmit: function() {
+              // also submit score details
               var editor = get_enclosing_editor(this);
-              // also always submit score details
               submit_score_details(editor);
 
+              // check if score changed (submit to server only if diff from cache)
+              var sub_id = editor.data("submission-id");
+              var prob_id = editor.data("problem-id");
+
+              var old_score = cache_get_item(sub_id, prob_id, 'score');
+              var curr_score = $('input',this).val();
+              if (curr_score != old_score) {
+                // update cache
+                cache_insert(sub_id, prob_id, 'score', curr_score);
+                return true;
+              }
+              return false;
+          },
+          submitdata: function(value, settings) {
               return {
                   submission_id: get_enclosing_editor(this).data("submission-id"),
                   problem_id: get_enclosing_editor(this).data("problem-id")
@@ -425,14 +438,23 @@ jQuery(function() {
     }
 
     function submit_score_details(editor, not_score) {
+        var sub_id = editor.data("submission-id");
+        var prob_id = editor.data("problem-id");
+
+        var old_feedback = cache_get_item(sub_id, prob_id, 'feedback');
+        var curr_feedback = jQuery('.score_details textarea.feedback', editor).val();
+
+        if (old_feedback == curr_feedback) {
+          return;
+        }
 
         var released = jQuery('.score_details input.released', editor).is(':checked');
         jQuery.ajax("quickSetScoreDetails", {
             type: 'POST',
             data: {
-                submission_id: editor.data('submission-id'),
-                problem_id: editor.data('problem-id'),
-                feedback: jQuery('.score_details textarea.feedback', editor).val(),
+                submission_id: sub_id,
+                problem_id: prob_id,
+                feedback: curr_feedback,
                 released: released,
                 score: jQuery(".editable input", editor).val()  // currently unused -- tombug#50
             },
@@ -443,6 +465,9 @@ jQuery(function() {
                 } else {
                     console.log("submit_score_details: not submitting editor");
                 }
+
+                // update cache
+                cache_insert(sub_id, prob_id, 'feedback', curr_feedback);
         
                 // update score id
                 editor.data('score-id', data)
@@ -537,43 +562,59 @@ jQuery(function() {
      *@param {element} e The editable element on which to show the feedback popover
      */
     function open_score_popover(e) {
-      var $editable = jQuery(e)
-      var $popover = $editable.siblings("div.popover")
-      var $td = $editable.parent()
-      var $score_details_tbody = jQuery(".score_details", $popover)
-      var score_id = $td.data("score-id")
+      var $editable = jQuery(e);
+      var $popover = $editable.siblings("div.popover");
+      var $td = $editable.parent();
+      var $score_details_tbody = jQuery(".score_details", $popover);
+      var score_id = $td.data("score-id");
+      var sub_id = $td.data('submission-id');
+      var prob_id = $td.data('problem-id');
 
       var grader_name_field = jQuery(".grader-name", $score_details_tbody);
       var $feedback_textarea = jQuery(".feedback", $score_details_tbody);
-      $feedback_textarea.prop('disabled', true);  // disable feedback editing until ajax returns
 
-      // lazy load grader and feedback
-      if (score_id) {
-        jQuery.ajax("score_grader_info", {
-          data: {
-            "score_id": score_id
-          },
-          success: function(data, status, jqXHR) {
-            try {
-              var grader = data.grader;
-              var feedback = data.feedback;
-            } catch(err) {
-              // invalid response
-              console.log("Invalid response from server: " + data);
-              console.log(err);
-              return;
-            }
+      // check cache first
+      var cache_feedback = cache_get_item(sub_id, prob_id, 'feedback');
+      if (cache_feedback != null) {
+        // cache hit
+        $feedback_textarea.html(cache_feedback);
+      } else {
+        // cache miss
+        $feedback_textarea.prop('disabled', true);  // disable feedback editing until ajax returns
 
-            if (grader_name_field.length != 0) {
-              grader_name_field.remove();
+        // lazy load grader and feedback
+        if (score_id) {
+          jQuery.ajax("score_grader_info", {
+            data: {
+              "score_id": score_id
+            },
+            success: function(data, status, jqXHR) {
+              try {
+                var grader = data.grader;
+                var feedback = data.feedback;
+              } catch(err) {
+                // invalid response
+                console.log("Invalid response from server: " + data);
+                console.log(err);
+                return;
+              }
+
+              // update cache
+              cache_insert(sub_id, prob_id, 'grader', grader);
+              cache_insert(sub_id, prob_id, 'feedback', feedback);
+
+              // update interface
+              if (grader_name_field.length != 0) {
+                grader_name_field.remove();
+              }
+              if (grader != " ") {
+                $score_details_tbody.prepend("<div class='grader-name'>Grader: " + grader + "</div>")
+              }
+              $feedback_textarea.html(feedback);
+              $feedback_textarea.prop('disabled', false);
             }
-            if (grader != " ") {
-              $score_details_tbody.prepend("<div class='grader-name'>Grader: " + grader + "</div>")
-            }
-            $feedback_textarea.html(feedback);
-            $feedback_textarea.prop('disabled', false);
-          }
-        });
+          });
+        }
       }
 
       show_popover($popover, {
@@ -608,6 +649,52 @@ jQuery(function() {
     
     var dirty = function(event) {
         score_details_dirty(get_enclosing_editor(event.target), "dirty");
+    }
+
+
+    /***************
+     * local cache *
+     ***************/
+    // original score and feedback used to check diff
+    cache = {};
+
+    // forcefully inserts an item into cache
+    function cache_insert(sub_id, prob_id, item_name, value) {
+        if (!(sub_id in cache)) {
+          cache[sub_id] = {};
+        }
+        var probs = cache[sub_id];
+
+        if (!(prob_id in probs)) {
+          probs[prob_id] = {};
+        }
+        var data = probs[prob_id];
+
+        data[item_name] = value;
+    }
+    // gets the entire cached object
+    function cache_get(sub_id, prob_id) {
+        if (!(sub_id in cache)) {
+          return null;
+        }
+        var probs = cache[sub_id];
+
+        if (!(prob_id in probs)) {
+          return null;
+        }
+        return probs[prob_id];
+    }
+    // gets an item from cache (either 'score', 'feedback', or 'grader' for now)
+    function cache_get_item(sub_id, prob_id, item_name) {
+        var data = cache_get(sub_id, prob_id);
+        if (data == null) {
+          return null;
+        }
+
+        if (!(item_name in data)) {
+          return null
+        }
+        return data[item_name];
     }
 
 });

--- a/app/controllers/assessment/grading.rb
+++ b/app/controllers/assessment/grading.rb
@@ -295,7 +295,7 @@ public
     end
 
     feedback = score.feedback
-    response = {"grader" => grader_info, "feedback" => feedback}
+    response = {"grader" => grader_info, "feedback" => feedback, "score" => score.score}
     render json: response
   end
 

--- a/app/views/assessments/_gradesheet.html.erb
+++ b/app/views/assessments/_gradesheet.html.erb
@@ -127,6 +127,54 @@
     // templates
     $col_name_template = jQuery('#col_name_template');
     $col_prob_template = jQuery('#col_prob_template');
+
+    /*** local cache ***/
+    // original score and feedback used to check diff
+    cache = {};
+
+    // forcefully inserts the new score and feedback into cache
+    function cache_insert(sub_id, prob_id, score, feedback) {
+        if (!(sub_id in cache)) {
+          cache[sub_id] = {};
+        }
+        probs = cache[sub_id];
+
+        if (!(prob_id in probs)) {
+          probs[prob_id] = {};
+        }
+        data = probs[prob_id];
+
+        if (score != null) {
+          data['score'] = score;
+        }
+        if (feedback != null) {
+          data['feedback'] = feedback;
+        }
+    }
+    // gets the cached object
+    function cache_get(sub_id, prob_id) {
+        if (!(sub_id in cache)) {
+          return null;
+        }
+        probs = cache[sub_id];
+
+        if (!(prob_id in probs)) {
+          return null;
+        }
+        return probs[prob_id];
+    }
+    // gets an item from cache (either 'score' or 'feedback')
+    function cache_get_item(sub_id, prob_id, item) {
+        data = cache_get(sub_id, prob_id);
+        if (data == null) {
+          return null;
+        }
+
+        if (!(item in data)) {
+          return null
+        }
+        return data[item];
+    }
   </script>
 
   <%= javascript_include_tag "gradesheet" %>

--- a/app/views/assessments/_gradesheet.html.erb
+++ b/app/views/assessments/_gradesheet.html.erb
@@ -129,52 +129,7 @@
     $col_prob_template = jQuery('#col_prob_template');
 
     /*** local cache ***/
-    // original score and feedback used to check diff
     cache = {};
-
-    // forcefully inserts the new score and feedback into cache
-    function cache_insert(sub_id, prob_id, score, feedback) {
-        if (!(sub_id in cache)) {
-          cache[sub_id] = {};
-        }
-        probs = cache[sub_id];
-
-        if (!(prob_id in probs)) {
-          probs[prob_id] = {};
-        }
-        data = probs[prob_id];
-
-        if (score != null) {
-          data['score'] = score;
-        }
-        if (feedback != null) {
-          data['feedback'] = feedback;
-        }
-    }
-    // gets the cached object
-    function cache_get(sub_id, prob_id) {
-        if (!(sub_id in cache)) {
-          return null;
-        }
-        probs = cache[sub_id];
-
-        if (!(prob_id in probs)) {
-          return null;
-        }
-        return probs[prob_id];
-    }
-    // gets an item from cache (either 'score' or 'feedback')
-    function cache_get_item(sub_id, prob_id, item) {
-        data = cache_get(sub_id, prob_id);
-        if (data == null) {
-          return null;
-        }
-
-        if (!(item in data)) {
-          return null
-        }
-        return data[item];
-    }
   </script>
 
   <%= javascript_include_tag "gradesheet" %>


### PR DESCRIPTION
Aims to resolve #446.

A really simple enhancement:
Users who click on a score but don't edit anything are no longer saved as the grader. 
(As a side effect, there's now a local cache of the fetched feedback, so subsequent clicks on the same score no longer go through the server).


Possible next steps (not included in the upcoming deployment) would be to include the feature discussed in last week's meeting:
Edits are saved locally until user clicks save button (i.e. do not automatically save to server when user clicks away) to prevent any accidental edits being saved.