### PR TITLE
Bind new submission CUD to correct field

### DIFF
--- a/app/views/submissions/new.html.erb
+++ b/app/views/submissions/new.html.erb
@@ -14,7 +14,7 @@
 
       /* user autocomplete */
       $studentAutocompleteField = $('#student_autocomplete');
-      $hiddenCUDField = $('#extension_course_user_datum_id');
+      $hiddenCUDField = $('#submission_course_user_datum_id');
       $studentAutocompleteField.autocomplete({
         data: {
           <% @cuds.each do |k,v| %>


### PR DESCRIPTION
Bind the CUD id to the correct form element in Submissions#new, so it is
sent to the server on submit. Otherwise no CUD would be sent and no
submission could be created.