### PR TITLE
Fix Moss Exit Status

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -419,7 +419,7 @@ file, most likely a duplicate email.  The exact error was: #{e} "
     `~/Autolab/script/cleanMoss #{tmp_dir}`
 		# Now run the Moss command
     @mossCmdString = @mossCmd.join(" ")
-    @mossExit = $CHILD_STATUS
+    @mossExit = $?.exitstatus
     @mossOutput = `#{@mossCmdString} 2>&1`
 
     # Clean up after ourselves (droh: leave for dsebugging)


### PR DESCRIPTION
Not a major issue, but runMoss page always says "failed" even when moss ran successfully. Apparently we were using the variable $CHILD_STATUS, which returns nil (not 0), for checking child exit status. The correct way to do it is $?.exitstatus.