### PR TITLE
Material Course List and Assessment List

### DIFF
--- a/app/assets/stylesheets/style.css.scss
+++ b/app/assets/stylesheets/style.css.scss
@@ -558,27 +558,28 @@ table.navigatable tr:hover {
 
 .card {
   font-weight: normal;
-}
 
-.card .card-content,
-.card .collection,
-.card .card-action {
-  border-radius: initial;
-}
+  .card-content,
+  .collection,
+  .card-action {
+    border-radius: initial;
+  }
 
-.card .row {
-  margin: 0;
-}
+  .row {
+    margin: 0;
+  }
 
-.card .card-content .card-title {
-  line-height: normal;
-}
+  .card-content .card-title {
+    line-height: normal;
+  }
 
-.card .collection {
-  margin-top: 0;
-  margin-bottom: 0;
-  border-left: 0;
-  border-right: 0;
+  .collection {
+    margin-top: 0;
+    margin-bottom: 0;
+    border-left: 0;
+    border-right: 0;
+    border-bottom: 0;
+  }
 }
 
 /* badge */

--- a/app/assets/stylesheets/style.css.scss
+++ b/app/assets/stylesheets/style.css.scss
@@ -593,6 +593,11 @@ a.collection-item {
   transition: none;
 }
 
+.collection
+div.collection-item:hover {
+  background-color: #ddd;
+}
+
 
 /* General Styling */
 

--- a/app/assets/stylesheets/style.css.scss
+++ b/app/assets/stylesheets/style.css.scss
@@ -556,110 +556,23 @@ table.navigatable tr:hover {
 
 /* Card Styling */
 
-div.card {
-  display:inline-block;
-  width: 300px;
-  margin-right: 10px;
-  margin-top: 15px;
-  vertical-align: top;
-  webkit-box-shadow: 0 0 8px rgba(0,0,0,0.10);
-  -moz-box-shadow: 0 0 8px rgba(0,0,0,0.10);
-  box-shadow: 0 0 8px rgba(0,0,0,0.10);
-  -webkit-border-radius: 6px;
-  -moz-border-radius: 6px;
-  overflow: hidden;
-  text-align:center;
-  padding: 0;
-  // There is 22px between the assignment list and the button (from various
-  // margins), so let's match it below the button as well.
-  padding-bottom: 22px;
-  min-height: 215px;
+.card .card-content,
+.card .collection,
+.card .card-action {
+  border-radius: initial;
 }
 
-div.card:hover {
-  webkit-box-shadow: 0 0 12px rgba(0,0,0,0.18);
-  -moz-box-shadow: 0 0 12px rgba(0,0,0,0.18);
-  box-shadow: 0 0 12px rgba(0,0,0,0.18);
+.card .card-content .card-title {
+  line-height: normal;
 }
 
-
-div.card h1,
-div.card h2 {
-  font-weight: 300;
-  margin: 0;
+.card .collection {
+  margin-top: 0;
+  margin-bottom: 0;
+  border-left: 0;
+  border-right: 0;
 }
 
-div.card h1 {
-  background-color:#9F9B9D;
-  color:#fff;
-  font-size: 20px;
-}
-
-div.card:hover h1 {
-  background-color:#949092;
-}
-
-div.card h1 a {
-  display: block;
-  color: #fff;
-  font-size: 20px;
-  padding: 15px 24px;
-  line-height: 24px;
-}
-
-div.card .content {
-}
-
-div.card ul {
-  list-style: none;
-  list-style-position:inside;
-  padding:0;
-  font-size: 17px;
-  font-weight: normal;
-  text-align: left;
-}
-
-div.card ul li {
-  color: #747072;
-  height: 50px;
-  border-bottom: 1px solid #eee;
-  padding-left: 24px;
-}
-
-div.card ul li .shortcuts {
-  margin-right: 24px;
-  line-height: 50px;
-
-  a {
-    margin-left: 4px;
-  }
-}
-
-div.card ul a {
-  line-height: 50px;
-}
-
-div.card .btn.main {
-  margin-top: 12px;
-}
-
-div.card .btn.main:hover {
-  background-color: rgba(153, 0, 0, 0.9)
-}
-
-@media (max-width: 768px) {
-
-  .rolodex {
-    text-align: center;
-  }
-
-  div.card {
-    width: 280px;
-    margin-right: 4px;
-    margin-left: 4px;
-    margin-top: 15px;
-  }
-}
 
 /* General Styling */
 
@@ -792,6 +705,25 @@ label.control-label {
 .autolab .btn.small {
   padding: 5px 10px;
   font-size: 15px;
+}
+
+.section-title {
+  position:relative;
+  text-align:left;
+}
+
+.section-title:before {
+  content:"";
+  position:absolute;
+  top:50%;
+  left:0;
+  width:100%;
+  border-bottom:4px solid #dddddd;
+}
+
+.section-title span {
+  position: relative;
+  padding-right: 12px;
 }
 
 /**

--- a/app/assets/stylesheets/style.css.scss
+++ b/app/assets/stylesheets/style.css.scss
@@ -566,6 +566,10 @@ table.navigatable tr:hover {
   border-radius: initial;
 }
 
+.card .row {
+  margin: 0;
+}
+
 .card .card-content .card-title {
   line-height: normal;
 }
@@ -575,6 +579,17 @@ table.navigatable tr:hover {
   margin-bottom: 0;
   border-left: 0;
   border-right: 0;
+}
+
+/* badge */
+.badge.padded-badge {
+  padding: 2px 10px;
+}
+
+/* collections */
+.collection
+a.collection-item {
+  transition: none;
 }
 
 

--- a/app/assets/stylesheets/style.css.scss
+++ b/app/assets/stylesheets/style.css.scss
@@ -675,36 +675,7 @@ label.control-label {
 }
 
 .autolab .btn {
-  display: inline-block;
-  padding: 13px 18px;
-  margin-bottom: 0;
-  font-size: 16px;
-  font-weight: 400;
-  color: #fff;
-  line-height: 18px;
-  text-align: center;
-  white-space: nowrap;
-  vertical-align: middle;
-  cursor: pointer;
-  border: 1px solid transparent;
-  border-radius: 4px;
-  -webkit-user-select: none;
-  background-color: #808080;
-}
-
-.autolab .btn:hover {
-  color: #fff;
-  background-color: #aaa;
-  text-decoration: none;
-}
-
-.autolab .btn.primary {
-  background-color: rgba(153,0,0,0.9);
-}
-
-.autolab .btn.small {
-  padding: 5px 10px;
-  font-size: 15px;
+  font-weight: normal;
 }
 
 .section-title {

--- a/app/assets/stylesheets/style.css.scss
+++ b/app/assets/stylesheets/style.css.scss
@@ -556,6 +556,10 @@ table.navigatable tr:hover {
 
 /* Card Styling */
 
+.card {
+  font-weight: normal;
+}
+
 .card .card-content,
 .card .collection,
 .card .card-action {

--- a/app/views/assessments/index.html.erb
+++ b/app/views/assessments/index.html.erb
@@ -17,7 +17,10 @@
   <h3 class="section-title"><span class="white">Assignments</span></h3>
 
   <div class="row">
-    <% @course.assessment_categories.each do |cat| %>
+    <% @course.assessment_categories.each_with_index do |cat, idx| %>
+      <% if idx % 3 == 0 %>
+        <div class="clearfix hide-on-small-only"></div>
+      <% end %>
       <% asmts = @course.assessments_with_category(cat, @cud.student?) %>
       <% if asmts.any? %>
         <div class="col s12 m4">

--- a/app/views/assessments/index.html.erb
+++ b/app/views/assessments/index.html.erb
@@ -6,46 +6,52 @@
 <% end %>
 
 <% if @is_instructor %>
-<h2>Instructor Actions</h2>
+<div class="section">
+  <h3 class="section-title"><span class="white">Instructor Actions</span></h4>
   <%= link_to 'Install Assessment',
                     {:action=>"installAssessment"},
-                    {:title=>"Install Assessment", :class => "btn" } %>
-  <% end %>
-
-<h2>Assignments</h2>
-<div class="rolodex">
-<% @course.assessment_categories.each do |cat| %>
-  <% asmts = @course.assessments_with_category(cat, @cud.student?) %>
-  <% if asmts.any? %>
-  <div class="card">
-    <h1><a href=""><%= cat %></a></h1>
-    <div class="content">
-      <ul>
-      <% asmts.each do |asmt| %>
-        <li>
-          <%= link_to asmt.display_name, course_assessment_url(@course, asmt) %><%= "*" unless asmt.released? %>
-          <span class="pull-right shortcuts">
-            <a class="goto-icon-small" href="<%= course_assessment_path(@course, asmt) %>"><%= image_tag "go-new.png", :height => 22, :alt=>"Go to assessment" %></a>
-          </span>
-        </li>
-      <% end %>
-      <% if asmts.length == 0%>
-       <div><i>No assignments in this category.</i></div>
-      <% end %>
-      </ul>
-    </div>
-  </div>
-  <% end %>
+                    {:title=>"Install Assessment", :class => "waves-effect waves-light btn btn-large red darken-4" } %>
 <% end %>
+
+<div class="section">
+  <h3 class="section-title"><span class="white">Assignments</span></h3>
+
+  <div class="row">
+    <% @course.assessment_categories.each do |cat| %>
+      <% asmts = @course.assessments_with_category(cat, @cud.student?) %>
+      <% if asmts.any? %>
+        <div class="col s12 m4">
+          <div class="card hoverable">
+            <div class="card-content red darken-4">
+              <span class="card-title white-text"><%= cat %></span>
+            </div>
+
+            <div class="collection red darken-4" style="border-bottom: 0">
+              <% asmts.each do |asmt| %>
+                <%= link_to(course_assessment_url(@course, asmt),
+                            {:class => "collection-item grey-text text-darken-4"}) do %>
+                    <%= asmt.display_name %>
+                    
+                    <% if !asmt.released? %>
+                      <span class="new badge blue darken-4" data-badge-caption="unreleased"></span>
+                    <% end %>
+                <% end %>
+              <% end %>
+            </div>
+
+          </div>
+        </div>
+      <% end %>
+    <% end %>
+
+  </div>
 </div>
 
 <% if @attachments.any? %>
-  <h2>Files</h2>
-  <ul class="attachments">
-    <%= render @attachments %>
-  </ul>
-<% end %>
-
-<% if @is_instructor and (@course.assessments.unreleased.any? or @course.attachments.where(released: false).any?) %>
-  <i class="smallText">* Not visible to students</i>
+  <div class="section">
+    <h3 class="section-title"><span class="white">Attachments</span></h3>
+    <ul class="attachments">
+      <%= render @attachments %>
+    </ul>
+  </div>
 <% end %>

--- a/app/views/assessments/index.html.erb
+++ b/app/views/assessments/index.html.erb
@@ -29,16 +29,17 @@
               <span class="card-title white-text"><%= cat %></span>
             </div>
 
-            <div class="collection red darken-4" style="border-bottom: 0">
+            <div class="collection red darken-4">
               <% asmts.each do |asmt| %>
-                <%= link_to(course_assessment_url(@course, asmt),
-                            {:class => "collection-item grey-text text-darken-4"}) do %>
-                    <%= asmt.display_name %>
-                    
-                    <% if !asmt.released? %>
+                <div class="collection-item">
+                  <%= link_to asmt.display_name, course_assessment_url(@course, asmt),
+                              {:class => "grey-text text-darken-4"} %>
+                  <% if !asmt.released? %>
+                    <a href="<%= edit_course_assessment_url(@course, asmt) %>/handin">
                       <span class="new badge blue darken-4" data-badge-caption="unreleased"></span>
-                    <% end %>
-                <% end %>
+                    </a>
+                  <% end %>
+                </div>
               <% end %>
             </div>
 

--- a/app/views/courses/index.html.erb
+++ b/app/views/courses/index.html.erb
@@ -11,7 +11,7 @@
           <div class="clearfix hide-on-small-only"></div>
         <% end %>
         <% course_cud = CourseUserDatum.find_cud_for_course(course, current_user.id) %>
-        <% not_student = course_cud.course_assistant? || course_cud.instructor? %>
+        <% not_student = course_cud.has_auth_level? :course_assistant %>
 
         <div class="col s12 m4">
           <div class="card hoverable">

--- a/app/views/courses/index.html.erb
+++ b/app/views/courses/index.html.erb
@@ -9,12 +9,7 @@
       <% list.each do |course| %>
         <% course_cud = CourseUserDatum.find_cud_for_course(course, current_user.id) %>
         <% not_student = course_cud.course_assistant? || course_cud.instructor? %>
-        <% if not_student
-             main_color = "deep-orange"
-           else
-             main_color = "red"
-           end
-        %>
+        <% main_color = not_student ? "deep-orange" : "red" %>
 
         <div class="col s12 m4">
           <div class="card hoverable">

--- a/app/views/courses/index.html.erb
+++ b/app/views/courses/index.html.erb
@@ -1,33 +1,52 @@
-<h1>Courses</h1>
+<h2>Courses</h2>
 
 <% @listing.each do |category, list| %>
   <% if list.size > 0 %>
-    <h2><%= category.capitalize %></h2>
+    <div class="section">
 
-    <div class="rolodex">
+    <h3 class="section-title"><span class="white"><%= category.capitalize %></span></h3>
+
+    <div class="row">
       <% list.each do |course| %>
-        <div class="card course">
-          <h1><%= link_to course.full_name, course_path(course) %></h1>
+        <% course_cud = CourseUserDatum.find_cud_for_course(course, current_user.id) %>
+        <% not_student = course_cud.instructor? || (course_cud.course_assistant? && !course_cud.section.blank?) %>
+        <% if not_student
+             main_color = "deep-orange"
+           else
+             main_color = "red"
+           end
+        %>
 
-          <div class="content">
-            <ul>
+        <div class="col s12 m4">
+          <div class="card hoverable">
+            <div class="card-content <%= main_color %> darken-4">
+              <span class="card-title white-text"><%= course.full_name %></span>
+            </div>
+
+            <div class="collection <%= main_color %> darken-4" style="border-bottom: 0">
               <% course.current_assessments.ordered.each do |asmt| %>
-                <li>
-                  <%= link_to asmt.display_name, course_assessment_path(course, asmt) %>
-                  <span class="pull-right shortcuts">
-                    <a href="<%= course_assessment_path(course, asmt) %>"><%= image_tag "go-new.png", :height => 22, :alt=>"Go to assessment" %></a>
-                  </span>
-                </li>
+                <%= link_to asmt.display_name, course_assessment_path(course, asmt), class: "collection-item grey-text text-darken-4" %>
               <% end %>
-            </ul>
-            <% if course.current_assessments.length == 0 %>
-              <div><i>No current assessments</i></div>
-            <% end %>
-            <%= link_to 'Go to Course Page', course_path(course), :class=>'btn main' %>
+            </div>
+
+            <div class="card-action">
+              <%= link_to 'Course Page', course_path(course), class: "#{main_color}-text text-darken-4", title: "Go to course page" %>
+              
+              <% if course_cud %>
+                <% if not_student %>
+                  <%= link_to "Grade Section", [:view, course, course_cud, :gradebook, section: course_cud.section], title: "View your gradebook", class: "#{main_color}-text text-darken-4" %>
+                <% else %>
+                  <%= link_to "Gradebook", [course, course_cud, :gradebook], title: "View your gradebook", class: "#{main_color}-text text-darken-4" %>
+                <% end %>
+              <% end %>
+            </div>
           </div>
         </div>
+
       <% end %>
     </div>
+
+    </div> <!-- section -->
   <% end %>
 <% end %>
 

--- a/app/views/courses/index.html.erb
+++ b/app/views/courses/index.html.erb
@@ -12,16 +12,18 @@
         <% end %>
         <% course_cud = CourseUserDatum.find_cud_for_course(course, current_user.id) %>
         <% not_student = course_cud.course_assistant? || course_cud.instructor? %>
-        <% main_color = not_student ? "deep-orange" : "red" %>
 
         <div class="col s12 m4">
           <div class="card hoverable">
-            <div class="card-content <%= main_color %> darken-4">
-              <%= link_to course.full_name, course_path(course), class: "card-title white-text", title: "Go to course page" %>
+            <div class="card-content red darken-4">
+              <div class="row">
+                <div class="col <%= not_student ? 's9' : 's12' %>"><%= link_to course.full_name, course_path(course), class: "card-title white-text", title: "Go to course page" %></div>
+                <% if not_student %> <div class="col s3"><span class="new badge padded-badge" data-badge-caption="Instructor"></span></div> <% end %>
+              </div>
             </div>
 
             <% if category != :completed %>
-              <div class="collection <%= main_color %> darken-4" style="border-bottom: 0">
+              <div class="collection red darken-4" style="border-bottom: 0">
                 <% course.current_assessments.ordered.each do |asmt| %>
                   <%= link_to asmt.display_name, course_assessment_path(course, asmt), class: "collection-item grey-text text-darken-4" %>
                 <% end %>
@@ -29,13 +31,13 @@
             <% end %>
 
             <div class="card-action">
-              <%= link_to 'Course Page', course_path(course), class: "#{main_color}-text text-darken-4", title: "Go to course page" %>
+              <%= link_to 'Course Page', course_path(course), class: "red-text text-darken-4", title: "Go to course page" %>
               
               <% if course_cud %>
                 <% if not_student && !course_cud.section.blank? %>
-                  <%= link_to "Grade Section", [:view, course, course_cud, :gradebook, section: course_cud.section], title: "Grade your section", class: "#{main_color}-text text-darken-4" %>
+                  <%= link_to "Grade Section", [:view, course, course_cud, :gradebook, section: course_cud.section], title: "Grade your section", class: "red-text text-darken-4" %>
                 <% elsif !not_student %>
-                  <%= link_to "Gradebook", [course, course_cud, :gradebook], title: "View your gradebook", class: "#{main_color}-text text-darken-4" %>
+                  <%= link_to "Gradebook", [course, course_cud, :gradebook], title: "View your gradebook", class: "red-text text-darken-4" %>
                 <% end %>
               <% end %>
             </div>

--- a/app/views/courses/index.html.erb
+++ b/app/views/courses/index.html.erb
@@ -17,7 +17,7 @@
           <div class="card hoverable">
             <div class="card-content red darken-4">
               <div class="row">
-                <div class="col <%= not_student ? 's9' : 's12' %>"><%= link_to course.full_name, course_path(course), class: "card-title white-text", title: "Go to course page" %></div>
+                <div class="col <%= not_student ? 's9' : 's12' %>"><h4><%= link_to course.full_name, course_path(course), class: "card-title white-text", title: "Go to course page" %></h4></div>
                 <% if not_student %> <div class="col s3"><span class="new badge padded-badge" data-badge-caption="Instructor"></span></div> <% end %>
               </div>
             </div>

--- a/app/views/courses/index.html.erb
+++ b/app/views/courses/index.html.erb
@@ -6,7 +6,10 @@
     <h3 class="section-title"><span class="white"><%= category.capitalize %></span></h3>
 
     <div class="row">
-      <% list.each do |course| %>
+      <% list.each_with_index do |course, idx| %>
+        <% if idx % 3 == 0 %>
+          <div class="clearfix hide-on-small-only"></div>
+        <% end %>
         <% course_cud = CourseUserDatum.find_cud_for_course(course, current_user.id) %>
         <% not_student = course_cud.course_assistant? || course_cud.instructor? %>
         <% main_color = not_student ? "deep-orange" : "red" %>

--- a/app/views/courses/index.html.erb
+++ b/app/views/courses/index.html.erb
@@ -19,7 +19,7 @@
         <div class="col s12 m4">
           <div class="card hoverable">
             <div class="card-content <%= main_color %> darken-4">
-              <span class="card-title white-text"><%= course.full_name %></span>
+              <%= link_to course.full_name, course_path(course), class: "card-title white-text", title: "Go to course page" %>
             </div>
 
             <% if category != :completed %>

--- a/app/views/courses/index.html.erb
+++ b/app/views/courses/index.html.erb
@@ -3,13 +3,12 @@
 <% @listing.each do |category, list| %>
   <% if list.size > 0 %>
     <div class="section">
-
     <h3 class="section-title"><span class="white"><%= category.capitalize %></span></h3>
 
     <div class="row">
       <% list.each do |course| %>
         <% course_cud = CourseUserDatum.find_cud_for_course(course, current_user.id) %>
-        <% not_student = course_cud.instructor? || (course_cud.course_assistant? && !course_cud.section.blank?) %>
+        <% not_student = course_cud.course_assistant? || course_cud.instructor? %>
         <% if not_student
              main_color = "deep-orange"
            else
@@ -23,19 +22,21 @@
               <span class="card-title white-text"><%= course.full_name %></span>
             </div>
 
-            <div class="collection <%= main_color %> darken-4" style="border-bottom: 0">
-              <% course.current_assessments.ordered.each do |asmt| %>
-                <%= link_to asmt.display_name, course_assessment_path(course, asmt), class: "collection-item grey-text text-darken-4" %>
-              <% end %>
-            </div>
+            <% if category != :completed %>
+              <div class="collection <%= main_color %> darken-4" style="border-bottom: 0">
+                <% course.current_assessments.ordered.each do |asmt| %>
+                  <%= link_to asmt.display_name, course_assessment_path(course, asmt), class: "collection-item grey-text text-darken-4" %>
+                <% end %>
+              </div>
+            <% end %>
 
             <div class="card-action">
               <%= link_to 'Course Page', course_path(course), class: "#{main_color}-text text-darken-4", title: "Go to course page" %>
               
               <% if course_cud %>
-                <% if not_student %>
-                  <%= link_to "Grade Section", [:view, course, course_cud, :gradebook, section: course_cud.section], title: "View your gradebook", class: "#{main_color}-text text-darken-4" %>
-                <% else %>
+                <% if not_student && !course_cud.section.blank? %>
+                  <%= link_to "Grade Section", [:view, course, course_cud, :gradebook, section: course_cud.section], title: "Grade your section", class: "#{main_color}-text text-darken-4" %>
+                <% elsif !not_student %>
                   <%= link_to "Gradebook", [course, course_cud, :gradebook], title: "View your gradebook", class: "#{main_color}-text text-darken-4" %>
                 <% end %>
               <% end %>

--- a/app/views/courses/index.html.erb
+++ b/app/views/courses/index.html.erb
@@ -23,7 +23,7 @@
             </div>
 
             <% if category != :completed %>
-              <div class="collection red darken-4" style="border-bottom: 0">
+              <div class="collection red darken-4">
                 <% course.current_assessments.ordered.each do |asmt| %>
                   <%= link_to asmt.display_name, course_assessment_path(course, asmt), class: "collection-item grey-text text-darken-4" %>
                 <% end %>


### PR DESCRIPTION
New course and assessment index pages using Materialize:

Courses page:
![material_course_page](https://cloud.githubusercontent.com/assets/3676913/20646008/06d5fde0-b43f-11e6-916f-bc0c0b562314.png)
Uses a different color (deep-orange for now) for courses where the user is a CA/Instructor so its easier to distinguish. The second card action also changes from viewing the user's gradebook to viewing the section's gradebook.

Assessments page:
![material_assessment_list](https://cloud.githubusercontent.com/assets/3676913/20646011/0ce7418a-b43f-11e6-8acf-ba7da8f61f2c.png)
Unreleased assessments will have the unreleased badge.

(We can definitely do a lot with these badges).