### PR TITLE
Really only display students' own jobs

### DIFF
--- a/app/controllers/jobs_controller.rb
+++ b/app/controllers/jobs_controller.rb
@@ -213,7 +213,7 @@ protected
     unless @cud.user.administrator?
       if !@cud.instructor?
         # Students can see only their own job names
-        job[:name] = "*" unless job[:name].ends_with? @cud.user.email
+        job[:name] = "*" unless job[:name].ends_with? "_#{@cud.user.email}"
       else
         # Instructors can see only their course's job names
         job[:name] = "*" if !rjob["notifyURL"] || !(job[:course].eql? @cud.course.id.to_s)


### PR DESCRIPTION
When deciding what jobs can be displayed to students, check the
whole email address part in the job name instead of treating
the email address as a suffix. Otherwise, students whose userid
is a right-anchored substring of another students userid will
see the latter student's jobs