### PR TITLE
Fixed csv import issue with all-comma lines

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -584,7 +584,8 @@ private
       # Major(11), Year(12), (skip)(13), Grade Policy(14), ...
 
       # Sanitize roster input, ignoring empty / incomplete lines.
-      parsedRoster.select! { |row| row.length == NEW_ROSTER_COLUMNS }
+      # Also requires each line to have an andrewID, else ignores it
+      parsedRoster.select! { |row| row.length == NEW_ROSTER_COLUMNS && row[8] != nil}
       # Detect if there is a header row
       if (parsedRoster[0][0] == "Semester")
         offset = 1


### PR DESCRIPTION
Addressing Issue #573 where the course roster importer would fail when trying to import a csv with a line of all commas.