### PR TITLE
fixed Base64 typo

### DIFF
--- a/app/controllers/extensions_controller.rb
+++ b/app/controllers/extensions_controller.rb
@@ -1,7 +1,7 @@
 ##
 # Extensions can be for a finite amount of time or infinite.
 #
-require 'Base64'
+require 'base64'
 
 class ExtensionsController < ApplicationController
   # inherited from ApplicationController


### PR DESCRIPTION
Accessing `http://localhost:8000/courses/AutoPopulated/assessments/labtemplate/extensions` results in

```txt
LoadError at /courses/AutoPopulated/assessments/labtemplate/extensions
cannot load such file -- Base64
```

This is because the `Base64` module actually uses lowercase `b`. See the [doc here](https://ruby-doc.org/stdlib-2.2.2/libdoc/base64/rdoc/Base64.html).