### PR TITLE
Fix issue #609: 'Edit Information' button visible

### DIFF
--- a/app/views/course_user_data/show.html.erb
+++ b/app/views/course_user_data/show.html.erb
@@ -11,4 +11,6 @@
   <li><b>Course Average Tweak</b> of <%=raw tweak(@requestedUser.tweak) %></li>
   <% end %>
 </ul>
+<% if @cud.instructor? then %>
 <%= link_to raw('<span class="btn primary">Edit Information</span>'), edit_course_course_user_datum_path(@course, @requestedUser) %>
+<% end %>

--- a/app/views/course_user_data/user.html.erb
+++ b/app/views/course_user_data/user.html.erb
@@ -12,4 +12,6 @@
   <li><b>Course Average Tweak</b> of <%=raw tweak(@requestedUser.tweak) %></li>
   <% end %>
 </ul>
+<% if @user.instructor? then %>
 <%= link_to raw('<span class="btn primary">Edit Information</span>'), edit_course_user_path(@course, @requestedUser), :id=>@requestedUser.id %>
+<% end %>


### PR DESCRIPTION
A few simple fixes to issue "Authorization for course_user_data#show #609", in which students would see an "Edit Information" button on the course_user_data page. Students no longer see an "Edit Information" button.