### PR TITLE
Do not fail on receiving non-ascii from Tango

### DIFF
--- a/app/controllers/assessment/autograde.rb
+++ b/app/controllers/assessment/autograde.rb
@@ -454,7 +454,7 @@ module AssessmentAutograde
 
       feedback_file = File.join(ass_dir, @assessment.handin_directory, filename)
       COURSE_LOGGER.log("Looking for Feedbackfile:" + feedback_file)
-      File.open(feedback_file, "w") do |f|
+      File.open(feedback_file, "wb") do |f|
         f.write(feedback)
       end
     end


### PR DESCRIPTION
Currently, Autolab fails if it receives unicode (or any non-ascii characters) from Tango, e.g.

```
An Encoding::UndefinedConversionError occurred in assessments#autograde_done:

  "\xC3" from ASCII-8BIT to UTF-8
  app/controllers/assessment/autograde.rb:458:in `write'
```

This is easily fixed by opening the file for writing in binary mode. This way, data is saved exactly as received from Tango. I tested it with a feedback message encoded in UTF-8 and everything else works as expected.