### PR TITLE
Added Submission Time to grade export csv

### DIFF
--- a/app/helpers/assessment_helper.rb
+++ b/app/helpers/assessment_helper.rb
@@ -47,7 +47,7 @@ module AssessmentHelper
   def gradesheet_csv(asmt, as_seen_by)
     CSV.generate do |csv|
       # title row with the column names:
-      title = ["Email:"]
+      title = ["Submission Time:","Email:"]
       asmt.problems.each { |problem| title << "#{problem.name}:" }
       title << "Total:"
       csv << title
@@ -69,8 +69,10 @@ private
     aud = AssessmentUserDatum.get asmt.id, cud.id
     throw "csv_row_for: no AUD for (#{asmt.id}, #{cud.id})" unless aud
 
-    # create csv row with user email (first column)
-    row = [cud.user.email]
+    # create csv row with latest submission time and user email (first and second columns)
+    submission = aud.latest_submission
+    submission_time = submission.nil? ? nil : submission.created_at.in_time_zone.to_s
+    row = [submission_time, cud.user.email]
 
     grade_type = aud.grade_type
     submission_status = aud.submission_status


### PR DESCRIPTION
Summary:
Adds the submission time for each grade when you bulk export.

Test Plan:
Visited Assignment page and clicked 'Bulk Export Grades'
<img width="1440" alt="screen shot 2018-10-17 at 1 01 08 pm" src="https://user-images.githubusercontent.com/1356687/47103226-ce74c600-d20c-11e8-898a-3d89ee30f1fa.png">

Before:
<img width="517" alt="screen shot 2018-10-17 at 12 55 26 pm" src="https://user-images.githubusercontent.com/1356687/47103242-d7fe2e00-d20c-11e8-90c6-34398c100ca6.png">

After:
<img width="625" alt="screen shot 2018-10-17 at 12 55 44 pm" src="https://user-images.githubusercontent.com/1356687/47103250-dc2a4b80-d20c-11e8-88bb-5e5096523ca3.png">

In the case that user doesn't have a latest submission, leaves their submission time column blank:
<img width="565" alt="screen shot 2018-10-17 at 12 58 33 pm" src="https://user-images.githubusercontent.com/1356687/47103283-ecdac180-d20c-11e8-9f38-81bbf4dec9c9.png">


