### PR TITLE
Entire blocks as links

### DIFF
--- a/app/views/assessments/index.html.erb
+++ b/app/views/assessments/index.html.erb
@@ -1,3 +1,17 @@
+<% content_for :javascripts do %>
+  <script>
+    jQuery(function() {
+      /* a way to mimic nested anchor tags */
+      $('a.collection-item span.new.badge').each(function(idx, obj) {
+        $(obj).on("click", function() {
+          window.location = obj.dataset.url;
+          return false;  // prevent click propagation
+        });
+      });
+    });
+  </script>
+<% end %>
+
 <%= render partial: "announcements/announcements_list", 
            locals: { announcements: @announcements } %>
 
@@ -31,15 +45,13 @@
 
             <div class="collection red darken-4">
               <% asmts.each do |asmt| %>
-                <div class="collection-item">
-                  <%= link_to asmt.display_name, course_assessment_url(@course, asmt),
-                              {:class => "grey-text text-darken-4"} %>
+                <%= link_to course_assessment_url(@course, asmt), 
+                    :class => "collection-item grey-text text-darken-4" do %>
+                  <%= asmt.display_name %>
                   <% if !asmt.released? %>
-                    <a href="<%= edit_course_assessment_url(@course, asmt) %>/handin">
-                      <span class="new badge blue darken-4" data-badge-caption="unreleased"></span>
-                    </a>
+                      <span class="new badge blue darken-4" data-badge-caption="unreleased" data-url="<%= edit_course_assessment_url(@course, asmt) %>/handin"></span>
                   <% end %>
-                </div>
+                <% end %>
               <% end %>
             </div>
 

--- a/app/views/courses/index.html.erb
+++ b/app/views/courses/index.html.erb
@@ -15,12 +15,14 @@
 
         <div class="col s12 m4">
           <div class="card hoverable">
-            <div class="card-content red darken-4">
-              <div class="row">
-                <div class="col <%= not_student ? 's9' : 's12' %>"><h4><%= link_to course.full_name, course_path(course), class: "card-title white-text", title: "Go to course page" %></h4></div>
-                <% if not_student %> <div class="col s3"><span class="new badge padded-badge" data-badge-caption="Instructor"></span></div> <% end %>
+            <%= link_to course_path(course), title: "Go to Course Page" do %>
+              <div class="card-content red darken-4">
+                <div class="row">
+                  <div class="col <%= not_student ? 's9' : 's12' %>"><h4><span class="card-title white-text"><%= course.full_name %></span></h4></div>
+                  <% if not_student %> <div class="col s3"><span class="new badge padded-badge" data-badge-caption="Instructor"></span></div> <% end %>
+                </div>
               </div>
-            </div>
+            <% end %>
 
             <% if category != :completed %>
               <div class="collection red darken-4">


### PR DESCRIPTION
Aims to fix #756.

This fixes the original issue with individual assessment links on the assessment index page. Instead of only the text being clickable, now the entire collection-item block is clickable and acts as a link. The sub-link for the badges still works (to allow for this, a JS onclick approach was used, since nested a tags are illegal).