### PR TITLE
Allow course assistants to submit assessments early

### DIFF
--- a/app/models/assessment_user_datum.rb
+++ b/app/models/assessment_user_datum.rb
@@ -171,7 +171,7 @@ class AssessmentUserDatum < ActiveRecord::Base
 
   # Check if user can submit at given date/time; provide reason, if not
   def can_submit?(at, submitter = course_user_datum)
-    if submitter.instructor?
+    if submitter.instructor? || submitter.course_assistant?
       [true, nil]
     elsif course_user_datum.dropped? # TODO: why not submitter?
       [false, :user_dropped]


### PR DESCRIPTION
Resolves a ticket where Course Assistants are unable to submit to assessments before their start time 

Tests:
Instructor role allows early submission
Impersonating as course assistant allows early submission
Impersonating as normal user results in user not being able to see the assignment at all 