### PR TITLE
set z-index for annotation forms

### DIFF
--- a/app/assets/stylesheets/annotations.css
+++ b/app/assets/stylesheets/annotations.css
@@ -146,6 +146,7 @@ pre code {
   padding: 6px;
   background-color: #fff;
   margin-top: 6px;
+  z-index: 5;
 }
 
 .annotation-edit-form {


### PR DESCRIPTION
Fixes #812.

The z-index of annotation forms were not set, causing them to be behind the next page.
(This was not introduced by 2.0 though. Tested with an earlier version and the same problem occurred.)

![pdf_annotations_box_zindex](https://cloud.githubusercontent.com/assets/3676913/24228393/47cf5ac4-0f4a-11e7-9130-9c0a17194d94.png)
