### PR TITLE
Introduced Materialize Gem and Phased out Bootstrap

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,9 @@ gem 'rails', '>=4.2.0'
 # Use SCSS for stylesheets
 gem 'sass-rails', '>= 4.0.3'
 
+# Use Materialize for the base css
+gem 'materialize-sass'
+
 # Use Uglifier as compressor for JavaScript assets
 gem 'uglifier', '>= 1.3.0'
 
@@ -39,7 +42,7 @@ gem 'rake', '>=10.3.2'
 gem 'populator', '>=1.0.0'
 
 # To communicate with MySQL database
-gem 'mysql2'
+# gem 'mysql2'
 gem 'sqlite3'
 
 # Development server

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -119,6 +119,8 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
+    materialize-sass (0.97.7)
+      sass (~> 3.3)
     mime-types (2.4.3)
     mini_portile (0.6.2)
     minitest (5.5.1)
@@ -127,7 +129,6 @@ GEM
     multi_json (1.11.0)
     multi_xml (0.5.5)
     multipart-post (2.0.0)
-    mysql2 (0.3.18)
     net-ldap (0.11)
     newrelic_rpm (3.11.2.286)
     nokogiri (1.6.6.2)
@@ -295,8 +296,8 @@ DEPENDENCIES
   httparty
   jbuilder (>= 2.0)
   jquery-rails
+  materialize-sass
   momentjs-rails (>= 2.9.0)
-  mysql2
   net-ldap
   newrelic_rpm
   omniauth (>= 1.2.2)
@@ -321,3 +322,6 @@ DEPENDENCIES
   thin
   turbolinks
   uglifier (>= 1.3.0)
+
+BUNDLED WITH
+   1.13.1

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -13,5 +13,5 @@
 //
 //= require jquery_ujs
 //= require moment
-//= require bootstrap-datetimepicker
 //= require app-level
+//= require materialize

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -1,6 +1,0 @@
-/* ...
-* require_self
-* require_tree .
-*= require bootstrap-datetimepicker
-*/
-

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,0 +1,10 @@
+/* ...
+* require_self
+* require_tree .
+*/
+
+/* For the materialize gem documentation, check out https://github.com/mkhairi/materialize-sass */
+
+$primary-color: #DD2222 !default;
+$secondary-color: #DD2222 !default;
+@import "materialize";

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -183,7 +183,7 @@ class SubmissionsController < ApplicationController
       send_data file,
                 filename: pathname,
                 disposition: "inline"
-    
+
     elsif params[:annotated]
 
       @filename_annotated = @submission.handin_annotated_file_path
@@ -197,7 +197,7 @@ class SubmissionsController < ApplicationController
       Prawn::Document.generate(@filename_annotated, :template => @filename) do |pdf|
 
         @annotations.each do |annotation|
-          
+
           return if annotation.coordinate.nil?
 
           position = annotation.coordinate.split(',')
@@ -224,10 +224,10 @@ class SubmissionsController < ApplicationController
 
           # + 1 since pages are indexed 1-based
           pdf.go_to_page(page + 1)
-          pdf.fill_color "ff0000" 
+          pdf.fill_color "ff0000"
           pdf.text_box comment,
-                      { :at => [xCord + 3, yCord - 3], 
-                        :height => height, 
+                      { :at => [xCord + 3, yCord - 3],
+                        :height => height,
                         :width => width }
 
         end
@@ -336,12 +336,12 @@ class SubmissionsController < ApplicationController
     # So if it fails, redirect, instead of showing an error page.
     if PDF.pdf?(file)
       @preview_mode = false
-      if params[:preview] then 
-        @preview_mode = true 
+      if params[:preview] then
+        @preview_mode = true
       end
 
       render(:viewPDF) && return
-    else 
+    else
       begin
         render(:view) && return
       rescue

--- a/app/views/assessments/bulkGrade.html.erb
+++ b/app/views/assessments/bulkGrade.html.erb
@@ -1,7 +1,7 @@
 <% @title = "Bulk Upload Grades" %>
 
 <% content_for :stylesheets do %>
-  <%= external_stylesheet_link_tag "bootstrap", "3.0.0" %>
+  
   <%= stylesheet_link_tag "bulkGrade" %>
 <% end %>
 

--- a/app/views/assessments/bulkGrade_complete.html.erb
+++ b/app/views/assessments/bulkGrade_complete.html.erb
@@ -1,5 +1,5 @@
 <% content_for :stylesheets do %>
-  <%= external_stylesheet_link_tag "bootstrap", "3.0.0" %>
+
   <%= stylesheet_link_tag "bulkGrade" %>
 <% end %>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,7 +7,7 @@
 
     <%= stylesheet_link_tag 'application' %>
     <%= stylesheet_link_tag 'animate' %>
-    <%= external_stylesheet_link_tag "bootstrap", "3.0.0" %>
+
     <%= stylesheet_link_tag 'style' %>
 
 
@@ -74,7 +74,7 @@
 
     <%= external_javascript_include_tag "jquery", "2.1.1" %>
     <%= content_for :js_widget_patch %>
-    <%= external_javascript_include_tag "bootstrap", "3.0.0" %>
+    
     <%= javascript_include_tag 'application' %>
     <script async defer id="github-bjs" src="https://buttons.github.io/buttons.js"></script>
     <%= content_for :javascripts %>

--- a/app/views/layouts/home.html.erb
+++ b/app/views/layouts/home.html.erb
@@ -7,7 +7,6 @@
 
     <%= stylesheet_link_tag 'application' %>
     <%= stylesheet_link_tag 'animate' %>
-    <%= external_stylesheet_link_tag "bootstrap", "3.0.0" %>
     <%= stylesheet_link_tag 'style' %>
 
     <% if Rails.configuration.x.analytics_id %>

--- a/config/database.yml.template
+++ b/config/database.yml.template
@@ -1,19 +1,19 @@
 # MySQL Configuration
-development:
-  adapter: mysql2
-  database: <username>_autolab_development 
-  pool: 5
-  username: <username>
-  password: '<password>'
-  socket: /var/run/mysqld/mysqld.sock
-  host: localhost
-
-# SQLite Configuration
 #development:
-#  adapter: sqlite3
-#  database: db/db.sqlite3
+#  adapter: mysql2
+#  database: <username>_autolab_development
 #  pool: 5
-#  timeout: 5000
+#  username: <username>
+#  password: '<password>'
+#  socket: /var/run/mysqld/mysqld.sock
+#  host: localhost
+
+SQLite Configuration
+development:
+  adapter: sqlite3
+  database: db/db.sqlite3
+  pool: 5
+  timeout: 5000
 
 test:
   adapter: mysql2
@@ -23,4 +23,3 @@ test:
   password: '<password>'
   socket: /var/run/mysqld/mysqld.sock
   host: localhost
-


### PR DESCRIPTION
Implemented Materialize as a ruby gem, changed the application.css stylesheet to application.scss to improve materialize import, and fully removed bootstrap css.

This breaks a lot of Autolab such as the navbar, but those issues will be fixed in future pull requests. This is meant to create a foundation for Autolab2.0 UI/UX changes as we fully adapt to Materialize.

Also removed the 'Bootstrap Date/Time Widget' from being included on every page.
