### PR TITLE
Change lab template image to autograding_image for use with Tango Docker

### DIFF
--- a/lib/tasks/autolab.rake
+++ b/lib/tasks/autolab.rake
@@ -286,7 +286,7 @@ namespace :autolab do
     # Load autograding properties
     Autograder.create! do |autograder|
       autograder.assessment_id = asmt.id
-      autograder.autograde_image = "rhel.img"
+      autograder.autograde_image = "autograding_image"
       autograder.autograde_timeout = 180
       autograder.release_score = true
     end


### PR DESCRIPTION
Previously the autopopulated image was `rhel.img`. This was causing problems in the build script as we are now using Tango Docker which uses `autograding_image` image name. Fixes build script