### PR TITLE
Fix initialization order of grading_deadline and end_at

### DIFF
--- a/app/controllers/assessments_controller.rb
+++ b/app/controllers/assessments_controller.rb
@@ -202,8 +202,8 @@ class AssessmentsController < ApplicationController
     @assessment.visible_at = Time.now
     @assessment.start_at = Time.now
     @assessment.due_at = Time.now
-    @assessment.grading_deadline = Time.now
     @assessment.end_at = Time.now
+    @assessment.grading_deadline = Time.now
     @assessment.quiz = false
     @assessment.quizData = ""
     @assessment.max_submissions = params.include?(:max_submissions) ? params[:max_submissions] : -1


### PR DESCRIPTION
Fixes #886.

When creating an assessment from scratch, `grading_deadline` and `end_at` are both set using Time.now, but `grading_deadline` is set earlier, causing the invariant that grading_deadline >= end_at to fail. Since there's no way for the user to manually set these dates during creation, a user is never able to create an assessment from scratch.
This fix reorders the commands so the invariant is preserved.