### PR TITLE
Disconnect from database before running Moss

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -365,7 +365,7 @@ file, most likely a duplicate email.  The exact error was: #{e} "
     extract_tar_for_moss(tmp_dir, params[:external_tar])
     # Ensure that all files in Moss tmp dir are readable
     system("chmod -R a+r #{tmp_dir}")
-
+    ActiveRecord::Base.clear_active_connections!
     # Now run the Moss command
     @mossCmdString = @mossCmd.join(" ")
     @mossExit = $CHILD_STATUS


### PR DESCRIPTION
Since moss can run for an extended period of time, it is possible
for database connections to time out while it is running. ActiveRecord
does not check database connections for liveness whenever they are used,
only when they are checked out or back in to the connection pool.

Make activerecord return all active connections to the pool before running
moss, so any post-moss database access will use hopefully-live connections.
