### PR TITLE
Add bundle task to confirm email address

### DIFF
--- a/lib/tasks/admin.rake
+++ b/lib/tasks/admin.rake
@@ -12,4 +12,17 @@ namespace :admin do
 
     puts "Successfully promoted user with email #{args.email} to admin level."
   end
+  
+  desc "Confirm a user's email address manually"
+  task :confirm_email, [:email] => [:environment] do |t, args|
+    unless args.email
+      puts "Which email did you want to confirm?"
+      next
+    end
+    
+    u = User.where(email: args.email).first
+    u.confirm!
+    
+    puts "Successfully confirmed user with email #{args.email}"
+  end
 end


### PR DESCRIPTION
Hi! Love the project! I recently ran into an issue where I needed to add a user who could not receive our emails. I created a bundle task to manually confirm a user's email address. An administrator can now run `bundle exec admin:confirm_email foo@bar.edu` to confirm the email address. If this gets merged, I'd be happy to submit a PR to autolab/docs with documentation.

Thanks for all your work,
Ryan