### PR TITLE
Handle non-ascii filenames in zip files

### DIFF
--- a/lib/archive.rb
+++ b/lib/archive.rb
@@ -98,7 +98,18 @@ module Archive
 
   def self.get_entry_name(entry)
     # tar/tgz vs zip
-    entry.respond_to?(:full_name) ? entry.full_name : entry.name
+    name = entry.respond_to?(:full_name) ? entry.full_name : entry.name
+    if ! name.ascii_only?
+      name = String.new(name)
+      name.force_encoding("UTF-8")
+      if ! name.valid_encoding?
+        # not utf-8. Assume single byte and choose windows western, since
+        # iso8859-1 printables are a subset
+        name.force_encoding("Windows-1252")
+        name.encode!()
+      end
+    end
+    name
   end
 
   def self.read_entry_file(entry)


### PR DESCRIPTION
zip files are opened in binary mode and rubyzip makes no attempt to
detect and tag filenames, so any non-ascii filename is labeled
as ASCII_8BIT encoding and cannot be used as a string. Detect
utf-8 or convert from single-byte Windows-1252, as appropriate.