### PR TITLE
Account for DST for late days calculation

### DIFF
--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -523,8 +523,8 @@ private
     # check if no due at (due to infinite extension)
     return 0 unless aud.due_at
 
-    # how late is the submission?
-    late_by = created_at - aud.due_at
+    # how late is the submission? (account for DST by offsetting difference in utc_offset)
+    late_by = created_at - aud.due_at + (created_at.utc_offset - aud.due_at.utc_offset);
     return 0 if late_by <= 0
 
     # if you're 2.5 days late, you're 3 days late


### PR DESCRIPTION
Fixes #932.

When calculating the time difference between handin time and due time, add in the difference in timezone between these two. This will properly adjust when crossing DST borders. The resulting behavior is that the same time of day will be used as cutoffs, which is what people normally expect.

e.g. For 2017, DST ends at 2am on Nov. 5th. A HW due on Nov. 4th at 8pm will be only 1 day late at Nov. 5th 7:30pm. The student gains 1 additional hour due to DST. Similarly, when DST begins, students lose 1 hour.