### PR TITLE
Moss permissions

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -332,7 +332,9 @@ file, most likely a duplicate email.  The exact error was: #{e} "
 
   action_auth_level :moss, :instructor
   def moss
-    @courses = Course.all
+    @courses = Course.all.select{ |course|
+        @cud.user.administrator ||
+        course.course_user_data.joins(:user).find_by(users: { email: @cud.user.email }, instructor: true) != nil }
   end
 
   action_auth_level :runMoss, :instructor

--- a/app/views/courses/moss.html.erb
+++ b/app/views/courses/moss.html.erb
@@ -29,7 +29,7 @@
 <h2>Run the Moss Cheat Checker</h2>
 
 <h4>Step 1:</h4>
-<p>Click on course names to see their assessments, then check box all of the assessments you want Moss to compare against.</p>
+<p>Click on course names to see their assessments, then check box all of the assessments you want Moss to compare against. </br> If a course doesn't appear, ensure you are an instructor.</p>
 
 <h5 style="display:inline">Filter Courses (Keywords Separated by Space): </h5>
 <div class="input-field">


### PR DESCRIPTION
Addresses #1012 by limiting the courses users can see on the Moss screen to those that they are instructors in. Shows all courses if the user is an administrator.