### PR TITLE
Form fixes

### DIFF
--- a/app/assets/stylesheets/style.css.scss
+++ b/app/assets/stylesheets/style.css.scss
@@ -184,6 +184,10 @@ input[type=text], input[type=email]{
   margin-top: 2vh;
 }
 
+.btn-primary{
+  margin-top:3vh;
+}
+
 
 /* Further Styling */
 
@@ -805,7 +809,7 @@ textarea {
 	}
 
   label.active {
-    font-size: 18px;
+    font-size: 20px;
   }
 }
 

--- a/app/assets/stylesheets/style.css.scss
+++ b/app/assets/stylesheets/style.css.scss
@@ -144,8 +144,12 @@ div.main-header img {
 }
 
 /* Custom Form Styling */
+form#edit_editCourse {
+  margin-top: 80px;
+}
+
 .input-field{
-  padding-bottom: 4vh !important;
+  padding-bottom: 3vh !important;
 }
 
 .input-field label{
@@ -162,6 +166,11 @@ input:not([type]):disabled, input[type=text]:disabled, input[type=password]:disa
   color: #666;
 }
 
+input[type=text], input[type=email]{
+  color: black;
+  font-weight: 400;
+}
+
 .tabs{
   overflow-x: hidden;
 }
@@ -171,7 +180,8 @@ input:not([type]):disabled, input[type=text]:disabled, input[type=password]:disa
 }
 
 .checkbox-input{
-  margin-bottom: 5vh;
+  // margin-bottom: 5vh;
+  margin-top: 2vh;
 }
 
 
@@ -399,7 +409,7 @@ div#footer .right {
 div#footer a {
   display: inline-block;
   padding: 12px;
-  color: $autolab-highlight-gray;
+  color: #666;
 }
 
 div#footer div.fb-like.fb_iframe_widget {
@@ -725,9 +735,9 @@ body.autolab {
   }
 }
 
-input[type="text"],
-input[type="email"],
-input[type="password"], {
+input[type=text],
+input[type=email],
+input[type=password], {
   /*border: none;*/
   height: auto;
 	margin-top: 0.8rem;
@@ -737,19 +747,19 @@ input[type="password"], {
 	box-shadow: 0 1px 0 0 #CCC;
 }
 
-input[type="text"]:focus,
-input[type="email"]:focus,
-input[type="password"]:focus {
+input[type=text]:focus,
+input[type=email]:focus,
+input[type=password]:focus {
   /*border: 1px solid rgba(133, 0, 0, 1);*/
   outline: none;
 }
 
-input[type="checkbox"] {
+input[type=checkbox] {
   // For spacing between this and an adjacent label
   margin-right: 10px;
 }
 
-input[type="search"] {
+input[type=search] {
 	border-bottom: 1px #CCC;
 	box-shadow: 0 1px 0 0 #CCC;
 }
@@ -795,17 +805,17 @@ textarea {
 	}
 
   label.active {
-    font-size: inherit;
+    font-size: 18px;
   }
 }
 
-input[type=text] {
+input[type=text], input[type=email] {
 	box-sizing: border-box;
 	margin-bottom: 10px;
 }
 
 .help-block {
-  color: #4e4e4e;
+  color: black;
   font-size: 15px;
   margin-left: 8px;
   margin-top: 2px;

--- a/app/assets/stylesheets/style.css.scss
+++ b/app/assets/stylesheets/style.css.scss
@@ -185,7 +185,7 @@ input[type=text], input[type=email]{
 }
 
 .btn-primary{
-  margin-top:3vh;
+  //margin-top:3vh;
 }
 
 

--- a/app/form_builders/form_builder_with_date_time_input.rb
+++ b/app/form_builders/form_builder_with_date_time_input.rb
@@ -4,7 +4,7 @@
 # custom datetimepicker. In reality, it's goal is to wrap common form builder
 # methods in Bootstrap boilerplate code.
 class FormBuilderWithDateTimeInput < ActionView::Helpers::FormBuilder
-  %w(text_field text_area).each do |method_name|
+  %w(text_field text_area email_field).each do |method_name|
     # retain access to default textfield, etc. helpers
     alias_method "vanilla_#{method_name}", method_name
 

--- a/app/views/assessments/new.html.erb
+++ b/app/views/assessments/new.html.erb
@@ -19,11 +19,10 @@
 
   <div class="col l6">
     <%= f.text_field :display_name,
-      help_text: "Name that will be displayed on the course home page. E.g.,
-      'Malloc Lab'" %>
+      help_text: "Name that will be displayed on the course home page.", placeholder: "Malloc Lab" %>
 
 
-    <div class="form-group">
+    <div class="input-field">
       <%= f.label :category_name, { :class=>"control-label" } %>
       <%= f.collection_select :category_name, @course.assessment_categories, :to_s, :to_s, {selected: @assessment.category_name}  %>
       <p>or</p>

--- a/app/views/course_user_data/_fields.html.erb
+++ b/app/views/course_user_data/_fields.html.erb
@@ -1,0 +1,42 @@
+<%= f.fields_for :user, cud.user do |u| %>
+    <%= u.email_field :email, disabled: true, placeholder: "johndoe@example.com" %>
+
+    <%= u.text_field :first_name, disabled: true, placeholder: "John" %>
+    <%= u.text_field :last_name, disabled: true, placeholder: "Doe" %>
+
+  <% end %>
+
+  <%= f.text_field :nickname, help_text: "Anonymizing nickname to display on the public scoreboards", placeholder: "batman" %>
+
+  <%= isDisabled = false
+      if !@cud.instructor? then
+        isDisabled = true
+      end
+        f.text_field :lecture, help_text: "The lecture number", placeholder: "15213", disabled: isDisabled %>
+
+  <%= isDisabled = false
+      if !@cud.instructor? then
+        isDisabled = true
+      end
+        f.text_field :section, help_text: "A course assistant can see the gradebook and bulk-release grades for their assigned lecture and section.", placeholder: "A", disabled: isDisabled %>
+
+  <% if @cud.instructor? then %>
+
+  <tr>
+    <th>Course average tweak:</th>
+    <td>
+    <%= f.fields_for :tweak, cud.tweak do |t| %>
+      <%= t.text_field :value, size: 18, value: "0", placeholder: "0"%>
+      <%= t.select :kind, options_for_select({"points" => "points", "%" => "percent"}, :selected => (cud.tweak ? cud.tweak.kind : "points")) %>
+    <% end %>
+    </td>
+    <td class="smallText">A tweak is a positive or negative value that adjusts the student's course average.<br>Ex: A tweak of 5 points would increase the student's course average by 5 points. </td>
+  </tr>
+
+	<%= f.check_box :dropped, help_text: "Dropping a student from a course prevents them from handing in submissions or downloading assessments. Additionally they do not appear in any gradebook. None of their account information or submissions are deleted." %>
+  
+  <%= f.check_box :instructor, help_text: "Instructors have full read/write access to the course." %>
+
+  <%= f.check_box :course_assistant, help_text: "Course assistants can assign scores to problems and nothing else." %>
+
+  <% end %>

--- a/app/views/course_user_data/edit.html.erb
+++ b/app/views/course_user_data/edit.html.erb
@@ -1,4 +1,4 @@
-<% @title = "Editing Account Details for " + @editCUD.user.email %>
+<% @title = "Editing Enrollment for " + @editCUD.user.full_name %>
 
 <% content_for :javascripts do %>
   <script type="application/javascript">
@@ -32,9 +32,10 @@
   </script>
 <% end %>
 
-<h2>Editing <%= @editCUD.user.email %>'s Enrollment in <%= @course.display_name %></h2>
+<br>
+<h2>Editing <%= @editCUD.user.full_name %>'s Enrollment in <%= @course.display_name %></h2>
 
-<%= form_for @editCUD, url: course_course_user_datum_path(@course, @editCUD) do |f| %>
+<%= form_for @editCUD, url: course_course_user_datum_path(@course, @editCUD), builder: FormBuilderWithDateTimeInput do |f| %>
 <% if @editCUD.errors.any? %>
 	<div id="error_explanation">
 		<h2><%= pluralize(@editCUD.errors.count, "error") %>
@@ -48,56 +49,9 @@
 	</div>
 <% end %>
 
-  <table width=70% class="verticalTable" >
+  <br><br>
+  <%= render partial: "fields", locals: {f: f, cud: @editCUD} %>
 
-  <%= f.fields_for :user, @editCUD.user do |u| %>
-    <tr><th>First name: </th><td><%= u.text_field :first_name %></td></tr>
-    <tr><th>Last name: </th><td><%= u.text_field :last_name %></td></tr>
-  	<tr><th>Email: </th><td><%= u.text_field :email %></td></tr>
-  <% end %>
-
-  <tr><th>Nickname: </th><td><%= f.text_field :nickname %></td>
-  <td class="smallText">Anonymizing nickname to display on the public scoreboards</td> </tr>
-
-  <tr><th>School</th><td><%= @editCUD.user.school or "N/A" %></td>
-  <td class="smallText">Ex: SCS/CIT</td></tr>
-
-  <tr><th>Major</th><td><%= @editCUD.user.major or "N/A"%></td>
-  <td class="smallText">Ex: CS/ECE</td></tr>
-
-  <tr><th>Year</th><td><%= @editCUD.user.year or "N/A" %></td>
-  <td class="smallText">Ex: 3</td></tr>
-
-  <tr><th>Lecture</th><td><%= if @cud.instructor? then f.text_field :lecture else @editCUD.lecture end %></td>
-  <td class="smallText">Ex: 15213/18213</td></tr>
-
-  <tr><th>Section</th><td><%= if (@cud.instructor?) or (@editCUD.course.name == "15213-s11") then f.text_field :section else @editCUD.section end%></td>
-  <td class="smallText">Ex: C<% if @cud.instructor? %>. A course assistant can see the gradebook and bulk-release grades for their assigned <em>lecture and section</em>.<% end %></td></tr>
-
-  <% if @cud.instructor? then %>
-
-  <tr>
-    <th>Course average tweak:</th>
-    <td>
-    <%= f.fields_for :tweak, @editCUD.tweak do |t| %>
-      <%= t.text_field :value, :size => 18 %>
-      <%= t.select :kind, options_for_select({"points" => "points", "%" => "percent"}, :selected => (@editCUD.tweak ? @editCUD.tweak.kind : "points")) %>
-    <% end %>
-    </td>
-    <td class="smallText">A tweak is a positive or negative value that adjusts the student's course average.<br>Ex: A tweak of 5 points would increase the student's course average by 5 points. </td>
-  </tr>
-
-	<tr><th>Dropped?</th><td><%= f.check_box :dropped %><label for="course_user_datum_dropped"></label></td>
-  <td class="smallText">Dropping a student from a course prevents them from handing in submissions or downloading assessments. Additionally they do not appear in any gradebook. None of their account information or submissions are deleted.</td></tr>
-
-  <tr><th>Instructor?</th><td><%= f.check_box :instructor %><label for="course_user_datum_instructor"></label></td>
-  <td class="smallText">Instructors have full read/write access to the course. </td></tr>
-
-  <tr><th>Course assistant?</th><td><%= f.check_box :course_assistant %><label for="course_user_datum_course_assistant"></label></td>
-  <td class="smallText">Course assistants can assign scores to problems and nothing else.</td></tr>
-  <% end %>
-
-  </table>
   <br>
   <br>
   <input id="user_submit" name="commit" type="submit" class="btn primary" value="Save Changes" onclick="formvalidation(this.parentNode); return false;">

--- a/app/views/course_user_data/edit.html.erb
+++ b/app/views/course_user_data/edit.html.erb
@@ -32,6 +32,8 @@
   </script>
 <% end %>
 
+<h2>Editing <%= @editCUD.user.email %>'s Enrollment in <%= @course.display_name %></h2>
+
 <%= form_for @editCUD, url: course_course_user_datum_path(@course, @editCUD) do |f| %>
 <% if @editCUD.errors.any? %>
 	<div id="error_explanation">
@@ -47,7 +49,6 @@
 <% end %>
 
   <table width=70% class="verticalTable" >
-  <tr><th>Course</th><td><%= @editCUD.course.display_name %></td></tr>
 
   <%= f.fields_for :user, @editCUD.user do |u| %>
     <tr><th>First name: </th><td><%= u.text_field :first_name %></td></tr>
@@ -82,7 +83,7 @@
       <%= t.text_field :value, :size => 18 %>
       <%= t.select :kind, options_for_select({"points" => "points", "%" => "percent"}, :selected => (@editCUD.tweak ? @editCUD.tweak.kind : "points")) %>
     <% end %>
-    </td>btn primary handin-btn
+    </td>
     <td class="smallText">A tweak is a positive or negative value that adjusts the student's course average.<br>Ex: A tweak of 5 points would increase the student's course average by 5 points. </td>
   </tr>
 

--- a/app/views/course_user_data/new.html.erb
+++ b/app/views/course_user_data/new.html.erb
@@ -50,48 +50,7 @@
 	</div>
 <% end %>
 
-  <%= f.fields_for :user, @newCUD.user do |u| %>
-    <%= u.email_field :email, help_text: "User's email address. Fill this out first - autopopulates other fields.", placeholder: "johndoe@example.com" %>
-
-    <%= u.text_field :first_name, placeholder: "John" %>
-    <%= u.text_field :last_name, placeholder: "Doe" %>
-
-  <% end %>
-
-  <%= f.text_field :nickname, help_text: "Anonymizing nickname to display on the public scoreboards", placeholder: "batman" %>
-
-  <%= isDisabled = false
-      if !@cud.instructor? then
-        isDisabled = true
-      end
-        f.text_field :lecture, help_text: "The lecture number", placeholder: "15213", disabled: isDisabled %>
-
-  <%= isDisabled = false
-      if !@cud.instructor? then
-        isDisabled = true
-      end
-        f.text_field :lecture, help_text: "A course assistant can see the gradebook and bulk-release grades for their assigned lecture and section.", placeholder: "C", disabled: isDisabled %>
-
-  <% if @cud.instructor? then %>
-
-  <tr>
-    <th>Course average tweak:</th>
-    <td>
-    <%= f.fields_for :tweak, @newCUD.tweak do |t| %>
-      <%= t.text_field :value, size: 18, value: "0"%>
-      <%= t.select :kind, options_for_select({"points" => "points", "%" => "percent"}, :selected => (@newCUD.tweak ? @newCUD.tweak.kind : "points")) %>
-    <% end %>
-    </td>
-    <td class="smallText">A tweak is a positive or negative value that adjusts the student's course average.<br>Ex: A tweak of 5 points would increase the student's course average by 5 points. </td>
-  </tr>
-
-	<%= f.check_box :dropped, help_text: "Dropping a student from a course prevents them from handing in submissions or downloading assessments. Additionally they do not appear in any gradebook. None of their account information or submissions are deleted." %>
-  
-  <%= f.check_box :instructor, help_text: "Instructors have full read/write access to the course." %>
-
-  <%= f.check_box :course_assistant, help_text: "Course assistants can assign scores to problems and nothing else." %>
-
-  <% end %>
+  <%= render partial: "fields", locals: {f: f, cud: @newCUD} %>
 
   <br>
   <input id="user_submit" class="btn primary"name="commit" type="submit" value="Save Changes" onclick="formvalidation(this.parentNode); return false;">

--- a/app/views/course_user_data/new.html.erb
+++ b/app/views/course_user_data/new.html.erb
@@ -1,7 +1,7 @@
 <% content_for :javascripts do %>
   <script type="application/javascript">
-    $("#user-lookup").on('click', userLookup);
-    $("#course_user_datum_user_attributes_email").on('blur', userLookup)
+    $("#course_user_datum_user_attributes_email").on('change', userLookup);
+    $("#course_user_datum_user_attributes_email").on('input', userLookup);
     /**
      * this AJAX function does an LDAP lookup on the partially-entered user email.
      **/
@@ -12,7 +12,7 @@
         if (!data)  {
           $('#course_user_datum_user_attributes_first_name').prop('disabled', false);
           $('#course_user_datum_user_attributes_last_name').prop('disabled', false);
-          $('#course_user_datum_user_attributes_first_name').focus();
+          // $('#course_user_datum_user_attributes_first_name').focus();
           $('#course_user_datum_user_attributes_first_name').val("");
             $('#course_user_datum_user_attributes_last_name').val("");
           return;
@@ -22,16 +22,20 @@
           $('#course_user_datum_user_attributes_first_name').prop('disabled', true);
           $('#course_user_datum_user_attributes_last_name').val(data.last_name);
           $('#course_user_datum_user_attributes_last_name').prop('disabled', true);
-          $('#course_user_datum_nickname').focus();
+          // $('#course_user_datum_nickname').focus();
         }
       });
     }
   </script>
 <% end %>
 
-<h2>Add New User to Course</h2>
-<div class=redText> * Indicates a required field</div>
-<%= form_for @newCUD, url: course_course_user_data_path do |f| %>
+<% @title="Enroll User" %>
+
+<h2>Enroll User in <%= @course.display_name %></h2>
+
+<br>
+
+<%= form_for @newCUD, url: course_course_user_data_path, builder: FormBuilderWithDateTimeInput do |f| %>
 
 <% if @newCUD.errors.any? %>
 	<div id="error_explanation">
@@ -46,29 +50,27 @@
 	</div>
 <% end %>
 
-  <table width=70% class="verticalTable" >
-  <tr><th>Course</th><td><%= @course.display_name %></td></tr>
-
   <%= f.fields_for :user, @newCUD.user do |u| %>
-    <tr><th>User Email: <a class=redText>*</a></th><td><%= u.email_field :email %></td>
-  		<td><a id="user-lookup">User Lookup</a>
-      <i class='smallText'> <b>(Enter email, then click this link to fill in user info from records)</b></i></td></tr>
+    <%= u.email_field :email, help_text: "User's email address. Fill this out first - autopopulates other fields.", placeholder: "johndoe@example.com" %>
 
-    <tr><th>First Name <a class=redText>*</a></th><td><%= u.text_field :first_name %></td>
-    <td class="smallText"></td></tr>
-    <tr><th>Last Name <a class=redText>*</a></th><td><%= u.text_field :last_name %></td>
-    <td class="smallText"></td></tr>
+    <%= u.text_field :first_name, placeholder: "John" %>
+    <%= u.text_field :last_name, placeholder: "Doe" %>
 
   <% end %>
 
-  <tr><th>Nickname: </th><td><%= f.text_field :nickname %></td>
-  <td class="smallText">Anonymizing nickname to display on the public scoreboards</td> </tr>
+  <%= f.text_field :nickname, help_text: "Anonymizing nickname to display on the public scoreboards", placeholder: "batman" %>
 
-  <tr><th>Lecture</th><td><%= if @cud.instructor? then f.text_field :lecture else @newCUD.lecture end %></td>
-  <td class="smallText">Ex: 15213/18213</td></tr>
+  <%= isDisabled = false
+      if !@cud.instructor? then
+        isDisabled = true
+      end
+        f.text_field :lecture, help_text: "The lecture number", placeholder: "15213", disabled: isDisabled %>
 
-  <tr><th>Section</th><td><%= if (@cud.instructor?) or (@newCUD.course.name == "15213-s11") then f.text_field :section else @newCUD.section end%></td>
-  <td class="smallText">Ex: C<% if @cud.instructor? %>. A course assistant can see the gradebook and bulk-release grades for their assigned <em>lecture and section</em>.<% end %></td></tr>
+  <%= isDisabled = false
+      if !@cud.instructor? then
+        isDisabled = true
+      end
+        f.text_field :lecture, help_text: "A course assistant can see the gradebook and bulk-release grades for their assigned lecture and section.", placeholder: "C", disabled: isDisabled %>
 
   <% if @cud.instructor? then %>
 
@@ -76,25 +78,21 @@
     <th>Course average tweak:</th>
     <td>
     <%= f.fields_for :tweak, @newCUD.tweak do |t| %>
-      <%= t.text_field :value, :size => 18, :value => "0" %>
+      <%= t.text_field :value, size: 18, value: "0"%>
       <%= t.select :kind, options_for_select({"points" => "points", "%" => "percent"}, :selected => (@newCUD.tweak ? @newCUD.tweak.kind : "points")) %>
     <% end %>
     </td>
     <td class="smallText">A tweak is a positive or negative value that adjusts the student's course average.<br>Ex: A tweak of 5 points would increase the student's course average by 5 points. </td>
   </tr>
 
-	<tr><th>Dropped?</th><td><%= f.check_box :dropped %><label for="course_user_datum_dropped"></label></td>
-  <td class="smallText">Dropping a student from a course prevents them from handing in submissions or downloading assessments. Additionally they do not appear in any gradebook. None of their account information or submissions are deleted.</td></tr>
+	<%= f.check_box :dropped, help_text: "Dropping a student from a course prevents them from handing in submissions or downloading assessments. Additionally they do not appear in any gradebook. None of their account information or submissions are deleted." %>
+  
+  <%= f.check_box :instructor, help_text: "Instructors have full read/write access to the course." %>
 
-  <tr><th>Instructor?</th><td><%= f.check_box :instructor %><label for="course_user_datum_instructor"></label></td>
-  <td class="smallText">Instructors have full read/write access to the course. </td></tr>
+  <%= f.check_box :course_assistant, help_text: "Course assistants can assign scores to problems and nothing else." %>
 
-  <tr><th>Course assistant?</th><td><%= f.check_box :course_assistant %><label for="course_user_datum_course_assistant"></label></td>
-  <td class="smallText">Course assistants can assign scores to problems and nothing else.</td></tr>
   <% end %>
 
-
-  </table>
   <br>
   <input id="user_submit" class="btn primary"name="commit" type="submit" value="Save Changes" onclick="formvalidation(this.parentNode); return false;">
 

--- a/app/views/courses/edit.html.erb
+++ b/app/views/courses/edit.html.erb
@@ -20,7 +20,7 @@
 
 
 	<div class="row">
-		<div class="col l6">
+		<div class="">
 	    	<%= render :partial=>"courseFields", :locals=>{:f=>f, :course=>@course} %>
 	  	</div>
 	</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -41,7 +41,7 @@
     <%= javascript_include_tag 'application' %>
 
     <!-- Flatpickr Datetimepicker JS (lightweight file) -->
-    <%= javascript_include_tag "https://unpkg.com/flatpickr@2.5.8" %>
+    <%= javascript_include_tag "https://unpkg.com/flatpickr" %>
 
     <div class="page-wrapper">
       <%= render "layouts/navbar" %>

--- a/app/views/users/_fields.html.erb
+++ b/app/views/users/_fields.html.erb
@@ -1,0 +1,9 @@
+<%= f.email_field :email, disabled: true, placeholder: "johndoe@example.com" %>
+	
+<%= f.text_field :first_name, placeholder: "John" %>
+
+<%= f.text_field :last_name, placeholder: "Doe" %>
+
+<%= f.text_field :school, placeholder: "School of Computer Science" %>
+
+<%= f.text_field :major, placeholder: "Computer Science" %>

--- a/app/views/users/_fields.html.erb
+++ b/app/views/users/_fields.html.erb
@@ -7,3 +7,7 @@
 <%= f.text_field :school, placeholder: "School of Computer Science" %>
 
 <%= f.text_field :major, placeholder: "Computer Science" %>
+
+<% if current_user.administrator? then %>
+	<%= f.check_box :administrator, help_text: "Administrators have total access to change anything in the system." %>
+<% end %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -19,10 +19,6 @@
 	<br>
 
   <%= render partial: "fields", locals: {f: f} %>
-
-  <% if current_user.administrator? then %>
-		<%= f.check_box :administrator, help_text: "Administrators have total access to change anything in the system." %>
-  <% end %>
   
 
   <%= f.submit 'Save Changes', { :class=>"btn primary"} %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,5 +1,7 @@
+<br><br>
+
 <h2>Editing Account Details for <%= @user.email %></h2>
-<%= form_for @user, url: user_path(@user) do |f| %>
+<%= form_for @user, url: user_path(@user), builder: FormBuilderWithDateTimeInput do |f| %>
 
 <% if @user.errors.any? %>
 	<div id="error_explanation">
@@ -14,25 +16,20 @@
 	</div>
 <% end %>
 
-<table width=70% class="verticalTable" >
-  <tr><th>Email</th><td><%= f.email_field :email, readonly: true %></td></tr>
-	
-  <tr><th>First name: </th><td><%= f.text_field :first_name %></td></tr>
+	<br>
 
-  <tr><th>Last name: </th><td><%= f.text_field :last_name %></td></tr>
+  <%= render partial: "fields", locals: {f: f} %>
 
   <% if current_user.administrator? then %>
-		<tr><th>Administrator?</th><td><%= f.check_box :administrator %><label for="user_administrator"></label>
-			    </p></td></tr>
+		<%= f.check_box :administrator, help_text: "Administrators have total access to change anything in the system." %>
   <% end %>
   
-</table>
 
   <%= f.submit 'Save Changes', { :class=>"btn primary"} %>
 <% end %>
 
 <% if current_user.administrator? %>
-<hr>
+<br> <br><hr><br>
 <h3> Admin Only</h3>
   <%= link_to raw('<span class="btn">Delete User</span>'), user_path(@user), method: :delete, confirm: "Are you sure!?" %>
 <% end %> 


### PR DESCRIPTION
Fixed a number of forms - Addressing issue #858 

Main changes are:
1. Making text bigger, bolder, and darker
2. Fixing spacing (in css and with <br> tags)
3. Refactored forms to use a _fields.html.erb
4. Changed form breadcrumbs to be more readable
5. Changed form titles to be more readable


To check this - go to the forms addressed in #858 and any others in the system. Key things are - functionality should be the same(except on edit course_user_data page) and the new forms are more readable.