### PR TITLE
Fixing Speedgrader Div Size Class

### DIFF
--- a/app/views/submissions/view.html.erb
+++ b/app/views/submissions/view.html.erb
@@ -118,7 +118,7 @@
 <div class="row" style="height: 100%">
   <%# If there are multiple files, we have a header position and need a file tree %>
   <% if (params[:header_position] || (!@ctag_obj.nil? && !@ctag_obj.empty?)) %>
-    <div class="col l2" style="height: 100%">
+    <div class="col s2" style="height: 100%">
       <% if (params[:header_position]) %>
         <%= render "file_tree" %>
       <% end %>
@@ -128,18 +128,18 @@
       <% end %>
       </div>
     </div>
-    <div class="col l8">
+    <div class="col s8">
       <%= render "code_viewer" %>
     </div>
-    <div class="col l2">
+    <div class="col s2">
       <%= render "annotation_pane" %>
     </div>
   <% else %>
   <%# Else center the code and annotations %>
-    <div class="col l10">
+    <div class="col s10">
       <%= render "code_viewer" %>
     </div>
-    <div class="col l2">
+    <div class="col s2">
       <%= render "annotation_pane" %>
     </div>
   <% end %>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/5773562/69601622-c330c400-0fe2-11ea-9b69-7766ea3de226.png)

As of now if you resize the screen and made it too small, the code grader will disappear. 
This PR changes the class type of the divs to ensure they show up even on small screens.

![image](https://user-images.githubusercontent.com/5773562/69601596-a98f7c80-0fe2-11ea-8355-d5330ba52dff.png)
