### PR TITLE
Fix Gradesheet Numeric Column Sorting

### DIFF
--- a/app/assets/javascripts/gradesheet.js.erb
+++ b/app/assets/javascripts/gradesheet.js.erb
@@ -7,7 +7,7 @@ jQuery(function() {
     var current_editor = undefined;
     var current_popover = undefined;
 
-    var num_cols = jQuery("table#grades > thead > tr:first > th").length
+    var num_cols = hclasses.length;
 
     numeric_columns = []
     for (var i = first_problem_column; i < num_cols; i++)
@@ -127,7 +127,7 @@ jQuery(function() {
         $prob_col.children().appendTo($td_prob);
       }
     }
-    console.log(table_data);
+    
     // main score table
     var oTable = jQuery("#grades").dataTable({
         'data' : table_data,


### PR DESCRIPTION
fixes #791.

There was already a set of custom sorting functions defined for the 'numeric columns', however the actual numeric columns were not registered with the datatables plugin because the count was wrong. Fixing the num_cols count solves the problem.

e.g.
![gradesheet_numeric_columns_sor](https://cloud.githubusercontent.com/assets/3676913/23391541/a70e5724-fd43-11e6-8e5d-e5c3f98e5261.jpg)
