### PR TITLE
Fix checkbox issues

### DIFF
--- a/app/assets/stylesheets/gradesheet.css.scss
+++ b/app/assets/stylesheets/gradesheet.css.scss
@@ -181,7 +181,7 @@ td.id {
 #grades td.id .popover span.filename span.links {
     float: right;
     padding-right: 3px;
-    text-transform: uppercase; 
+    text-transform: uppercase;
     font-weight: bold;
     font-size: 0.9em;
 }
@@ -268,4 +268,10 @@ td.id {
 
 .template {
     display: none;
+}
+
+[type="checkbox"]:not(:checked), [type="checkbox"]:checked {
+    position: static;
+    left: auto;
+    opacity: 1;
 }

--- a/app/views/assessments/_gradesheet.html.erb
+++ b/app/views/assessments/_gradesheet.html.erb
@@ -21,7 +21,7 @@
 
     /* table data */
     // header classes
-    hclasses = ["enumerator", "id", "lec", "sec", 
+    hclasses = ["enumerator", "id", "lec", "sec",
                 <% for i in 0..(@assessment.problems.length - 1) do%>
                   "problem",
                 <% end %>
@@ -60,7 +60,7 @@
               <% if @assessment.version_penalty? %>
                 "version_penalty": "<%= computed_score(history_url s.course_user_datum) { s.version_penalty @cud } %>",
               <% end %>
-                "tweak": `<%= link_to raw(tweak(s.tweak)), 
+                "tweak": `<%= link_to raw(tweak(s.tweak)),
                   edit_course_assessment_submission_path(@course, @assessment, s),
                   tabindex: -1 %>`,
             <% end %>
@@ -113,7 +113,7 @@
       { title: "Sec", className: "sec", data: "sec" },
       <% @assessment.problems.each_with_index do |p,i| %>
         { title: `<%= p.name %>
-            <span class="max_score">(<%= p.max_score %>)</span>`, 
+            <span class="max_score">(<%= p.max_score %>)</span>`,
           className: "problem",
           data: "problem<%= i %>",
           render: function(data, type, full, meta) {
@@ -220,13 +220,15 @@
             <textarea class="feedback">loading...</textarea>
           </div>
           <div>
-            <b>Released</b>
-              <input class="released" type="checkbox"></input>
-              <span class="save_box">
-                  <span class="saving">Saving...</span>
-                  <span class="save waves-effect waves-light btn small primary" tabindex="1">Save</span>
-                  <span class="error" tabindex="1">Try again?</span>
-              </span>
+            <span class="left">
+              <b>Released</b>
+              <input class="released" type="checkbox" />
+            </span>
+            <span class="save_box">
+              <span class="saving">Saving...</span>
+              <span class="save waves-effect waves-light btn small primary" tabindex="1">Save</span>
+              <span class="error" tabindex="1">Try again?</span>
+            </span>
           </div>
       </div>
   </div>


### PR DESCRIPTION
Fixes invisible checkbox when choosing whether or not to release a grade. This issues was caused by how materiel styles check boxes. A check box MUST have a label associated in order to appear (in materialize), however this checkbox had no label and was invisible.