### PR TITLE
Fix destroy course id reference

### DIFF
--- a/app/controllers/admins_controller.rb
+++ b/app/controllers/admins_controller.rb
@@ -2,9 +2,12 @@
 # this controller contains methods for system-wise
 # admin functionality
 class AdminsController < ApplicationController
-    rescue_from ActionView::MissingTemplate do |exception|
-      redirect_to("/home/error_404")
+  rescue_from ActionView::MissingTemplate do |exception|
+    redirect_to("/home/error_404")
   end
+
+  skip_before_action :set_course
+
   action_auth_level :show, :administrator
   def show
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -60,7 +60,6 @@ class ApplicationController < ActionController::Base
     end
 
     if level == :administrator
-      skip_before_action :set_course, only: [action]
       skip_before_action :authorize_user_for_course, only: [action]
       skip_filter authenticate_for_action: [action]
       skip_before_action :update_persistent_announcements, only: [action]

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -161,18 +161,7 @@ class CoursesController < ApplicationController
   # DELETE courses/:id/
   action_auth_level :destroy, :administrator
   def destroy
-    unless current_user.administrator?
-      flash[:error] = "Permission denied."
-      redirect_to(courses_path) && return
-    end
-
-    course = Course.find(params[:id])
-    if course.nil?
-      flash[:error] = "Course doesn't exist."
-      redirect_to(courses_path) && return
-    end
-
-    course.destroy
+    @course.destroy
     flash[:success] = "Course destroyed."
     redirect_to(courses_path) && return
   end


### PR DESCRIPTION
Destroy course tried to reference the "id" param, which doesn't exist at all. Replaced it with the @course instance variable set by "set_course".

For some reason, set_course is skipped if the authorization level is set to administrator, which doesn't make sense, but also didn't cause any problems since course#destroy is the only method with admin authorization that needs the course set. This update removes the skip, and adds it to the other admin methods that need skipping.