### PR TITLE
Make search experience consistent

### DIFF
--- a/app/controllers/extensions_controller.rb
+++ b/app/controllers/extensions_controller.rb
@@ -11,7 +11,7 @@ class ExtensionsController < ApplicationController
     @extensions = @assessment.extensions.includes(:course_user_datum)
     @users = {}
     @course.course_user_data.each do |cud|
-      @users[cud.email] = cud.id
+      @users[cud.full_name_with_email] = cud.id
     end
     @new_extension = @assessment.extensions.new
   end

--- a/app/views/extensions/index.html.erb
+++ b/app/views/extensions/index.html.erb
@@ -8,6 +8,9 @@
   <%= javascript_include_tag 'chosen.jquery.min' %>
   <script type="application/javascript">
     jQuery(function() {
+      $('.chosen-select').chosen({search_contains: true});
+
+
       $dueDate = moment("<%= @assessment.due_at.to_s %>", "YYYY-MM-DD hh:mm:ss ZZ").startOf('day');
 
       $extensionDaysField = $('#extension_days');
@@ -17,7 +20,6 @@
         format: 'YYYY-MM-DD'
       });
       $extensionNewDayField.data('DateTimePicker').minDate($dueDate);
-      $('.chosen-select').chosen();
 
       /* Enable/disable extension days options */
       $enableInfiniteExtension = $('#infinite_extension');

--- a/app/views/submissions/index.html.erb
+++ b/app/views/submissions/index.html.erb
@@ -68,7 +68,8 @@
   <% for submission in @submissions %>
     <tr id="row-<%= submission.id %>" class="submission-row">
       <td><input class="cbox" type="checkbox" id="cbox-<%= submission.id %>"></td>
-      <td><%= link_to submission.course_user_datum.email,
+      <td><%= "#{submission.course_user_datum.last_name}, #{submission.course_user_datum.first_name}" %>
+      <%= link_to submission.course_user_datum.email,
                       history_course_assessment_path(@course, @assessment, cud_id: submission.course_user_datum_id, partial: true),
                       {remote: true, class: :trigger}
 

--- a/app/views/submissions/new.html.erb
+++ b/app/views/submissions/new.html.erb
@@ -6,7 +6,7 @@
   <%= javascript_include_tag 'chosen.jquery.min' %>
   <script type="application/javascript">
     jQuery(function() {
-      $('.chosen-select').chosen();
+      $('.chosen-select').chosen({search_contains: true});
     });
   </script>
 <% end %>


### PR DESCRIPTION
Aims to fix #660.

All search boxes can now search for _any part of a user's first name, last name, or email_.

Affected pages and example:
Grade Submissions (gradesheet)
<img src="https://cloud.githubusercontent.com/assets/3676913/14923601/10362542-0e0c-11e6-8fb1-e324dca98f72.png" alt="gradesheet" height="175">
Manage Submissions (now shows the user's name in the table like the gradesheet)
<img src="https://cloud.githubusercontent.com/assets/3676913/14923606/1496210a-0e0c-11e6-97d0-9ae451e2f34e.png" alt="manage_extensions" height="240">
Create Submission
<img src="https://cloud.githubusercontent.com/assets/3676913/14923616/1ea2543e-0e0c-11e6-8061-b9adab5965e0.png" alt="create_submission" width="250">
Manage Extensions
<img src="https://cloud.githubusercontent.com/assets/3676913/14923619/22d386b8-0e0c-11e6-9dbd-31bbe44af6e4.png" alt="manage_extension" width="250">
