### PR TITLE
fix trailing slash issue with importing assessment from tarball

### DIFF
--- a/app/controllers/assessments_controller.rb
+++ b/app/controllers/assessments_controller.rb
@@ -671,10 +671,11 @@ private
     tar_extract.each do |entry|
       pathname = entry.full_name
       next if pathname.start_with? "."
+      pathname.chomp!("/") if entry.directory?
       # nested directories are okay
-      if entry.directory? && asmt_name.nil?
-        # the highest level directory is assumed to be the assessment name per spec above
-        asmt_name = pathname.chomp("/")
+      if entry.directory? && pathname.count("/") == 0
+        return false if asmt_name
+        asmt_name = pathname
       else
         return false unless asmt_name
         asmt_rb_exists = true if pathname == "#{asmt_name}/#{asmt_name}.rb"

--- a/app/controllers/assessments_controller.rb
+++ b/app/controllers/assessments_controller.rb
@@ -672,9 +672,9 @@ private
       pathname = entry.full_name
       next if pathname.start_with? "."
       # nested directories are okay
-      if entry.directory? && pathname.count("/") == 0
-        return false if asmt_name
-        asmt_name = pathname
+      if entry.directory? && asmt_name.nil?
+        # the highest level directory is assumed to be the assessment name per spec above
+        asmt_name = pathname.chomp("/")
       else
         return false unless asmt_name
         asmt_rb_exists = true if pathname == "#{asmt_name}/#{asmt_name}.rb"


### PR DESCRIPTION
For #675.

The logic with the original code seems fine. The only problem was it was assuming directories in a tarball don't end with a slash. We just need to remove any trailing slashes for directories so that it aligns with the assumption.

(This assumption guarantees that directories containing no slashes are root level directories. An alternative solution would be updating the export assessment code so it appends a slash to every directory (just like how the cmdline tool tar would), and then assuming directories that contain exactly one slash are root level directories, but that isn't robust either. So it seems the most flexible way is to just preprocess the directory name so we don't assume anything about trailing slashes)