### PR TITLE
Fix Datepicker Initializing Bug

### DIFF
--- a/app/assets/javascripts/initialize_datetimepickers.js
+++ b/app/assets/javascripts/initialize_datetimepickers.js
@@ -21,8 +21,8 @@
 
     for (var i = 0; i < dateElts.length; i++) {
       var defaultDate = new Date(moment())
-      if ($(datetimeElts[i]).val()) {
-        defaultDate = new Date(moment($(datetimeElts[i]).val()).format("MMMM D YYYY"))
+      if ($(dateElts[i]).val()) {
+        defaultDate = new Date(moment($(dateElts[i]).val()).format("MMMM D YYYY"))
       }
 
       $(dateElts[i]).flatpickr({


### PR DESCRIPTION
The datepicker loop was referencing the datetimepicker elements, causing date-only pickers to not display correctly.