### PR TITLE
Fix setup script regarding database and school templates

### DIFF
--- a/bin/setup.sh
+++ b/bin/setup.sh
@@ -187,12 +187,12 @@ autolab_setup() {
     cp $AUTOLAB_PATH/config/database.yml.template $AUTOLAB_PATH/config/database.yml
     sed -i "s/<username>/$USER/g" $AUTOLAB_PATH/config/database.yml
 
+    cp $AUTOLAB_PATH/config/school.yml.template $AUTOLAB_PATH/config/school.yml
+
     cp $AUTOLAB_PATH/config/initializers/devise.rb.template $AUTOLAB_PATH/config/initializers/devise.rb
     sed -i "s/<YOUR-SECRET-KEY>/`bundle exec rake secret`/g" $AUTOLAB_PATH/config/initializers/devise.rb
 
     cp $AUTOLAB_PATH/config/autogradeConfig.rb.template $AUTOLAB_PATH/config/autogradeConfig.rb
-    
-    cp $AUTOLAB_PATH/config/school.yml.template $AUTOLAB_PATH/config/school.yml
 
     log "Granting MySQL database permissions..."
     mysql -uroot -p$MYSQL_ROOT_PSWD -e "GRANT ALL PRIVILEGES ON ""$USER""_autolab_development.* TO '$USER'@'%' IDENTIFIED BY '<password>'"

--- a/config/database.yml.template
+++ b/config/database.yml.template
@@ -1,19 +1,19 @@
 # MySQL Configuration
-#development:
-#  adapter: mysql2
-#  database: <username>_autolab_development
-#  pool: 5
-#  username: <username>
-#  password: '<password>'
-#  socket: /var/run/mysqld/mysqld.sock
-#  host: localhost
-
-SQLite Configuration
 development:
-  adapter: sqlite3
-  database: db/db.sqlite3
-  pool: 5
-  timeout: 5000
+ adapter: mysql2
+ database: <username>_autolab_development
+ pool: 5
+ username: <username>
+ password: '<password>'
+ socket: /var/run/mysqld/mysqld.sock
+ host: localhost
+
+# SQLite Configuration
+# development:
+#   adapter: sqlite3
+#   database: db/db.sqlite3
+#   pool: 5
+#   timeout: 5000
 
 test:
   adapter: mysql2


### PR DESCRIPTION
Apparently Autolab 2.0 reverted the 'revert from sqlite to mysql' change. The change also left a comment in database.yml.template uncommented, causing the setup to fail right now... This fix reverts everything back to mysql. 

In addition, the school.yml.template was not setup before it's needed, so this fix moves it up.