### PR TITLE
Fix pdf annotation borderbox positioning

### DIFF
--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -221,12 +221,14 @@ class SubmissionsController < ApplicationController
 
           comment = "#{annotation.comment}\n\nProblem: #{problem_name}\nScore:#{value}"
 
+          # + 1 since pages are indexed 1-based
+          pdf.go_to_page(page + 1)
+
+          # draw box
           pdf.stroke_color "ff0000"
           pdf.stroke_rectangle [xCord, yCord], width, height
           pdf.fill_color "000000"
-
-          # + 1 since pages are indexed 1-based
-          pdf.go_to_page(page + 1)
+          # draw text
           pdf.fill_color "ff0000"
           pdf.text_box comment,
                       { :at => [xCord + 3, yCord - 3],


### PR DESCRIPTION
As I mentioned in #694, annotations on the downloaded pdf places the red borderbox on the page of the previous annotation, separating it from the text content that is in the right place.

This commit fixes the positioning of the borderbox.