### PR TITLE
Address annotations box overflowing out of page with long annotations issue

### DIFF
--- a/app/assets/stylesheets/annotations.css
+++ b/app/assets/stylesheets/annotations.css
@@ -733,3 +733,7 @@
     opacity: 0;
   }
 }
+.collapsible {
+  max-height: 50vh;
+  overflow: auto;
+}


### PR DESCRIPTION
`overflow: auto` will add scrollbar when annotations are long, `max-height` keeps everything sane (and also needed to force scrollbar to appear)