### PR TITLE
Move moss status fetching to after moss command

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -419,8 +419,8 @@ file, most likely a duplicate email.  The exact error was: #{e} "
     `~/Autolab/script/cleanMoss #{tmp_dir}`
 		# Now run the Moss command
     @mossCmdString = @mossCmd.join(" ")
-    @mossExit = $?.exitstatus
     @mossOutput = `#{@mossCmdString} 2>&1`
+    @mossExit = $?.exitstatus
 
     # Clean up after ourselves (droh: leave for dsebugging)
     `rm -rf #{tmp_dir}`


### PR DESCRIPTION
fix for #816.

The command that gets the exit status used to be before the command that actually runs moss, which meant it was getting the exit status of the previous child.