### PR TITLE
fixed missing closing span in erb template

### DIFF
--- a/app/views/gradebooks/student.html.erb
+++ b/app/views/gradebooks/student.html.erb
@@ -58,7 +58,8 @@
                       <a class="history_icon" href="<%= history_url(@_cud, asmt) %>">
                         <i title="Handin history" class="icon-list tip"></i>
                       </a>
-                  <% end %>
+                    <% end %>
+                    </span>
                 </td>
                 <% if @course.grace_days > 0 %>
                   <td><%= aud.grace_days_used %></td>


### PR DESCRIPTION
A closing `</span>` tag is missing in ` app/views/gradebooks/student.html.erb`. This PR fixes it.