### PR TITLE
Display browser local time everywhere

### DIFF
--- a/app/assets/javascripts/app-level.js
+++ b/app/assets/javascripts/app-level.js
@@ -5,9 +5,9 @@
 $(document).ready(function() {
 	$(".moment-date-time").each(function(ind) {
 		$el = $(this);
-		var format = $el.data("format")  || "MMMM Do YYYY, HH:mm:ss";
+		var format = $el.data("format")  || "YYYY-MM-DD HH:mm:ss";
 		var unformattedDate = $el.html();
-		var formattedDate = moment(unformattedDate, "YYYY-MM-DD hh:mm ZZ").format(format);
+		var formattedDate = moment(unformattedDate, "YYYY-MM-DD hh:mm:ss ZZ").format(format);
 		$el.html(formattedDate);
 	});
 

--- a/app/assets/javascripts/app-level.js
+++ b/app/assets/javascripts/app-level.js
@@ -5,7 +5,7 @@
 $(document).ready(function() {
 	$(".moment-date-time").each(function(ind) {
 		$el = $(this);
-		var format = $el.data("format")  || "MMMM Do YYYY, h:mm a";
+		var format = $el.data("format")  || "MMMM Do YYYY, HH:mm:ss";
 		var unformattedDate = $el.html();
 		var formattedDate = moment(unformattedDate, "YYYY-MM-DD hh:mm ZZ").format(format);
 		$el.html(formattedDate);

--- a/app/controllers/jobs_controller.rb
+++ b/app/controllers/jobs_controller.rb
@@ -226,7 +226,7 @@ protected
       # until now.  Dead jobs show end-to-end elapsed time.
       t1 = DateTime.parse(job[:first]).to_time
       if is_live
-        snow = Time.now.localtime.to_s
+        snow = Time.now.in_time_zone.to_s
         t2 = DateTime.parse(snow).to_time
       else
         t2 = DateTime.parse(job[:last]).to_time

--- a/app/controllers/scoreboards_controller.rb
+++ b/app/controllers/scoreboards_controller.rb
@@ -47,7 +47,7 @@ class ScoreboardsController < ApplicationController
       if @grades[uid][:version] != row["version"]
         # MySQL returns a Time object, but SQLite returns a time-stamp string
         row["time"] = Time.parse(row["time"]) if row["time"].class != Time
-        @grades[uid][:time] = row["time"].localtime
+        @grades[uid][:time] = row["time"].in_time_zone
         @grades[uid][:version] = row["version"].to_i
         @grades[uid][:autoresult] = row["autoresult"]
       end

--- a/app/helpers/assessment_user_datum_helper.rb
+++ b/app/helpers/assessment_user_datum_helper.rb
@@ -12,11 +12,11 @@ module AssessmentUserDatumHelper
 
   # Due At in string form. If it is nil (meaning there is infinite extension), display appropriate information.
   def due_at_display(due_at)
-    due_at.nil? ? "Not applicable (infinite extension granted)" : due_at.to_s
+    due_at.nil? ? "Not applicable (infinite extension granted)" : due_at.in_time_zone.to_s
   end
 
   # End At string form. If it is nil (meaning there is infinite extension), display appropriate information.
   def end_at_display(end_at)
-    end_at.nil? ? "Not applicable (infinite extension granted)" : end_at.to_s
+    end_at.nil? ? "Not applicable (infinite extension granted)" : end_at.in_time_zone.to_s
   end
 end

--- a/app/views/assessments/_submission_history_row.html.erb
+++ b/app/views/assessments/_submission_history_row.html.erb
@@ -17,7 +17,7 @@
     <% end %>
   </td>
 
-  <td class=smallText><%= submission.created_at %></td>
+  <td class=smallText><span class="moment-date-time"><%= submission.created_at.localtime.to_s %></span></td>
 
   <% for problem in @problems do %>
     <td class="prettyBorder">

--- a/app/views/assessments/_submission_history_row.html.erb
+++ b/app/views/assessments/_submission_history_row.html.erb
@@ -17,7 +17,7 @@
     <% end %>
   </td>
 
-  <td class=smallText><span class="moment-date-time"><%= submission.created_at.localtime.to_s %></span></td>
+  <td class=smallText><span class="moment-date-time"><%= submission.created_at.in_time_zone.to_s %></span></td>
 
   <% for problem in @problems do %>
     <td class="prettyBorder">

--- a/app/views/assessments/_submission_summary_row.html.erb
+++ b/app/views/assessments/_submission_summary_row.html.erb
@@ -118,7 +118,7 @@
 
 </table>
 <br>
-  <span class="smallText">Submitted at: <span class="moment-date-time"><%= submission.created_at %></span></span>
+  <span class="smallText">Submitted at: <span class="moment-date-time"><%= submission.created_at.in_time_zone.to_s %></span></span>
 <br>
   <% if @cud.instructor? then %>
       <% if @assessment.has_autograder? and submission.version > 0 then %>

--- a/app/views/assessments/show.html.erb
+++ b/app/views/assessments/show.html.erb
@@ -139,11 +139,11 @@
         <p class="valign-wrapper">
           <i class="material-icons valign">access_time</i>
             &nbsp;&nbsp;Due<% if @extension then %>&nbsp;(with <%=@extension.days %> day extension)<% end %>:&nbsp;
-            <b><span class="moment-date-time"> <%= due_at_display @aud.due_at %></span></b>
+            <b><span class="moment-date-time" data-format="MMMM Do YYYY, h:mm a"> <%= due_at_display @aud.due_at %></span></b>
         </p>
 
         <p class="valign-wrapper">
-          <i class="valign material-icons">today</i>&nbsp;&nbsp;Last day to handin:&nbsp;&nbsp;<b><span class="moment-date-time"> <%= end_at_display(@aud.end_at false) %></span></b>
+          <i class="valign material-icons">today</i>&nbsp;&nbsp;Last day to handin:&nbsp;&nbsp;<b><span class="moment-date-time" data-format="MMMM Do YYYY, h:mm a"> <%= end_at_display(@aud.end_at false) %></span></b>
 
         </p>
 

--- a/app/views/jobs/getjob.html.erb
+++ b/app/views/jobs/getjob.html.erb
@@ -43,7 +43,7 @@
 <ul>
   <% for item in @job[:rjob]["trace"] do %>
     <% poo = item.split("|") %>
-    <li><span class="moment-date-time"><%= DateTime.parse(poo[0]).to_time.localtime.to_s %></span> | <%= poo[1] %></li>
+    <li><span class="moment-date-time"><%= DateTime.parse(poo[0]).to_time.in_time_zone.to_s %></span> | <%= poo[1] %></li>
   <% end %>
 </ul>
 

--- a/app/views/jobs/getjob.html.erb
+++ b/app/views/jobs/getjob.html.erb
@@ -43,7 +43,7 @@
 <ul>
   <% for item in @job[:rjob]["trace"] do %>
     <% poo = item.split("|") %>
-    <li><%= DateTime.parse(poo[0]).to_time.localtime.to_s(:db) %> | <%= poo[1] %></li>
+    <li><span class="moment-date-time"><%= DateTime.parse(poo[0]).to_time.localtime.to_s %></span> | <%= poo[1] %></li>
   <% end %>
 </ul>
 

--- a/app/views/jobs/index.html.erb
+++ b/app/views/jobs/index.html.erb
@@ -19,7 +19,7 @@ This page shows you the status of current and recent autograding jobs.<br />
     <tr>
     <td> <%= @job[:id] %> </td> 
     <td> <%= @job[:name] %> </td> 
-    <td> <span class="moment-date-time"><%= DateTime.parse(@job[:first]).to_time.localtime.to_s %></span> </td> 
+    <td> <span class="moment-date-time"><%= DateTime.parse(@job[:first]).to_time.in_time_zone.to_s %></span> </td> 
     <td> <%= @job[:elapsed] %> </td>
 
     <% if @job[:name] == "*" then %>
@@ -47,7 +47,7 @@ This page shows you the status of current and recent autograding jobs.<br />
     <tr>
     <td> <%= @job[:id] %> </td> 
     <td> <%= @job[:name] %> </td> 
-    <td> <span class="moment-date-time"><%= DateTime.parse(@job[:first]).to_time.localtime.to_s %></span> </td> 
+    <td> <span class="moment-date-time"><%= DateTime.parse(@job[:first]).to_time.in_time_zone.to_s %></span> </td> 
     <td> <%= @job[:elapsed] %> </td>
 
     <% if @job[:name] == "*" then %>
@@ -71,7 +71,7 @@ if @dead_jobs_view and
   @dead_jobs_view[-1] and 
   @dead_jobs_view[-1][:first] and 
   @dead_jobs_view[-1][:first] != "" then
-    since = DateTime.parse(@dead_jobs_view[-1][:first]).to_time.localtime.to_s
+    since = DateTime.parse(@dead_jobs_view[-1][:first]).to_time.in_time_zone.to_s
 end
 %>
 
@@ -92,7 +92,7 @@ end
   <% for @job in @dead_jobs_view do %>
     <tr <% if @job[:state] == "Failed" then %> style="background-color:#ce4844; color:#fff"<% end %>>    <td> <%= @job[:id] %> </td>
     <td> <%= @job[:name] %> </td> 
-    <td> <span class="moment-date-time"><%= DateTime.parse(@job[:first]).to_time.localtime.to_s %></span> </td> 
+    <td> <span class="moment-date-time"><%= DateTime.parse(@job[:first]).to_time.in_time_zone.to_s %></span> </td> 
     <td> <%= @job[:elapsed] %> </td>
     <td> <%= link_to @job[:state], {:controller => "jobs", :action => "getjob", :id=>@job[:id]} %> </td>
     </tr>

--- a/app/views/jobs/index.html.erb
+++ b/app/views/jobs/index.html.erb
@@ -19,7 +19,7 @@ This page shows you the status of current and recent autograding jobs.<br />
     <tr>
     <td> <%= @job[:id] %> </td> 
     <td> <%= @job[:name] %> </td> 
-    <td> <span class="moment-date-time"><%= DateTime.parse(@job[:first]).to_time.localtime.to_s(:db) %></span> </td> 
+    <td> <span class="moment-date-time"><%= DateTime.parse(@job[:first]).to_time.localtime.to_s %></span> </td> 
     <td> <%= @job[:elapsed] %> </td>
 
     <% if @job[:name] == "*" then %>
@@ -47,7 +47,7 @@ This page shows you the status of current and recent autograding jobs.<br />
     <tr>
     <td> <%= @job[:id] %> </td> 
     <td> <%= @job[:name] %> </td> 
-    <td> <span class="moment-date-time"><%= DateTime.parse(@job[:first]).to_time.localtime.to_s(:db) %></span> </td> 
+    <td> <span class="moment-date-time"><%= DateTime.parse(@job[:first]).to_time.localtime.to_s %></span> </td> 
     <td> <%= @job[:elapsed] %> </td>
 
     <% if @job[:name] == "*" then %>
@@ -71,7 +71,7 @@ if @dead_jobs_view and
   @dead_jobs_view[-1] and 
   @dead_jobs_view[-1][:first] and 
   @dead_jobs_view[-1][:first] != "" then
-    since = DateTime.parse(@dead_jobs_view[-1][:first]).to_time.localtime.to_s(:db)
+    since = DateTime.parse(@dead_jobs_view[-1][:first]).to_time.localtime.to_s
 end
 %>
 
@@ -92,7 +92,7 @@ end
   <% for @job in @dead_jobs_view do %>
     <tr <% if @job[:state] == "Failed" then %> style="background-color:#ce4844; color:#fff"<% end %>>    <td> <%= @job[:id] %> </td>
     <td> <%= @job[:name] %> </td> 
-    <td> <span class="moment-date-time"><%= DateTime.parse(@job[:first]).to_time.localtime.to_s(:db) %></span> </td> 
+    <td> <span class="moment-date-time"><%= DateTime.parse(@job[:first]).to_time.localtime.to_s %></span> </td> 
     <td> <%= @job[:elapsed] %> </td>
     <td> <%= link_to @job[:state], {:controller => "jobs", :action => "getjob", :id=>@job[:id]} %> </td>
     </tr>

--- a/app/views/jobs/index.html.erb
+++ b/app/views/jobs/index.html.erb
@@ -19,7 +19,7 @@ This page shows you the status of current and recent autograding jobs.<br />
     <tr>
     <td> <%= @job[:id] %> </td> 
     <td> <%= @job[:name] %> </td> 
-    <td> <%= DateTime.parse(@job[:first]).to_time.localtime.to_s(:db) %> </td> 
+    <td> <span class="moment-date-time"><%= DateTime.parse(@job[:first]).to_time.localtime.to_s(:db) %></span> </td> 
     <td> <%= @job[:elapsed] %> </td>
 
     <% if @job[:name] == "*" then %>
@@ -47,7 +47,7 @@ This page shows you the status of current and recent autograding jobs.<br />
     <tr>
     <td> <%= @job[:id] %> </td> 
     <td> <%= @job[:name] %> </td> 
-    <td> <%= DateTime.parse(@job[:first]).to_time.localtime.to_s(:db) %> </td> 
+    <td> <span class="moment-date-time"><%= DateTime.parse(@job[:first]).to_time.localtime.to_s(:db) %></span> </td> 
     <td> <%= @job[:elapsed] %> </td>
 
     <% if @job[:name] == "*" then %>
@@ -71,16 +71,16 @@ if @dead_jobs_view and
   @dead_jobs_view[-1] and 
   @dead_jobs_view[-1][:first] and 
   @dead_jobs_view[-1][:first] != "" then
-    since = "(since #{DateTime.parse(@dead_jobs_view[-1][:first]).to_time.localtime.to_s(:db)})"
+    since = DateTime.parse(@dead_jobs_view[-1][:first]).to_time.localtime.to_s(:db)
 end
 %>
 
 <% if @cud.user.administrator? then %>
-  <h2>Recently Completed Jobs <%=since%></h2>
+  <h2>Recently Completed Jobs (since <span class="moment-date-time"><%=since%></span>)</h2>
 <% elsif @cud.instructor? then %>
-  <h2>Recently Completed Jobs For This Course <%=since%></h2>
+  <h2>Recently Completed Jobs For This Course (since <span class="moment-date-time"><%=since%></span>)</h2>
 <% else %>
-  <h2>Your Recently Completed Jobs <%=since%></h2>
+  <h2>Your Recently Completed Jobs (since <span class="moment-date-time"><%=since%></span>)</h2>
 <% end %>
 
 <% if @dead_jobs_view.blank? or @dead_jobs == [] then %>
@@ -92,7 +92,7 @@ end
   <% for @job in @dead_jobs_view do %>
     <tr <% if @job[:state] == "Failed" then %> style="background-color:#ce4844; color:#fff"<% end %>>    <td> <%= @job[:id] %> </td>
     <td> <%= @job[:name] %> </td> 
-    <td> <%= DateTime.parse(@job[:first]).to_time.localtime.to_s(:db) %> </td> 
+    <td> <span class="moment-date-time"><%= DateTime.parse(@job[:first]).to_time.localtime.to_s(:db) %></span> </td> 
     <td> <%= @job[:elapsed] %> </td>
     <td> <%= link_to @job[:state], {:controller => "jobs", :action => "getjob", :id=>@job[:id]} %> </td>
     </tr>

--- a/app/views/scoreboards/show.html.erb
+++ b/app/views/scoreboards/show.html.erb
@@ -51,7 +51,7 @@
               <%= grade[:version] %>
             <% end %>
           </td>
-          <td><%= grade[:time] %></td>
+          <td><span class="moment-date-time"><%= grade[:time] %></span></td>
           <% if @colspec %>
             <% @colspec.each_with_index do |c, i| %>
               <% # this is a hack for 15-122's image lab.  It displays b64 encoded results in image tags %>

--- a/app/views/submissions/index.html.erb
+++ b/app/views/submissions/index.html.erb
@@ -75,7 +75,7 @@
           %></td>
       <!-- TODO: for now, until rewrite -->
       <td style="<%= ignored_submission_style submission %>"><%= submission.version %></td>
-      <td><%= submission.created_at.strftime("%Y-%m-%d %T") %></td>
+      <td><span class="moment-date-time"><%= submission.created_at.localtime.to_s %></span></td>
       <!-- TODO: for now, until rewrite -->
       <td style="<%= ignored_submission_style submission %>">
         <% if submission.filename then %>

--- a/app/views/submissions/index.html.erb
+++ b/app/views/submissions/index.html.erb
@@ -75,7 +75,7 @@
           %></td>
       <!-- TODO: for now, until rewrite -->
       <td style="<%= ignored_submission_style submission %>"><%= submission.version %></td>
-      <td><span class="moment-date-time"><%= submission.created_at.localtime.to_s %></span></td>
+      <td><span class="moment-date-time"><%= submission.created_at.in_time_zone.to_s %></span></td>
       <!-- TODO: for now, until rewrite -->
       <td style="<%= ignored_submission_style submission %>">
         <% if submission.filename then %>


### PR DESCRIPTION
Currently times displayed on Autolab are in the time zone of the server clock (and sometimes in the time zone specified in the config file, and sometimes even in UTC). #729 brought into attention that we should instead use browser local time to prevent confusion or the need for manual conversion.

New standardized procedure:
All instances of displayed time are wrapped in a 'moment-date-time' class, which will be processed once on the client side into the browser local time (a feature of moment.js). The raw time in the html will still be in the time zone specified in the rails config file, so even if js is blocked or fails, the time will still be understandable.

A list of all instances of time updated:
- Submit file page (assessments:show)
- Assessment submission history page (assessments:history)
- Manage submissions page (submissions:index)
- Recent jobs page (jobs:index)
- Job details page (jobs:getjob)
- Scoreboard page (scoreboard:index)

If there's any other page with a displayed time that's missing please comment.