### PR TITLE
Annotation requires problem fix

### DIFF
--- a/app/assets/javascripts/annotations.js
+++ b/app/assets/javascripts/annotations.js
@@ -310,13 +310,20 @@ function displayAnnotations() {
 }
 
 function attachEvents() {
-  $(".add-button").on("click", function(e) {
-    e.preventDefault();
-    var line = $(this).parent().parent().parent();
-    var annotationContainer = line.data("lineId");
-    $("#annotation-line-" + annotationContainer).append(newAnnotationFormCode());
 
-    refreshAnnotations();
+  $(".add-button").on("click", function(e) {
+
+    if(problems.length > 0){
+      e.preventDefault();
+      var line = $(this).parent().parent().parent();
+      var annotationContainer = line.data("lineId");
+      $("#annotation-line-" + annotationContainer).append(newAnnotationFormCode());
+      refreshAnnotations();
+    }
+    else{
+      alert("Please create a problem for the assessment prior to annotating. (Edit Assessment > Problems) ")
+    }
+
   });
 }
 
@@ -1097,10 +1104,16 @@ var initializeAnnotationsForPDF = function() {
 
   $(".page-canvas").on("click", function(e) {
     if ($(e.target).hasClass("page-canvas")) {
-      var pageCanvas = e.currentTarget;
-      var pageInd = parseInt(pageCanvas.id.replace('page-canvas-',''), 10);
-      $('.annotation-form').remove();
-      showAnnotationFormAtCoord(pageInd, e.offsetX, e.offsetY);
+      
+      if(problems.length > 0){
+        var pageCanvas = e.currentTarget;
+        var pageInd = parseInt(pageCanvas.id.replace('page-canvas-',''), 10);
+        $('.annotation-form').remove();
+        showAnnotationFormAtCoord(pageInd, e.offsetX, e.offsetY);
+      }
+      else{
+        alert("Please create a problem for the assessment prior to annotating. (Edit Assessment > Problems) ")
+      }
     }
 
   });

--- a/app/assets/javascripts/annotations.js
+++ b/app/assets/javascripts/annotations.js
@@ -437,10 +437,10 @@ function newAnnotationFormCode() {
     }
 
     if (problem_id == undefined) {
-      if(problems.length > 0)
-        box.find('.error').text("No Problem Selected").show();
+      if($('.select').children('option').length > 0)
+        box.find('.error').text("Problem not selected");
       else
-        box.find('.error').text("Problems must be created before annotating (Edit Assessment > Problems)").show();
+        box.find('.error').text("There are no non-autograded problems. Create a new one at Edit Assessment > Problems");
       return;
     }
 
@@ -813,6 +813,8 @@ var newAnnotationFormForPDF = function(pageInd, xCord, yCord) {
       }, problem.name));
     }
   })
+  
+  
 
   var newForm = elt("form", {
     title: "Press <Enter> to Submit",
@@ -838,10 +840,10 @@ var newAnnotationFormForPDF = function(pageInd, xCord, yCord) {
     }
 
     if (!problem_id) {
-      if(problems.length > 0)
+      if($('#problem').children('option').length > 0)
         $(newForm).find('.form-warning').text("Problem not selected");
       else
-        $(newForm).find('.form-warning').text("Problem must be created before annotation (Edit Assessment > Problems)");
+        $(newForm).find('.form-warning').text("There are no non-autograded problems. Create a new one at Edit Assessment > Problems");
       return;
     }
     
@@ -986,7 +988,10 @@ var newEditAnnotationForm = function(lineInd, annObj) {
     }
 
     if (!problem_id) {
-      $(newForm).find('.form-warning').text("Problem not selected");
+      if($('#problem').children('option').length > 0)
+        $(newForm).find('.form-warning').text("Problem not selected");
+      else
+        $(newForm).find('.form-warning').text("There are no non-autograded problems. Create a new one at Edit Assessment > Problems");
       return;
     }
 

--- a/app/assets/javascripts/annotations.js
+++ b/app/assets/javascripts/annotations.js
@@ -438,9 +438,9 @@ function newAnnotationFormCode() {
 
     if (problem_id == undefined) {
       if($('.select').children('option').length > 0)
-        box.find('.error').text("Problem not selected");
+        box.find('.error').text("Problem not selected").show();
       else
-        box.find('.error').text("There are no non-autograded problems. Create a new one at Edit Assessment > Problems");
+        box.find('.error').text("There are no non-autograded problems. Create a new one at Edit Assessment > Problems").show();
       return;
     }
 

--- a/app/models/annotation.rb
+++ b/app/models/annotation.rb
@@ -49,10 +49,8 @@ class Annotation < ActiveRecord::Base
               problem_id: self.problem_id).
         map(&:value).sum{|v| v.nil? ? 0 : v}
 
-    # Default score to 0 if problem doesn't exist or problem.max_score is nil
-    # The possibility of a problem not existing is due to legacy data and
-    # now we validate that an annotation should always have a problem
-    max_score = score.problem ? score.problem.max_score || 0 : 0;
+    # Default score to 0 if problem.max_score is nil
+    max_score = score.problem.max_score || 0;
     new_score = max_score + annotation_delta
 
     # Update score

--- a/app/models/annotation.rb
+++ b/app/models/annotation.rb
@@ -7,7 +7,7 @@ class Annotation < ActiveRecord::Base
   belongs_to :submission
   belongs_to :problem
 
-  validates :comment, :filename, :submission_id, presence: true
+  validates :comment, :filename, :submission_id, :problem_id, presence: true
 
   def as_text
     if value
@@ -49,7 +49,11 @@ class Annotation < ActiveRecord::Base
               problem_id: self.problem_id).
         map(&:value).sum{|v| v.nil? ? 0 : v}
 
-    new_score = score.problem.max_score + annotation_delta
+    # Default score to 0 if problem doesn't exist or problem.max_score is nil
+    # The possibility of a problem not existing is due to legacy data and
+    # now we validate that an annotation should always have a problem
+    max_score = score.problem ? score.problem.max_score || 0 : 0;
+    new_score = max_score + annotation_delta
 
     # Update score
     score.update!(score: new_score)

--- a/app/models/score.rb
+++ b/app/models/score.rb
@@ -25,7 +25,11 @@ class Score < ActiveRecord::Base
     with_exclusive_scope { find(*args) }
   end
 
+  # Requires submission_id, problem_id not null
   def self.find_or_initialize_by_submission_id_and_problem_id(submission_id, problem_id)
+    if submission_id.nil? || problem_id.nil?
+      raise InvalidScoreException.new, "submission_id and problem_id cannot be empty"
+    end
     score = Score.find_by(submission_id: submission_id, problem_id: problem_id)
 
     if !score
@@ -41,6 +45,7 @@ class Score < ActiveRecord::Base
     else
       setter = "Autograder"
     end
+
     # Some scores don't have submissions, probably if they're deleted ones
     unless submission.nil?
       COURSE_LOGGER.log("Score #{id} UPDATED for " \

--- a/lib/utilities.rb
+++ b/lib/utilities.rb
@@ -37,6 +37,9 @@ module Utilities
   end
 end
 
+class InvalidScoreException < StandardError
+end
+
 class ScoreComputationException < StandardError
 end
 


### PR DESCRIPTION
It is currently possible to create annotations without an associated problem, resulting in errors when attempting to update the score for non-autograded problems since the max_score of the problem cannot be determined.

Furthermore, in re-computing the score of the problem, we are identifying all annotations with the associated `problem_id` and `submission_id`, so it is essential for both fields to be present when saving.

Frontend changes:
Prevent users from creating annotation if there are no problems selected
Show a helpful message if there are no autograded problems available

Backend changes:
Validation that `problem_id` is present on the annotation is done before saving
In computing the score, if the max_score of the problem is nil, it defaults to 0
