### PR TITLE
Defaults for annotations without line numbers

### DIFF
--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -388,7 +388,7 @@ class SubmissionsController < ApplicationController
     end
 
     @annotations = @submission.annotations.to_a
-    @annotations.sort! { |a, b| a.line <=> b.line }
+    @annotations.sort! { |a, b| a.line.to_i <=> b.line.to_i }
 
     @problemSummaries = {}
     @problemGrades = {}

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -205,7 +205,11 @@ class Submission < ActiveRecord::Base
     result = file.lines.map { |line| [line.force_encoding("UTF-8"), nil] }
 
     # annotation lines are one-indexed, so adjust for the zero-indexed array
-    annotations.each { |a| result[a.line - 1][1] = a }
+    annotations.each do |a|
+      # If a.line is nil, this becomes -1 so take max of this and 0
+      idx = [a.line.to_i - 1, 0].max
+      result[idx][1] = a
+    end
 
     result
   end


### PR DESCRIPTION
This is to resolve an exception generated when we try to sort with annotations that have nil line numbers, resulting in an invalid comparison:

> submissions#view (ArgumentError) "comparison of Annotation with Annotation failed"
> 
> An ArgumentError occurred in submissions#view:
>   comparison of Annotation with Annotation failed
>   app/controllers/submissions_controller.rb:391:in `sort!'

There is another usage of annotation.line in determining the index for it to be added to an array, which has also been updated to default to 0 if line is nil.