### PR TITLE
School specific config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ before_script:
 - cp cmu-prod/frontend-configs/initializers/devise.rb $AUTOLAB/config/initializers/devise.rb
 - cd $AUTOLAB
 - cp config/database.travis.yml config/database.yml
+- cp config/school.yml.template config/school.yml
 - cp config/autogradeConfig.rb.template config/autogradeConfig.rb
 - mkdir attachments/ tmp/
 - bundle install --quiet

--- a/app/controllers/assessment/autograde.rb
+++ b/app/controllers/assessment/autograde.rb
@@ -157,7 +157,7 @@ module AssessmentAutograde
       end
     elsif job == -1
       link = "<a href=\"#{url_for(controller: 'jobs')}\">Jobs</a>"
-      flash[:error] = "There was an error submitting your autograding job. We are likely down for maintenance if issues persist, please contact autolab-dev-list@listserv.buffalo.edu"
+      flash[:error] = "There was an error submitting your autograding job. We are likely down for maintenance if issues persist, please contact #{Rails.configuration.school['support_email']}"
     elsif job == -3 || job == -4 || job == -6
       flash[:error] = "There was an error uploading the submission file. (Error #{job})"
     elsif job == -9

--- a/app/controllers/assessment/handin.rb
+++ b/app/controllers/assessment/handin.rb
@@ -159,7 +159,7 @@ module AssessmentHandin
         Dir.mkdir(remote_handin_dir)
       rescue SystemCallError
         COURSE_LOGGER.log("ERROR: Could not create handin directory. Please contact
-        autolab-dev@andrew.cmu.edu with this error")
+        #{Rails.configuration.school['support_email']} with this error")
       end
 
       system("fs sa #{remote_handin_dir} #{@user.email} rlidw")

--- a/app/mailers/course_mailer.rb
+++ b/app/mailers/course_mailer.rb
@@ -29,7 +29,7 @@ class CourseMailer < ActionMailer::Base
     @text = text
 
     mail(
-      to: "autolab-dev@andrew.cmu.edu",
+      to: Rails.configuration.school['tech_email'],
       subject: subject,
       from: @user.email,
       sent_on: Time.now

--- a/app/views/home/contact.html.erb
+++ b/app/views/home/contact.html.erb
@@ -47,7 +47,7 @@ experience on Autolab amazing. Here are some frequently asked questions:
     In this case, feel free to send an email to the Autolab developers mailing list,
     </p>
     <p>
-		<b>hartloff [at] buffalo.edu</b>
+		<b><%= Rails.configuration.school['support_email'] %></b>
     </p>
     <p>
     We get a good deal of traffic on this list, but we'll make our best effort to

--- a/app/views/home/error.html.erb
+++ b/app/views/home/error.html.erb
@@ -4,7 +4,7 @@
 
 <% if flash[:error] %><p><b><%= flash[:error] %></b></p><% end %>
 
-<p><b>Oops!</b> Autolab seems to have done something wrong.  We have been notified about this and will look into it. If you would like to file a Bug Report, you may email us at <a href="mailto:hartloff@buffalo.edu">hartloff@buffalo.edu</a> or open an issue in our <a href="https://github.com/autolab/Autolab/issues/">issue tracker</a> on GitHub.</p>
+<p><b>Oops!</b> Autolab seems to have done something wrong.  We have been notified about this and will look into it. If you would like to file a Bug Report, you may email us at <a href="mailto:<%= Rails.configuration.school['support_email'] %>"><%= Rails.configuration.school['support_email'] %></a> or open an issue in our <a href="https://github.com/autolab/Autolab/issues/">issue tracker</a> on GitHub.</p>
 
 <%= image_tag "DonkeyKong.jpg", width: '200px' %>
 

--- a/app/views/home/error.html.erb
+++ b/app/views/home/error.html.erb
@@ -33,6 +33,6 @@
 <% end %>
 
 <div id="footer">
-  <a href="http://autolab.cs.cmu.edu">CMU Autolab</a>
+  <a href="/"><%= Rails.configuration.school['school_short_name'] %> Autolab</a>
   <p>Questions or problems? Please <a href="/contact">contact us</a>.</p>
 </div>

--- a/app/views/home/error_404.html.erb
+++ b/app/views/home/error_404.html.erb
@@ -4,7 +4,7 @@
 
 <% if flash[:error] %><p><b><%= flash[:error] %></b></p><% end %>
 
-<p><b>Oops!</b> Find this page Autolab can not. If you believe there should be something here please email us at  <a href="mailto:autolab-dev-list@listserv.buffalo.edu">autolab-dev-list@listserv.buffalo.edu</a>, with the page that you were trying to access.</p>
+<p><b>Oops!</b> Find this page Autolab can not. If you believe there should be something here please email us at  <a href="mailto:<%= Rails.configuration.school['support_email'] %>"><%= Rails.configuration.school['support_email'] %></a>, with the page that you were trying to access.</p>
 
 <%= image_tag "DonkeyKong.jpg", width: '200px' %>
 

--- a/app/views/home/no_user.html.erb
+++ b/app/views/home/no_user.html.erb
@@ -105,7 +105,7 @@ Here are some resources to get you started.
         </li>
         <li>
         If you need help troubleshooting something related to Autolab that
-        doens't belong on our issue tracker, you can email us at <b>hartloff [at] buffalo.edu</b>.
+        doens't belong on our issue tracker, you can email us at <b><%= Rails.configuration.school['tech_email'] %></b>.
         </li>
       </ul>
       </p>

--- a/bin/setup.sh
+++ b/bin/setup.sh
@@ -191,6 +191,8 @@ autolab_setup() {
     sed -i "s/<YOUR-SECRET-KEY>/`bundle exec rake secret`/g" $AUTOLAB_PATH/config/initializers/devise.rb
 
     cp $AUTOLAB_PATH/config/autogradeConfig.rb.template $AUTOLAB_PATH/config/autogradeConfig.rb
+    
+    cp $AUTOLAB_PATH/config/school.yml.template $AUTOLAB_PATH/config/school.yml
 
     log "Granting MySQL database permissions..."
     mysql -uroot -p$MYSQL_ROOT_PSWD -e "GRANT ALL PRIVILEGES ON ""$USER""_autolab_development.* TO '$USER'@'%' IDENTIFIED BY '<password>'"

--- a/config/application.rb
+++ b/config/application.rb
@@ -93,5 +93,8 @@ module Autolab3
 
     # Allow MOSS to work with as many files as it wants
     Rack::Utils.multipart_part_limit = 0
+
+    # School specific configuration (please edit config/school.yml)
+    config.school = config_for(:school)
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -35,7 +35,7 @@ module Autolab3
     end
 
     # TODO: this should be a macro
-    config.action_mailer.default_url_options = {protocol: 'https', host: 'autograder.cse.buffalo.edu' }
+    config.action_mailer.default_url_options = {protocol: 'https', host: 'YOUR_APP_URL' }
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers

--- a/config/school.yml
+++ b/config/school.yml
@@ -1,0 +1,17 @@
+production:
+  school_name: "My School"
+  school_short_name: "MS"
+  support_email: "autolab@myschool.edu"
+  tech_email: "autolab-tech@myschool.edu"
+
+development:
+  school_name: "Carnegie Mellon University"
+  school_short_name: "CMU"
+  support_email: "autolab-help@andrew.cmu.edu"
+  tech_email: "autolab-dev@andrew.cmu.edu"
+
+test:
+  school_name: "Carnegie Mellon University"
+  school_short_name: "CMU"
+  support_email: "autolab-help@andrew.cmu.edu"
+  tech_email: "autolab-dev@andrew.cmu.edu"

--- a/config/school.yml.template
+++ b/config/school.yml.template
@@ -7,11 +7,11 @@ production:
 development:
   school_name: "Carnegie Mellon University"
   school_short_name: "CMU"
-  support_email: "autolab-help@andrew.cmu.edu"
-  tech_email: "autolab-dev@andrew.cmu.edu"
+  support_email: "autolab@myschool.edu"
+  tech_email: "autolab-tech@myschool.edu"
 
 test:
   school_name: "Carnegie Mellon University"
   school_short_name: "CMU"
-  support_email: "autolab-help@andrew.cmu.edu"
-  tech_email: "autolab-dev@andrew.cmu.edu"
+  support_email: "autolab@myschool.edu"
+  tech_email: "autolab-tech@myschool.edu"

--- a/public/404.html
+++ b/public/404.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
     <head>
-        <title>500 - Internal Server Error</title>
+        <title>404 - Page not found</title>
         <link rel="stylesheet" type="text/css" href="/assets/style.css">
         <link rel="shortcut icon" href="/assets/autolab.ico" type="image/x-icon"> 
     </head>
@@ -11,11 +11,10 @@
             <h1 id="courseTitle">Autolab</h1>
 
             <div id="content">
-                <h2>500 - Internal error</h2>
+                <h2>404 - Page not found</h2>
 
-                <p><b>Oops!</b> Autolab seems to have done something wrong.</p>
-                <p><b>We have NOT been notified about this.</b></p>
-                <img src="images/DonkeyKong.jpg" width=200px />
+                <p><b>Oops!</b> The page you are looking for could not be found. 
+                <img src="images/donkey_kong_lost.jpg" width=200px />
             </div>
             <div id="footer">
                 <p><a href="/">Autolab Home</a></p>


### PR DESCRIPTION
Targeted at #770.

Adds a config file school.yml (or if someone has a better name?) that allows specification of:
- SchoolName
- SchoolShortName
- SupportEmail
- TechEmail

Some Issues:
The static pages (e.g. 404, 500) do not go through rails, so there's no way of using these config for those pages unless we change how we handle these errors. One would have to manually edit these pages.
Additionally, the 'contact' page ([/contact](https://autolab.andrew.cmu.edu/contact)) also needs to be edited as the entire page is mostly school specific FAQ.