### PR TITLE
add features - use dynamic AWS credentials

### DIFF
--- a/app/controllers/assessments_controller.rb
+++ b/app/controllers/assessments_controller.rb
@@ -429,6 +429,11 @@ class AssessmentsController < ApplicationController
     @autograded = @assessment.has_autograder?
   end
 
+  action_auth_level :credentials, :student
+  def credentials
+  
+  end
+
   action_auth_level :history, :student
   def history
     # Remember the student ID in case the user wants visit the gradesheet
@@ -519,6 +524,13 @@ class AssessmentsController < ApplicationController
     flash[:success] = "Saved!" if @assessment.update!(edit_assessment_params)
 
     redirect_to(action: :edit) && return
+  end
+
+  action_auth_level :updatec, :student
+  def updatec
+    flash[:success] = "Saved!" if @cud.update!(edit_cud_params)
+
+    redirect_to(action: :credentials) && return
   end
 
   action_auth_level :releaseAllGrades, :instructor
@@ -658,6 +670,11 @@ private
       @assessment.version_penalty.destroy unless @assessment.version_penalty.nil?
     end
     ass.permit!
+  end
+
+  def edit_cud_params
+    cud = params.require(:course_user_datum)
+    cud.permit!
   end
 
   ##

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -286,6 +286,10 @@ class Assessment < ActiveRecord::Base
     config_module.instance_methods.include?(methodKey)
   end
 
+  def use_credentials?
+    use_aws_credentials
+  end
+
   def has_autograder?
     autograder != nil
   end
@@ -501,3 +505,4 @@ private
 
   include AssessmentAssociationCache
 end
+

--- a/app/models/course_user_datum.rb
+++ b/app/models/course_user_datum.rb
@@ -152,6 +152,10 @@ class CourseUserDatum < ActiveRecord::Base
     end
   end
 
+  def has_credentials?
+    access_key_id != nil && access_key != nil
+  end
+
   #
   # User Attribute Wrappers - these functions get attributes from the CUD's
   #   associated User object, in an attempt to hide the User object

--- a/app/views/assessments/_edit_basic.html.erb
+++ b/app/views/assessments/_edit_basic.html.erb
@@ -42,6 +42,10 @@
   display_name: "Use SVN?",
   help_text: "Whether to use SVN in conjunction with this assignment." %></span>
 
+<span class="checkbox"><%= f.check_box :use_aws_credentials,
+  display_name: "Use student credentials?",
+  help_text: "Whether to use students credentials when autograding." %></span>
+
 <%= f.text_field :group_size,
   display_name: "Group Size",
   help_text: "Set the maximum size of groups for this assessment.  If group size is 1, the assessment is solo.  If the size is decreased, groups that are too large will not be broken up.  If the size is set to 1, groups will be saved, but the assessment will be solo." %>

--- a/app/views/assessments/credentials.html.erb
+++ b/app/views/assessments/credentials.html.erb
@@ -27,13 +27,16 @@
             <% end %>
           </ul>
       <% end %>
-        <%= f.text_field :access_key_id, :placeholder => "AKIAII7NQSHQXVDNDMQQ",
-                         help_text: "Please fill in aws_access_key_id." %>
-        <%= f.text_field :access_key, :placeholder => "PGTnvXMoK4ER1RAKF0RJ5x+VsORtlrob3xswWHo5",
-                         help_text: "Please fill in aws_secret_access_key." %>
-        <div class="action_buttons">
-          <%= f.submit "Save" , {:class=>"btn primary"} %>
-        </div>
+
+      <%= f.text_field :access_key_id, :placeholder => "AKIAII7NQSHQXVDNDMQQ",
+                       :display_name => "Access key id",
+                       help_text: "Please fill in aws_access_key_id" %>
+      <%= f.text_field :access_key, :placeholder => "hBVOKQ98rGCYXg9TvzO9Rr4+r4f+g7Z8KhqmBOXc",
+                       help_text: "Please fill in aws_secret_access_key." %>
+      <div class="action_buttons">
+        <%= f.submit "Save" , {:class=>"btn primary"} %>
+      </div>
+
   <% end %>
   </div>
 </div>

--- a/app/views/assessments/credentials.html.erb
+++ b/app/views/assessments/credentials.html.erb
@@ -1,0 +1,40 @@
+<%# For navigation breadcrumbs %>
+<% @title = "Set credentials" %>
+
+<% content_for :stylesheets do %>
+  <%= stylesheet_link_tag "assessments/create_edit" %>
+<% end %>
+
+<% content_for :javascripts do %>
+  <%= javascript_include_tag "confirm_discard_changes" %>
+<% end %>
+
+<div class="row">
+  <div class="col-md-6">
+    <%= form_for [ @course, @assessment, @cud], url: credentials_course_assessment_path(@course, @assessment) + "/", builder: FormBuilderWithDateTimeInput do |f| %>
+      <% if @course.errors.any? %>
+          <ul>
+            <% @course.errors.full_messages.each do |msg| %>
+              <li><%= msg %></li>
+            <% end %>
+          </ul>
+      <% end %>
+
+      <% if @assessment.errors.any? %>
+          <ul>
+            <% @assessment.errors.full_messages.each do |msg| %>
+              <li><%= msg %></li>
+            <% end %>
+          </ul>
+      <% end %>
+        <%= f.text_field :access_key_id, :placeholder => "AKIAII7NQSHQXVDNDMQQ",
+                         help_text: "Please fill in aws_access_key_id." %>
+        <%= f.text_field :access_key, :placeholder => "PGTnvXMoK4ER1RAKF0RJ5x+VsORtlrob3xswWHo5",
+                         help_text: "Please fill in aws_secret_access_key." %>
+        <div class="action_buttons">
+          <%= f.submit "Save" , {:class=>"btn primary"} %>
+        </div>
+  <% end %>
+  </div>
+</div>
+

--- a/app/views/assessments/show.html.erb
+++ b/app/views/assessments/show.html.erb
@@ -94,6 +94,9 @@
       <% if @assessment.has_scoreboard? %>
           <li><%= link_to "View scoreboard", [@course, @assessment, :scoreboard], title: "View the assessment scoreboard" %></li>
       <% end %>
+      <% if @assessment.use_credentials? %>
+          <li> <%= link_to "Set credentials", {:action => 'credentials'}, {:title=> "Set your AWS credentails" } %> </li>
+      <% end %>
 
     <% @list.sort { |a,b| a[1] <=> b[1] }.each { |key, value| %>
       <% if value.size > 0  then  %>
@@ -195,3 +198,5 @@
 
     <% end %>
   </div>
+
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -89,6 +89,8 @@ Autolab3::Application.routes.draw do
         get "viewGradesheet"
         get "writeup"
         get "handout"
+        patch "credentials", action: :updatec
+        get "credentials"
 
         # autograde actions
         post "autograde_done"

--- a/db/migrate/20160408063211_add_use_aws_credentials_to_assessment.rb
+++ b/db/migrate/20160408063211_add_use_aws_credentials_to_assessment.rb
@@ -1,0 +1,5 @@
+class AddUseAwsCredentialsToAssessment < ActiveRecord::Migration
+  def change
+	add_column :assessments, :use_aws_credentials, :boolean, :default=>false
+  end
+end

--- a/db/migrate/20160408215116_add_access_key_id_and_access_key_to_course_user_data.rb
+++ b/db/migrate/20160408215116_add_access_key_id_and_access_key_to_course_user_data.rb
@@ -1,0 +1,6 @@
+class AddAccessKeyIdAndAccessKeyToCourseUserData < ActiveRecord::Migration
+  def change
+    add_column :course_user_data, :access_key_id, :string
+    add_column :course_user_data, :access_key, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150825212603) do
+ActiveRecord::Schema.define(version: 20160408215116) do
 
   create_table "annotations", force: :cascade do |t|
     t.integer  "submission_id", limit: 4
@@ -63,34 +63,35 @@ ActiveRecord::Schema.define(version: 20150825212603) do
     t.datetime "end_at"
     t.datetime "visible_at"
     t.datetime "start_at"
-    t.string   "name",               limit: 255
-    t.text     "description",        limit: 65535
+    t.string   "name",                limit: 255
+    t.text     "description",         limit: 65535
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer  "course_id",          limit: 4
-    t.string   "display_name",       limit: 255
-    t.string   "handin_filename",    limit: 255
-    t.string   "handin_directory",   limit: 255
-    t.integer  "max_grace_days",     limit: 4,     default: 0
-    t.string   "handout",            limit: 255
-    t.string   "writeup",            limit: 255
-    t.boolean  "allow_unofficial",   limit: 1
-    t.integer  "max_submissions",    limit: 4,     default: -1
-    t.boolean  "disable_handins",    limit: 1
-    t.boolean  "exam",               limit: 1,     default: false
-    t.integer  "max_size",           limit: 4,     default: 2
-    t.integer  "version_threshold",  limit: 4
-    t.integer  "late_penalty_id",    limit: 4
-    t.integer  "version_penalty_id", limit: 4
-    t.datetime "grading_deadline",                                 null: false
-    t.boolean  "has_autograde_old",  limit: 1
-    t.boolean  "has_scoreboard_old", limit: 1
-    t.boolean  "has_svn",            limit: 1
-    t.string   "remote_handin_path", limit: 255
-    t.boolean  "quiz",               limit: 1,     default: false
-    t.text     "quizData",           limit: 65535
-    t.integer  "group_size",         limit: 4,     default: 1
-    t.string   "category_name",      limit: 255
+    t.integer  "course_id",           limit: 4
+    t.string   "display_name",        limit: 255
+    t.string   "handin_filename",     limit: 255
+    t.string   "handin_directory",    limit: 255
+    t.integer  "max_grace_days",      limit: 4,     default: 0
+    t.string   "handout",             limit: 255
+    t.string   "writeup",             limit: 255
+    t.boolean  "allow_unofficial",    limit: 1
+    t.integer  "max_submissions",     limit: 4,     default: -1
+    t.boolean  "disable_handins",     limit: 1
+    t.boolean  "exam",                limit: 1,     default: false
+    t.integer  "max_size",            limit: 4,     default: 2
+    t.integer  "version_threshold",   limit: 4
+    t.integer  "late_penalty_id",     limit: 4
+    t.integer  "version_penalty_id",  limit: 4
+    t.datetime "grading_deadline",                                  null: false
+    t.boolean  "has_autograde_old",   limit: 1
+    t.boolean  "has_scoreboard_old",  limit: 1
+    t.boolean  "has_svn",             limit: 1
+    t.string   "remote_handin_path",  limit: 255
+    t.boolean  "quiz",                limit: 1,     default: false
+    t.text     "quizData",            limit: 65535
+    t.integer  "group_size",          limit: 4,     default: 1
+    t.string   "category_name",       limit: 255
+    t.boolean  "use_aws_credentials", limit: 1,     default: false
   end
 
   create_table "attachments", force: :cascade do |t|
@@ -134,6 +135,8 @@ ActiveRecord::Schema.define(version: 20150825212603) do
     t.boolean  "course_assistant", limit: 1,   default: false
     t.integer  "tweak_id",         limit: 4
     t.integer  "user_id",          limit: 4,                   null: false
+    t.string   "access_key_id",    limit: 255
+    t.string   "access_key",       limit: 255
   end
 
   create_table "courses", force: :cascade do |t|


### PR DESCRIPTION
1. Add a new option in "edit assessment" - use student credentials.
2. if the above option is enabled, students are able to set their own AWS credentials in "Set credentials" tab.
3. Send the credentials to Tango back-end if credentials are set when autograding
