### PR TITLE
Fix for 500 error when downloading single file submissions on speedgrader

### DIFF
--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -300,7 +300,6 @@ class SubmissionsController < ApplicationController
           @filename.include?(".metadata"),
         directory: Archive.looks_like_directory?(@filename)
       }]
-      @header_position = 0
     end
 
     if params[:header_position]


### PR DESCRIPTION
This PR fixes the issue in the Speedgrader where Download File on Submission#view page fails with 500 error when the submission is a file instead of an archive.

For some context, header_position is used to provide a unique ID for all files in an archive, so that when users want to download a single file they will pass us the header_position of that file (i.e 4) and the file from the archive which was labeled 4 is returned. The presence of header_position therefore assumes that the files are from an archive.

However, when we are dealing with single-file submissions this flag should not be present, if not when submissions#download is called it will assume that it is dealing with an archive and attempt to extract it, which results in a failure.