### PR TITLE
Use Rails.root.join everywhere

### DIFF
--- a/app/controllers/assessment/grading.rb
+++ b/app/controllers/assessment/grading.rb
@@ -361,8 +361,7 @@ private
   def load_course_config
     course = @course.name.gsub(/[^A-Za-z0-9]/, "")
     begin
-      load(File.join(Rails.root, "courseConfig",
-                     "#{course}.rb"))
+      load(Rails.root.join("courseConfig", "#{course}.rb"))
       eval("extend(Course#{course.camelize})")
     rescue Exception
       render(text: "Error loading your course's grading " \

--- a/app/controllers/assessments_controller.rb
+++ b/app/controllers/assessments_controller.rb
@@ -298,10 +298,9 @@ class AssessmentsController < ApplicationController
     @submission = @assessment.submissions.find(params[:submission])
     # Shows a form which has the submission on top, and feedback on bottom
     begin
-      subFile = File.join(Rails.root, "courses",
-                          @course.name, @assessment.name,
-                          @assessment.handin_directory,
-                          @submission.filename)
+      subFile = Rails.root.join("courses", @course.name, @assessment.name,
+                                @assessment.handin_directory,
+                                @submission.filename)
       @submissionData = File.read(subFile)
     rescue
       @submissionData = "Could not read #{subFile}"

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -274,7 +274,7 @@ file, most likely a duplicate email.  The exact error was: #{e} "
   # assessment directory.
   action_auth_level :installAssessment, :instructor
   def installAssessment
-    @assignDir = File.join(Rails.root, "courses", @course.name)
+    @assignDir = Rails.root.join("courses", @course.name)
     @availableAssessments = []
     begin
       Dir.foreach(@assignDir) do |filename|

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -30,18 +30,18 @@ class Course < ActiveRecord::Base
 
   # generate course folder
   def init_course_folder
-    course_dir = File.join Rails.root, "courses", name
+    course_dir = Rails.root.join("courses", name)
     FileUtils.mkdir_p course_dir
 
-    FileUtils.touch (File.join course_dir, "autolab.log")
+    FileUtils.touch File.join(course_dir, "autolab.log")
 
-    course_rb = File.join course_dir, "course.rb"
-    default_course_rb = File.join Rails.root, "lib", "__defaultCourse.rb"
+    course_rb = File.join(course_dir, "course.rb")
+    default_course_rb = Rails.root.join("lib", "__defaultCourse.rb")
     FileUtils.cp default_course_rb, course_rb
 
-    FileUtils.mkdir_p (File.join Rails.root, "assessmentConfig")
-    FileUtils.mkdir_p (File.join Rails.root, "courseConfig")
-    FileUtils.mkdir_p (File.join Rails.root, "gradebooks")
+    FileUtils.mkdir_p Rails.root.join("assessmentConfig")
+    FileUtils.mkdir_p Rails.root.join("courseConfig")
+    FileUtils.mkdir_p Rails.root.join("gradebooks")
   end
 
   def order_of_dates
@@ -72,8 +72,8 @@ class Course < ActiveRecord::Base
 
   def reload_config_file
     course = name.gsub(/[^A-Za-z0-9]/, "")
-    src = File.join(Rails.root, "courses", name, "course.rb")
-    dest = File.join(Rails.root, "courseConfig/", "#{course}.rb")
+    src = Rails.root.join("courses", name, "course.rb")
+    dest = Rails.root.join("courseConfig/", "#{course}.rb")
     s = File.open(src, "r")
     lines = s.readlines
     s.close
@@ -177,7 +177,7 @@ private
   end
 
   def config_file_path
-    File.join(Rails.root, "courseConfig", "#{sanitized_name}.rb")
+    Rails.root.join("courseConfig", "#{sanitized_name}.rb")
   end
 
   def config_module_name

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -74,9 +74,8 @@ class Submission < ActiveRecord::Base
                version.to_s + "_" +
                assessment.handin_filename
     directory = assessment.handin_directory
-    path = File.join(Rails.root, "courses",
-                     course_user_datum.course.name,
-                     assessment.name, directory, filename)
+    path = Rails.root.join("courses", course_user_datum.course.name,
+                           assessment.name, directory, filename)
 
     if upload["file"]
       # Sanity!

--- a/app/views/assessments/installAssessment.html.erb
+++ b/app/views/assessments/installAssessment.html.erb
@@ -16,7 +16,7 @@
   then you can import it into your current course:</p>
 
   <ul>
-  <li> Step 1: Copy the assessment from the previous course directory to the current course directory (<%= File.join(Rails.root, "courses", @course.name) %>).
+  <li> Step 1: Copy the assessment from the previous course directory to the current course directory (<%= Rails.root.join("courses", @course.name) %>).
 
   <li>Step 2: Refresh this page to cause your new assessment to appear 
   in the list below. 

--- a/lib/tasks/autolab.rake
+++ b/lib/tasks/autolab.rake
@@ -13,9 +13,9 @@ namespace :autolab do
 
   AUTOGRADE_CATEGORY_NAME = "CategoryAutograde"
   AUTOGRADE_TEMPLATE_DIR_PATH =
-          File.join(Rails.root, "templates", "labtemplate")
+          Rails.root.join("templates", "labtemplate")
   AUTOGRADE_TEMPLATE_CONFIG_PATH =
-          File.join(Rails.root, "templates", "AutoPopulated-labtemplate.rb")
+          Rails.root.join("templates", "AutoPopulated-labtemplate.rb")
   AUTOGRADE_TEMPLATE_NAME = "labtemplate"
   AUTOGRADE_TEMPLATE_DISPLAY_NAME = "Lab Template"
   AUTOGRADE_TEMPLATE_MAX_SCORE = 100.0
@@ -38,7 +38,7 @@ namespace :autolab do
   end
 
   def load_assessments course
-    course_dir = File.join(Rails.root, "courses", course.name)
+    course_dir = Rails.root.join("courses", course.name)
     ASSESSMENT_CATEGORIES.each do |cat|
 
       # start date for this category
@@ -173,7 +173,7 @@ namespace :autolab do
   end
 
   def load_submissions_for(course, cud)
-    course_dir = File.join(Rails.root, "courses", course.name)
+    course_dir = Rails.root.join("courses", course.name)
     user = cud.user
 
     course.assessments.each do |a|
@@ -228,12 +228,12 @@ namespace :autolab do
   end
 
   def add_assessment_files course
-    course_dir = File.join Rails.root, "courses", course.name
+    course_dir = Rails.root.join("courses", course.name)
 
     course.assessments.each do |a|
       assessment_dir = File.join(course_dir, a.name)
       assessment_handin_dir = File.join(assessment_dir, a.handin_directory)
-      assessment_template_path = File.join(Rails.root, "lib", "__defaultAssessment.rb")
+      assessment_template_path = Rails.root.join("lib", "__defaultAssessment.rb")
       assessment_template = nil
 
       File.open(assessment_template_path) do |f|
@@ -262,7 +262,7 @@ namespace :autolab do
 
   def load_autograde_assessment course
 
-    course_dir = File.join(Rails.root, "courses", course.name)
+    course_dir = Rails.root.join("courses", course.name)
 
     # Create assessment
     asmt = course.assessments.create! do |a|
@@ -299,7 +299,7 @@ namespace :autolab do
     FileUtils.cp_r(AUTOGRADE_TEMPLATE_DIR_PATH, course_dir)
 
     # Copy assessment config
-    assessmentConfig_dir = File.join(Rails.root, "assessmentConfig")
+    assessmentConfig_dir = Rails.root.join("assessmentConfig")
     FileUtils.cp(AUTOGRADE_TEMPLATE_CONFIG_PATH, assessmentConfig_dir)
 
     # Reload config file
@@ -361,8 +361,8 @@ namespace :autolab do
 
   def delete_course course
     if course
-      course_dir = File.join(Rails.root, "courses", course.name)
-      course_config_dir = File.join(Rails.root, "courseConfig")
+      course_dir = Rails.root.join("courses", course.name)
+      course_config_dir = Rails.root.join("courseConfig")
       course_config_path = File.join(course_config_dir, "#{course.name}.rb")
 
       course.destroy


### PR DESCRIPTION
Never use File.join(Rails.root...), only Rails.root.join(...)

also add some parenthesis around some path computations to
improve readability.

I assumed that this would be requested after reviewing #751. If you don't think it is necessary, close it.