### PR TITLE
Fix Issue #763: Duplicate email error not caught

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -99,6 +99,9 @@ class UsersController < ApplicationController
     save_worked = false
     begin
       save_worked = @user.save
+      if !save_worked
+        flash[:error] = "User creation failed"
+      end
     rescue => error
       error_message = error.message
       if error_message.include? "Duplicate entry" and error_message.include? "@"

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -102,17 +102,17 @@ class UsersController < ApplicationController
     rescue => error
       error_message = error.message
       if error_message.include? "Duplicate entry" and error_message.include? "@"
-        flash[:error] = "Email #{@user.email} already in use"
+        flash[:error] = "User with email #{@user.email} already exists"
       else
-        flash[:error] = error_message
+        flash[:error] = "User creation failed"
       end
+      save_worked = false
     end
     if save_worked
       @user.send_reset_password_instructions
       flash[:success] = "User creation success"
       redirect_to(users_path) && return
     else
-      #flash[:error] = "User creation failed"
       render action: "new"
     end
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -96,13 +96,23 @@ class UsersController < ApplicationController
     @user.password = temp_pass
     @user.password_confirmation = temp_pass
     @user.skip_confirmation!
-
-    if @user.save
+    save_worked = false
+    begin
+      save_worked = @user.save
+    rescue => error
+      error_message = error.message
+      if error_message.include? "Duplicate entry" and error_message.include? "@"
+        flash[:error] = "Email #{@user.email} already in use"
+      else
+        flash[:error] = error_message
+      end
+    end
+    if save_worked
       @user.send_reset_password_instructions
       flash[:success] = "User creation success"
       redirect_to(users_path) && return
     else
-      flash[:error] = "User creation failed"
+      #flash[:error] = "User creation failed"
       render action: "new"
     end
   end


### PR DESCRIPTION
I added a begin/rescue clause that flashes "Email #{@user.email} already in use" if the email already exists.