### PR TITLE
Added the ability to toggle full screen mode when annotating submissions

### DIFF
--- a/app/assets/javascripts/fullscreenToggle.js
+++ b/app/assets/javascripts/fullscreenToggle.js
@@ -1,0 +1,23 @@
+toggleFullscreen () = {
+    var cont = document.getElementById("pageBody");
+    if(cont.classList.contains('container')){
+      cont.classList.remove('container');
+      cont.classList.add('container-fluid');
+      var annotationPane = document.getElementById("annotationPaneId");
+      annotationPage.classList.remove('col');
+      annotationPage.classList.remove('l3');
+      var codePane = document.getElementById("codePaneId");
+      codePane.classList.remove('col');
+      codePane.classList.remove('l9');
+    } else{
+      cont.classList.remove('container-fluid');
+      cont.classList.add('container');
+      var annotationPane = document.getElementById("annotationPaneId");
+      annotationPage.classList.add('col');
+      annotationPage.classList.add('l3');
+      var codePane = document.getElementById("codePaneId");
+      codePane.classList.add('col');
+      codePane.classList.add('l9');
+
+    }
+}

--- a/app/views/submissions/view.html.erb
+++ b/app/views/submissions/view.html.erb
@@ -43,7 +43,7 @@
 </h2>
 <hr>
 <div class="row">
-  <div class="annotationPane col l3">
+  <div class="annotationPane col l3" id="annotationPaneId">
     <h3 class="annotationHeader">Summary</h3>
     <% if @problemSummaries.empty? then %>
       <% if (@cud.instructor? or @cud.course_assistant?) then %>
@@ -75,8 +75,8 @@
     <input type="button" value="Reload Summary" class="btn primary" onclick="reloadSummary()">
 
   </div>
-  <div class="col l9">
-    <h3 id="filename"><%= @displayFilename %></h3><button class="btn collapse_expand" onclick="$('.minimize').click();">Collapse All</button> <button class="btn collapse_expand" onclick="$('.ann-box').click();">Expand All</button>
+  <div class="col l9" id ="codePaneId">
+    <h3 id="filename"><%= @displayFilename %></h3><button class="btn collapse_expand" onclick="$('.minimize').click();">Collapse All</button> <button class="btn collapse_expand" onclick="$('.ann-box').click();">Expand All</button> <button class="btn" onclick=toogleFullscreen()>Toggle Fullscreen</button>
     <div id="code-box">
     <% # these lines can't have white space due to the styling for pre and code tages %>
     <% # anything wrapped in a <pre><code> will be highlighted by highlightsjs %>


### PR DESCRIPTION
I'm a TA for 15213 at CMU. In the class I annotate the submissions in the grading pane. The bootstrap layout wastes a lot of useful space, which makes grading in split screen mode difficult (I would like to be able to open the grading rubric in one screen and the code in the other). Try to use the file annotation page in half screen mode on a 13 inch monitor and you will see the that the annotation page wastes a lot of useful space.

I often manually make the changes specified in the code to improve my grading experience and thought it would be helpful for other graders.

*Note* - I have not tested this commit. I have not set up a test version of Autolab and so I am not confident that it will work correctly. I mainly wanted to provide some starter code for the change that the project maintainers can easily adjust to implement the requested feature.

Also, I think I forgot to include the javascript file on the page.  Can you fix that when you review the commit? Thanks!