### PR TITLE
changed text for remaining submissions to account for version penalties

### DIFF
--- a/app/helpers/handin_helper.rb
+++ b/app/helpers/handin_helper.rb
@@ -1,0 +1,16 @@
+module HandinHelper
+  def remainingSubmissionsMsg(submissions, assessment)
+    numSubmissions = submissions.size
+    maxSubmit = (assessment.max_submissions || -1)
+    versionThresh = (assessment.effective_version_threshold || -1)
+    if maxSubmit == -1 and versionThresh == -1
+      return "(unlimited submissions left)"
+    elsif maxSubmit != -1 and versionThresh == -1
+      return "(#{[maxSubmit - numSubmissions, 0].max} submissions left)"
+    elsif versionThresh != -1 and maxSubmit == -1
+      return "(#{[versionThresh - numSubmissions, 0].max} unpenalized submissions left)"
+    else
+      return "(#{[versionThresh - numSubmissions, 0].max} unpenalized, #{[maxSubmit - numSubmissions, 0].max} total submissions left)"
+    end
+  end
+end

--- a/app/views/assessments/_handin_form.html.erb
+++ b/app/views/assessments/_handin_form.html.erb
@@ -213,16 +213,16 @@
             </div>
             <div class="row">
               <% numSubmissions = @submissions.size
-                 maxSubmit = @assessment.max_submissions
-                 versionThresh = (@assessment.version_threshold || -1)
+                 maxSubmit = (@assessment.max_submissions || -1)
+                 versionThresh = (@assessment.effective_version_threshold || -1)
                  if maxSubmit == -1 and versionThresh == -1
                    remaining_submissions_str = "(unlimited submissions left)"
                  elsif maxSubmit != -1 and versionThresh == -1
-                   remaining_submissions_str = "(#{[@assessment.max_submissions - numSubmissions, 0].max} submissions left)"
+                   remaining_submissions_str = "(#{[maxSubmit - numSubmissions, 0].max} submissions left)"
                  elsif versionThresh != -1 and maxSubmit == -1
-                   remaining_submissions_str = "(#{[@assessment.version_threshold - numSubmissions, 0].max} unpenalized submissions left)"
+                   remaining_submissions_str = "(#{[versionThresh - numSubmissions, 0].max} unpenalized submissions left)"
                  else
-                   remaining_submissions_str = "(#{[@assessment.version_threshold - numSubmissions, 0].max} unpenalized, #{[@assessment.max_submissions - numSubmissions, 0].max} total submissions left)"
+                   remaining_submissions_str = "(#{[versionThresh - numSubmissions, 0].max} unpenalized, #{[maxSubmit - numSubmissions, 0].max} total submissions left)"
                  end
               %>
               <div class="smallText col s6 offset-s6 m4 offset-m8 center-align" style="padding-top: 6px"> <%= remaining_submissions_str %>  </div>

--- a/app/views/assessments/_handin_form.html.erb
+++ b/app/views/assessments/_handin_form.html.erb
@@ -212,20 +212,9 @@
               <% end %>
             </div>
             <div class="row">
-              <% numSubmissions = @submissions.size
-                 maxSubmit = (@assessment.max_submissions || -1)
-                 versionThresh = (@assessment.effective_version_threshold || -1)
-                 if maxSubmit == -1 and versionThresh == -1
-                   remaining_submissions_str = "(unlimited submissions left)"
-                 elsif maxSubmit != -1 and versionThresh == -1
-                   remaining_submissions_str = "(#{[maxSubmit - numSubmissions, 0].max} submissions left)"
-                 elsif versionThresh != -1 and maxSubmit == -1
-                   remaining_submissions_str = "(#{[versionThresh - numSubmissions, 0].max} unpenalized submissions left)"
-                 else
-                   remaining_submissions_str = "(#{[versionThresh - numSubmissions, 0].max} unpenalized, #{[maxSubmit - numSubmissions, 0].max} total submissions left)"
-                 end
-              %>
-              <div class="smallText col s6 offset-s6 m4 offset-m8 center-align" style="padding-top: 6px"> <%= remaining_submissions_str %>  </div>
+              <div class="smallText col s6 offset-s6 m4 offset-m8 center-align" style="padding-top: 6px">
+                <%= remainingSubmissionsMsg(@submissions, @assessment) %>  
+              </div>
             </div>
           <% end %>
         <% end %>

--- a/app/views/assessments/_handin_form.html.erb
+++ b/app/views/assessments/_handin_form.html.erb
@@ -212,17 +212,20 @@
               <% end %>
             </div>
             <div class="row">
-              <% if @assessment.max_submissions != -1 then %>
-                <% numSubmissions = @submissions.size %>
-                <% if numSubmissions > @assessment.max_submissions then %>
-                  <% numSubmissions = 0 %>
-                <% else %>
-                  <% numSubmissions = @assessment.max_submissions - numSubmissions %>
-                <% end %>
-                <div class="smallText col s6 offset-s6 m4 offset-m8 center-align" style="padding-top: 6px">&nbsp;&nbsp;(<%= numSubmissions %> submissions left)</div>
-              <% else %>
-                <div class="smallText col s6 offset-s6 m4 offset-m8 center-align" style="padding-top: 6px">(&nbsp;&#x221e;&nbsp;&nbsp;submissions left)</div>
-              <% end %>
+              <% numSubmissions = @submissions.size
+                 maxSubmit = @assessment.max_submissions
+                 versionThresh = (@assessment.version_threshold || -1)
+                 if maxSubmit == -1 and versionThresh == -1
+                   remaining_submissions_str = "(unlimited submissions left)"
+                 elsif maxSubmit != -1 and versionThresh == -1
+                   remaining_submissions_str = "(#{[@assessment.max_submissions - numSubmissions, 0].max} submissions left)"
+                 elsif versionThresh != -1 and maxSubmit == -1
+                   remaining_submissions_str = "(#{[@assessment.version_threshold - numSubmissions, 0].max} unpenalized submissions left)"
+                 else
+                   remaining_submissions_str = "(#{[@assessment.version_threshold - numSubmissions, 0].max} unpenalized, #{[@assessment.max_submissions - numSubmissions, 0].max} total submissions left)"
+                 end
+              %>
+              <div class="smallText col s6 offset-s6 m4 offset-m8 center-align" style="padding-top: 6px"> <%= remaining_submissions_str %>  </div>
             </div>
           <% end %>
         <% end %>


### PR DESCRIPTION
In response to Iliano's bug, changes the logic for rendering the remaining submissions string to account for a version threshold.

If there is no submission limit and no version threshold:
<img width="657" alt="screen shot 2019-02-08 at 2 37 36 pm" src="https://user-images.githubusercontent.com/1356687/52502162-0f278f00-2bb0-11e9-94ba-5fb501478db8.png">

If there is a submission limit but no version threshold:
<img width="652" alt="screen shot 2019-02-08 at 2 38 00 pm" src="https://user-images.githubusercontent.com/1356687/52502168-1353ac80-2bb0-11e9-857d-d1d6e043a40b.png">

If there is a version threshold but no submission limit:
<img width="650" alt="screen shot 2019-02-08 at 2 38 24 pm" src="https://user-images.githubusercontent.com/1356687/52502176-16e73380-2bb0-11e9-80d8-aded264a4fb6.png">

If there is a version threshold and a submission limit:
<img width="651" alt="screen shot 2019-02-08 at 2 38 51 pm" src="https://user-images.githubusercontent.com/1356687/52502186-1c447e00-2bb0-11e9-9ef6-edf10daccd73.png">
