### PR TITLE
Attachments#show should use an absolute path

### DIFF
--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -36,7 +36,7 @@ class AttachmentsController < ApplicationController
       flash[:error] = "Could not find Attachment # #{params[:id]}"
       redirect_to([@course, :attachments]) && return
     end
-    filename = File.join("attachments", @attachment.filename)
+    filename = Rails.root.join("attachments", @attachment.filename)
     unless File.exist?(filename)
       flash[:error] = "Error loading #{@attachment.name} from #{@attachment.filename}"
       redirect_to([@course, :attachments]) && return


### PR DESCRIPTION
Otherwise if the working directory changes (e.g. due to moss),
it will always fail