### PR TITLE
Fix Issue #757: CUD creation now explains problem

### DIFF
--- a/app/assets/stylesheets/style.css.scss
+++ b/app/assets/stylesheets/style.css.scss
@@ -386,6 +386,11 @@ ul.gray-box.small > li + li {
   font-size:10px;
 }
 
+/*This is the one that we're (I'm) using for required-field indicators.*/
+.redText {
+  color: red;
+}
+
 /**
 * Displayed on the home page
 **/
@@ -990,7 +995,7 @@ div.center {
 }
 
 .attachment {
-  
+
   font-weight: bold;
   color:  #eee;
   border: 2px solid #eee;

--- a/app/controllers/course_user_data_controller.rb
+++ b/app/controllers/course_user_data_controller.rb
@@ -31,8 +31,21 @@ class CourseUserDataController < ApplicationController
       if user
         @newCUD.user = user
       else
-        flash[:error] = "The user with email #{email} could not be created  "
-        redirect_to(action: "new") && return
+        # Here I'm checking if any of three required fields are blank.
+        # If one of them is, we know what the error is and we can flash
+        # that to the user.
+        if cud_parameters[:user_attributes][:email] == "" or
+           cud_parameters[:user_attributes][:first_name] == "" or
+           cud_parameters[:user_attributes][:last_name] == ""
+
+          flash[:error] = "All required fields must be filled"
+          redirect_to(action: "new") && return
+        else
+          # If we get to this point, then we don't really know for certain
+          # what the error is, so we just flash an error message.
+          flash[:error] = "The user with email #{email} could not be created"
+          redirect_to(action: "new") && return
+        end
       end
 
     else

--- a/app/controllers/course_user_data_controller.rb
+++ b/app/controllers/course_user_data_controller.rb
@@ -31,9 +31,6 @@ class CourseUserDataController < ApplicationController
       if user
         @newCUD.user = user
       else
-        # Here I'm checking if any of three required fields are blank.
-        # If one of them is, we know what the error is and we can flash
-        # that to the user.
         if cud_parameters[:user_attributes][:email] == "" or
            cud_parameters[:user_attributes][:first_name] == "" or
            cud_parameters[:user_attributes][:last_name] == ""
@@ -41,15 +38,12 @@ class CourseUserDataController < ApplicationController
           flash[:error] = "All required fields must be filled"
           redirect_to(action: "new") && return
         else
-          # If we get to this point, then we don't really know for certain
-          # what the error is, so we just flash an error message.
           flash[:error] = "The user with email #{email} could not be created"
           redirect_to(action: "new") && return
         end
       end
 
     else
-      # check CUD existence
       unless user.course_user_data.where(course: @course).empty?
         flash[:error] = "User #{email} is already in #{@course.full_name}"
         redirect_to(action: "new") && return
@@ -57,7 +51,6 @@ class CourseUserDataController < ApplicationController
       @newCUD.user = user
     end
 
-    # save CUD
     if @newCUD.save
       flash[:success] = "Success: added user #{email} in #{@course.full_name}"
       if @cud.user.administrator?

--- a/app/views/course_user_data/new.html.erb
+++ b/app/views/course_user_data/new.html.erb
@@ -8,9 +8,7 @@
     function userLookup() {
       var email_input = document.getElementById("course_user_datum_user_attributes_email").value;
       if (!email_input || email_input == "") return;
-
       $.get('<%= url_for [:userLookup, @course, remote: true]  %>',  { email: email_input }, function( data ) {
-
         if (!data)  {
           $('#course_user_datum_user_attributes_first_name').prop('disabled', false);
           $('#course_user_datum_user_attributes_last_name').prop('disabled', false);
@@ -32,13 +30,14 @@
 <% end %>
 
 <h2>Add New User to Course</h2>
+<div class=redText> * Indicates a required field</div>
 <%= form_for @newCUD, url: course_course_user_data_path do |f| %>
 
 <% if @newCUD.errors.any? %>
 	<div id="error_explanation">
 		<h2><%= pluralize(@newCUD.errors.count, "error") %>
       prohibited the data from being saved:</h2>
-			
+
 		<ul>
 			<% @newCUD.errors.full_messages.each do |msg| %>
 			<li><%= msg %></li>
@@ -49,15 +48,15 @@
 
   <table width=70% class="verticalTable" >
   <tr><th>Course</th><td><%= @course.display_name %></td></tr>
-  
+
   <%= f.fields_for :user, @newCUD.user do |u| %>
-    <tr><th>User Email: </th><td><%= u.email_field :email %></td>
+    <tr><th>User Email: <a class=redText>*</a></th><td><%= u.email_field :email %></td>
   		<td><a id="user-lookup">User Lookup</a>
       <i class='smallText'> <b>(Enter email, then click this link to fill in user info from records)</b></i></td></tr>
 
-    <tr><th>First Name</th><td><%= u.text_field :first_name %></td>
+    <tr><th>First Name <a class=redText>*</a></th><td><%= u.text_field :first_name %></td>
     <td class="smallText"></td></tr>
-    <tr><th>Last Name</th><td><%= u.text_field :last_name %></td>
+    <tr><th>Last Name <a class=redText>*</a></th><td><%= u.text_field :last_name %></td>
     <td class="smallText"></td></tr>
 
   <% end %>
@@ -80,7 +79,7 @@
       <%= t.text_field :value, :size => 18, :value => "0" %>
       <%= t.select :kind, options_for_select({"points" => "points", "%" => "percent"}, :selected => (@newCUD.tweak ? @newCUD.tweak.kind : "points")) %>
     <% end %>
-    </td> 
+    </td>
     <td class="smallText">A tweak is a positive or negative value that adjusts the student's course average.<br>Ex: A tweak of 5 points would increase the student's course average by 5 points. </td>
   </tr>
 
@@ -94,7 +93,7 @@
   <td class="smallText">Course assistants can assign scores to problems and nothing else.</td></tr>
   <% end %>
 
-  
+
   </table>
   <br>
   <input id="user_submit" class="btn primary"name="commit" type="submit" value="Save Changes" onclick="formvalidation(this.parentNode); return false;">


### PR DESCRIPTION
Basically, we know that when CUD creation fails, it simply displays the message "The user with email #{email} could not be created". As it turns out, there is a code snippet in app/views/course_user_data/new.html.erb that displays all errors that the object contains, but because @newCUD.user is equal to nil when the user is created, no errors are actually stored anywhere (at least, as far as I know). So instead of printing the errors, I added a code snippet in course_user_data_controller.rb that flashes "All required fields must be filled" if the email, first, or last name fields are empty (which caused the error in the first place) if any of these fields are empty. The generic error message "The user with email #{email} could not be created" is still included just in case there are any errors that are not caused by empty fields.

In addition to these changes, I also added some html code that indicates required fields.