### PR TITLE
fixed uninitialized errors string issues on InstallAssessment

### DIFF
--- a/app/controllers/assessments_controller.rb
+++ b/app/controllers/assessments_controller.rb
@@ -93,6 +93,7 @@ class AssessmentsController < ApplicationController
       next if !File.directory?(File.join(ass_dir, filename)) or filename == ".." or filename == "."
       # assessment's yaml file must exist
       if !File.exist?(File.join(ass_dir, filename, "#{filename}.yml"))
+        flash[:error] = flash[:error] || ""
         flash[:error] += "Yml does not exist: " + filename +"     -     "
         next
       end
@@ -601,6 +602,7 @@ class AssessmentsController < ApplicationController
         begin
           updateScore(@assessment.course.course_user_data, score)
         rescue ActiveRecord::RecordInvalid => invalid
+          flash[:error] = flash[:error] || ""
           flash[:error] += "Unable to withdraw score for "+@assessment.course.course_user_data.user.email+": " + invalid.message
         end
 


### PR DESCRIPTION
Fixes issue where InstallAssessment crashes if there are missing file errors. Before, it tried to add to an error string that was nonexistent. Now, we initialize it (if necessary) right before we add to it.

Before:
<img width="719" alt="screen shot 2019-02-06 at 4 07 40 pm" src="https://user-images.githubusercontent.com/1356687/52373990-1f156680-2a2a-11e9-8734-71633ed8a53b.png">

After:
<img width="720" alt="screen shot 2019-02-06 at 4 07 49 pm" src="https://user-images.githubusercontent.com/1356687/52374001-23da1a80-2a2a-11e9-8277-8d6f8a4fb748.png">
