### PR TITLE
Fix Issue #710: Version Penalty does not account for deleted submissions

### DIFF
--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -234,13 +234,18 @@ class Submission < ActiveRecord::Base
     final_score_opts o
   end
 
+  # NOTE: threshold  is no longer calculated using submission version,
+  # but now using the number of submissions. This way, deleted submissions will
+  # not be accounted for in the version penalty. 
   def version_over_threshold_by
     # version threshold of -1 allows infinite submissions without penalty
     return 0 if assessment.effective_version_threshold < 0
 
     # normal submission versions start at 1
     # unofficial submissions conveniently have version 0
-    [version - assessment.effective_version_threshold, 0].max
+    # actual version number is not used here, instead submission count is used
+    count = assessment.submissions.where(course_user_datum: course_user_datum).count
+    [count - assessment.effective_version_threshold, 0].max
   end
 
   # Refer to https://github.com/autolab/autolab-src/wiki/Caching


### PR DESCRIPTION
Fix Issue #710: When calculating version penalty, the version_over_threshold_by method in submission.rb now only accounts for the number of submissions that exist rather than the version number of the current submission. The new version numbers of new submissions will still be dependent upon deleted submissions, but deleted submissions will not count toward the version penalty.