### PR TITLE
Fix student search bar

### DIFF
--- a/app/views/submissions/new.html.erb
+++ b/app/views/submissions/new.html.erb
@@ -22,6 +22,34 @@
 		}
 
   </script>
+
+  <script type="application/javascript">
+    jQuery(function() {
+      /* match user name/email with cud_id */
+      userData = {
+        <% @cuds.each do |k,v| %>
+          "<%= k %>": "<%= v %>",
+        <% end %>
+      };
+
+      /* user autocomplete */
+      $studentAutocompleteField = $('#student_autocomplete');
+      $hiddenCUDField = $('#extension_course_user_datum_id');
+      $studentAutocompleteField.autocomplete({
+        data: {
+          <% @cuds.each do |k,v| %>
+            "<%= k %>": null,
+          <% end %>
+        }
+      });
+
+      /* track changes in student autocomplete field */
+      $studentAutocompleteField.on('change', function() {
+        $hiddenCUDField.val(userData[$studentAutocompleteField.val()]);
+      })
+    });
+  </script>
+
 <% end %>
 
 <h2>Create Submission for <%= link_to @assessment.display_name, [@course, @assessment] %> </h2>
@@ -47,7 +75,13 @@
   <th>User:</th>
   <td>
   <% if params[:course_user_datum_id].nil? then %>
-    <%= f.select(:course_user_datum_id, @cuds, {prompt: 'select user'}, {class: ''}) %>
+
+    <div class="input-field">
+      <input type="text" size="3" id="student_autocomplete" class="autocomplete" />
+      <label for="student_autocomplete">Start typing student name or email</label>
+    </div><br>
+    <%= f.hidden_field(:course_user_datum_id)%>
+
   <% else %>
     <%= @cuds.collect { |u| u.email }.join(", ") %>
     <input type='hidden' name='submission[course_user_datum_id]' value='<%=@cuds.collect{ |u| u.id }.join(',')%>' />

--- a/app/views/submissions/new.html.erb
+++ b/app/views/submissions/new.html.erb
@@ -6,26 +6,6 @@
   <%= javascript_include_tag 'chosen.jquery.min' %>
   <script type="application/javascript">
     jQuery(function() {
-      $('.chosen-select').chosen();
-		});
-
-		function filterNames(name) {
-			$(".select-wrapper").each( function() {
-				var user = this;
-				var keywords = name.split(" ");
-				var toShow = true;
-				for (var i = 0; i < keywords.length; i++) {
-					toShow = false;
-				}
-				$(this).toggle(toShow);
-			});
-		}
-
-  </script>
-
-  <script type="application/javascript">
-    jQuery(function() {
-      /* match user name/email with cud_id */
       userData = {
         <% @cuds.each do |k,v| %>
           "<%= k %>": "<%= v %>",
@@ -49,7 +29,6 @@
       })
     });
   </script>
-
 <% end %>
 
 <h2>Create Submission for <%= link_to @assessment.display_name, [@course, @assessment] %> </h2>
@@ -76,11 +55,11 @@
   <td>
   <% if params[:course_user_datum_id].nil? then %>
 
-    <div class="input-field">
-      <input type="text" size="3" id="student_autocomplete" class="autocomplete" />
-      <label for="student_autocomplete">Start typing student name or email</label>
-    </div><br>
-    <%= f.hidden_field(:course_user_datum_id)%>
+  <div class="input-field">
+    <input type="text" size="3" id="student_autocomplete" class="autocomplete" autocomplete="off"/>
+    <label for="student_autocomplete">Start typing student name or email</label>
+  </div><br>
+  <%= f.hidden_field(:course_user_datum_id)%>
 
   <% else %>
     <%= @cuds.collect { |u| u.email }.join(", ") %>


### PR DESCRIPTION
As per issue #821, the student search bar on the "Create Submission" page searches by first name, but sorts the list by andrewid. This fix replaces that choosing method with a search bar that searches students by either andrewid or first name.