### PR TITLE
Non exist course 404 error

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -30,7 +30,7 @@ class ApplicationController < ActionController::Base
     rescue_from Exception, with: :render_error
     rescue_from CourseUserDatum::AuthenticationFailed do |e|
       COURSE_LOGGER.log("AUTHENTICATION FAILED: #{e.user_message}, #{e.dev_message}")
-      respond_to do |format| 
+      respond_to do |format|
          format.html {
             flash[:error] = e.user_message
             redirect_to root_path
@@ -141,8 +141,8 @@ protected
     @course = Course.find_by(name: course_name) if course_name
 
     unless @course
-      flash[:error] = "Course #{params[:course_name]} does not exist!"
-      redirect_to(controller: :home, action: :error) && return
+      # Throw a 404 error if the course page is not found.
+      render :file => "#{Rails.root}/public/404.html",  :status => 404
     end
 
     # set course logger

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -141,7 +141,6 @@ protected
     @course = Course.find_by(name: course_name) if course_name
 
     unless @course
-      # Throw a 404 error if the course page is not found.
       render :file => "#{Rails.root}/public/404.html",  :status => 404
     end
 


### PR DESCRIPTION
Fixes #625. Courses that don't exist will produce a 404 instead of a 500.