### PR TITLE
Fixes directories not showing up, by parsing directories on the fly

### DIFF
--- a/lib/archive.rb
+++ b/lib/archive.rb
@@ -57,8 +57,51 @@ module Archive
     return root
   end
 
+  # given a list of files, sanitize and create
+  # missing file directories
+  def self.sanitize_directories(files)
+
+    cleaned_files = []
+    file_path_set = Set[]
+    
+    # arbitrary header positions for the new directories
+    starting_header = -1
+
+    # add pre-existing directories to the set
+    for file in files
+      if(file[:directory])
+        file_path_set.add(file[:pathname])
+      end
+    end
+
+    for file in files
+      # for each file, check if each of its directories and subdir
+      # exist. If it does not, create and add them
+      if(!file[:directory])
+        paths = file[:pathname].split("/")
+        for i in 1..(paths.size - 1) do
+          new_path = paths[0,paths.size-i].join("/") + "/"
+          if(!file_path_set.include?(new_path))
+            cleaned_files.append({
+              :pathname=>new_path,
+              :header_position=>starting_header,
+              :mac_bs_file=>false,
+              :directory=>true
+            })
+            starting_header = starting_header - 1
+            file_path_set.add(new_path)
+          end
+        end 
+      end
+      cleaned_files.append(file)
+    end
+
+    cleaned_files
+  end
+
   def self.get_file_hierarchy(archive_path)
     files = get_files(archive_path)
+    files = sanitize_directories(files)
     res = recoverHierarchy(files, {pathname: "", directory: true})
     return res[:subfiles]
   end

--- a/lib/archive.rb
+++ b/lib/archive.rb
@@ -69,6 +69,12 @@ module Archive
 
     # add pre-existing directories to the set
     for file in files
+
+      # edge case for removing "./" from pathnames
+      if file[:pathname].include?("./")
+        file[:pathname] = file[:pathname].split("./")[1]
+      end
+
       if(file[:directory])
         file_path_set.add(file[:pathname])
       end
@@ -93,7 +99,11 @@ module Archive
           end
         end 
       end
-      cleaned_files.append(file)
+      
+      # excludes "./" paths
+      if(file[:pathname]!=nil)
+        cleaned_files.append(file)
+      end
     end
 
     cleaned_files


### PR DESCRIPTION
The sanitization should work for both archives with directories, and archives without directories.