### PR TITLE
Allow empty score dictionaries.

### DIFF
--- a/app/controllers/assessment/autograde.rb
+++ b/app/controllers/assessment/autograde.rb
@@ -467,7 +467,6 @@ module AssessmentAutograde
       else
         scores = parseAutoresult(autoresult, true)
       end
-      fail "Empty autoresult string." if scores.keys.length == 0
 
       # Grab the autograde config info
       @autograde_prop = @assessment.autograder


### PR DESCRIPTION
The semantics of autoresults seem to be: for every problem key in the
scores dictionary, update the recorded problem score with the new value.
Consequently, problems that don't appear in the dictionary don't get
their recorded scores updated.

To be fully consistent with this semantics, it *should* be possible to
have an empty score dictionary, i.e., one of the form
    {"scores": {}},
that updates none of the recorded scores. This is useful, e.g., when
your autograder needs to abort due to an error and doesn't want to
update anything.