### PR TITLE
upgrade to latest datatables to fix error with gradesheet

### DIFF
--- a/app/views/assessments/_gradesheet.html.erb
+++ b/app/views/assessments/_gradesheet.html.erb
@@ -4,7 +4,7 @@
 
 <% content_for :javascripts do %>
   <%= external_javascript_include_tag "jquery-ui", "1.10.2" %>
-  <%= external_javascript_include_tag "jquery.dataTables", "1.10.5" %>
+  <%= external_javascript_include_tag "jquery.dataTables", "1.10.13" %>
 
   <%= javascript_include_tag "jquery.jeditable" %>
 


### PR DESCRIPTION
Apparently the gradesheet page no longer works now because of a problem with our old version of JQuery Datatables library. Upgrading it to the latest version restores functionality. 