### PR TITLE
Annotation Viewing Fixes

### DIFF
--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -195,7 +195,10 @@ class SubmissionsController < ApplicationController
       @problems = @assessment.problems.to_a
       @problems.sort! { |a, b| a.id <=> b.id }
 
-      @annotations = @submission.annotations.to_a
+      @annotations = []
+      if(!@assessment.before_grading_deadline? || @cud.instructor || @cud.course_assistant)
+        @annotations = @submission.annotations.to_a
+      end
 
       Prawn::Document.generate(@filename_annotated, :template => @filename) do |pdf|
 
@@ -322,6 +325,11 @@ class SubmissionsController < ApplicationController
     @problemSummaries = {}
     @problemGrades = {}
 
+
+    # Only show annotations if grades have been released or the user is an instructor
+    unless(!@assessment.before_grading_deadline? || @cud.instructor || @cud.course_assistant)
+      @annotations = []
+    end
 
     # extract information from annotations
     @annotations.each do |annotation|

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -195,6 +195,7 @@ class SubmissionsController < ApplicationController
       @problems = @assessment.problems.to_a
       @problems.sort! { |a, b| a.id <=> b.id }
 
+      # Only show annotations if grades have been released or the user is an instructor
       @annotations = []
       if(!@assessment.before_grading_deadline? || @cud.instructor || @cud.course_assistant)
         @annotations = @submission.annotations.to_a


### PR DESCRIPTION
Hides annotation (in pdfs and code) if the grading deadline hasn't passed and user is not an instructor. Also stops annotations from showing up in the downloaded pdf unless the above condition is met. Addresses #862.