### PR TITLE
Hotfix handin

### DIFF
--- a/app/views/assessments/_handin_form.html.erb
+++ b/app/views/assessments/_handin_form.html.erb
@@ -94,6 +94,7 @@
                 document.querySelector("#handin_show_assessment input[type='file']").addEventListener(
                   "change",
                   function (e) {
+                    console.log("files changed");
                     showFiles();
                   },
                   false
@@ -178,7 +179,7 @@
             <% end %>
             <div class="row handin-row">
               <div class="valign-wrapper drag-drop-handin" onclick="clickDrag();" ondrop="dropHandler(event);" ondragover="dragOverHandler(event);" ondragenter="dragEnter(event);" ondragexit="dragExit(event);">
-                <p class="center-align" style="color:grey;" onclick="clickDrag();" ondrop="dropHandler(event);" ondragover="dragOverHandler(event);" ondragenter="dragEnter(event);" ondragexit="dragExit(event);"><b>Drag a file here to hand in. Click to select a file.</b> <br /> <span style="font-size: 10px;">Files do not submit automatically.</span></p>
+                <p class="center-align" style="color:grey;" ondrop="dropHandler(event);" ondragover="dragOverHandler(event);" ondragenter="dragEnter(event);" ondragexit="dragExit(event);"><b>Drag a file here to hand in. Click to select a file.</b> <br /> <span style="font-size: 10px;">Files do not submit automatically.</span></p>
               </div>
             </div>
 

--- a/app/views/assessments/_handin_form.html.erb
+++ b/app/views/assessments/_handin_form.html.erb
@@ -49,10 +49,30 @@
             <% end %>
             <% content_for :javascripts do %>
               <script>
+                var submittedFile = false;
+
+                function flashError(message) {
+                  const elem = $("<div />").prop("id", "flash_error").addClass("error").text(message);
+                  $("#flashes").append(
+                    elem
+                  );
+
+                  setTimeout(() => {
+                    elem.hide(500);
+                  }, 3000);
+                }
+
                 function dropHandler(e) {
                   e.preventDefault();
                   $(".drag-drop-handin").get(0).style = undefined;
-                  handleFiles(e.dataTransfer.files);
+                  if (e.dataTransfer.files.length === 1) {
+                    var fileSelector = $("#handin_show_assessment input[type='file']").get(0);
+                    fileSelector.files = e.dataTransfer.files;
+                    if (fileSelector.files.length === 1) {
+                      showFiles();
+                      enableSubmit();
+                    }
+                  }
                 }
 
                 function dragOverHandler(e) {
@@ -79,22 +99,12 @@
                   false
                 );
 
-                function handleFiles(fileList) {
-                  if (fileList.length === 1) {
-                    var fileSelector = $("#handin_show_assessment input[type='file']").get(0);
-                    fileSelector.files = fileList;
-                    showFiles();
-                  } else {
-                    // invalid number of files alert
-                  }
-                }
-
                 function showFiles() {
                   var fileSelector = $("#handin_show_assessment input[type='file']").get(0);
                   var file = fileSelector.files[0];
-                  console.log(file);
                   $("#handin-file-name").text(file.name);
                   $("#handin-modify-date").text(moment(file.lastModified).format("MMMM Do YYYY, h:mm a"));
+                  submittedFile = false;
 
                   var sOutput = file.size + " bytes";
                   for (var aMultiples = ["kb", "mb", "gb", "tb", "pb", "eb", "zb", "yb"], nMultiple = 0, nApprox = file.size / 1024; nApprox > 1; nApprox /= 1024, nMultiple++) {
@@ -116,9 +126,11 @@
                     }
                   }
 
-                  $(".handin-row").hide();
-                  $(".handedin-row").show();
-                  enableSubmit();
+                  if (fileSelector.files.length === 1) {
+                      $(".handin-row").hide();
+                      $(".handedin-row").show();
+                      enableSubmit();
+                  }
                 }
 
                 $("#integrity_checkbox").change(function (e) {
@@ -129,9 +141,10 @@
                   e.preventDefault();
                   var fileSelector = $("#handin_show_assessment input[type='file']").get(0);
                   fileSelector.value = null;
-                  $(".handin-row").show();
+                  $(".handin-row").show(function () {
+                    enableSubmit();
+                  });
                   $(".handedin-row").hide();
-                  enableSubmit();
                 });
 
                 function enableSubmit() {
@@ -144,7 +157,23 @@
                   } else {
                     $("#fake-submit").removeClass("disabled");
                   }
+
+                  if (checkbox.checked && $(".handin-row").is(":hidden") && $("#fake-submit").hasClass("disabled") && fileSelector.files.length === 0) {
+                    // theres an issue
+                    $(".handin-row").show();
+                    $(".handedin-row").hide();
+                    flashError("There was an error processing your file, please try again.");
+                  }
                 }
+
+                $("#fake-submit").click(function (e) {
+                  if (submittedFile) {
+                    e.preventDefault();
+                    return;
+                  }
+                  $("#fake-submit").addClass("disabled");
+                  submittedFile = true;
+                });
               </script>
             <% end %>
             <div class="row handin-row">

--- a/app/views/assessments/_handin_form.html.erb
+++ b/app/views/assessments/_handin_form.html.erb
@@ -52,14 +52,7 @@
                 var submittedFile = false;
 
                 function flashError(message) {
-                  const elem = $("<div />").prop("id", "flash_error").addClass("error").text(message);
-                  $("#flashes").append(
-                    elem
-                  );
-
-                  setTimeout(() => {
-                    elem.hide(500);
-                  }, 3000);
+                  const elem = $(".file-error").text(message).show();
                 }
 
                 function dropHandler(e) {
@@ -94,7 +87,6 @@
                 document.querySelector("#handin_show_assessment input[type='file']").addEventListener(
                   "change",
                   function (e) {
-                    console.log("files changed");
                     showFiles();
                   },
                   false
@@ -128,7 +120,9 @@
                   }
 
                   if (fileSelector.files.length === 1) {
-                      $(".handin-row").hide();
+                      $(".handin-row").hide(0, function () {
+                        $(".file-error").hide();
+                      });
                       $(".handedin-row").show();
                       enableSubmit();
                   }
@@ -178,6 +172,9 @@
               </script>
             <% end %>
             <div class="row handin-row">
+              <div class="error file-error" id="flash_error" style="background: white;display: none;">
+                There was an error processing your file, please try adding it again.
+              </div>
               <div class="valign-wrapper drag-drop-handin" onclick="clickDrag();" ondrop="dropHandler(event);" ondragover="dragOverHandler(event);" ondragenter="dragEnter(event);" ondragexit="dragExit(event);">
                 <p class="center-align" style="color:grey;" ondrop="dropHandler(event);" ondragover="dragOverHandler(event);" ondragenter="dragEnter(event);" ondragexit="dragExit(event);"><b>Drag a file here to hand in. Click to select a file.</b> <br /> <span style="font-size: 10px;">Files do not submit automatically.</span></p>
               </div>


### PR DESCRIPTION
Hotfix to hand in page that fixes a bug brought up in an issue:

- Adds a client-side fix to a duplicate submission bug experienced by one professor. After a student clicks the Submit button, they can not click it again
- Adds a fix for a bug in Chrome where some users would have two file selectors open upon clicking on the file input, with the second actually uploading the file
- Adds a notification to users about a bug experienced rarely in Firefox, where a dragged file is not successfully added to the hidden file selector field.