### PR TITLE
Explicitly test value on whether scores should be released

### DIFF
--- a/app/controllers/assessments_controller.rb
+++ b/app/controllers/assessments_controller.rb
@@ -4,6 +4,7 @@ require "fileutils"
 require "rubygems/package"
 require "statistics"
 require "yaml"
+require "utilities"
 
 class AssessmentsController < ApplicationController
   include ActiveSupport::Callbacks
@@ -442,7 +443,7 @@ class AssessmentsController < ApplicationController
         score: result["score"].to_f,
         feedback: result["feedback"],
         score_id: result["score_id"].to_i,
-        released: result["released"] == "t" ? 1 : 0
+        released: Utilities.is_truthy?(result["released"]) ? 1 : 0
       }
     end
 

--- a/app/controllers/assessments_controller.rb
+++ b/app/controllers/assessments_controller.rb
@@ -442,7 +442,7 @@ class AssessmentsController < ApplicationController
         score: result["score"].to_f,
         feedback: result["feedback"],
         score_id: result["score_id"].to_i,
-        released: result["released"].to_i
+        released: result["released"] == "t" ? 1 : 0
       }
     end
 

--- a/lib/utilities.rb
+++ b/lib/utilities.rb
@@ -35,6 +35,10 @@ module Utilities
 
     score
   end
+
+  def self.is_truthy?(val)
+    val == true || val == "True" || val == "true" || val == "t" || val == 1 || val == "1" || val == "T"
+  end
 end
 
 class InvalidScoreException < StandardError


### PR DESCRIPTION
In setting `@scores` to determine whether the scores should be released, currently this is being done:

`released: result["released"].to_i`

However, the "boolean" value in result["released"] takes on string values of "t" and "f", which always gets casted to 0 under `.to_i` (see https://apidock.com/ruby/String/to_i)

The question I'm wondering is how this piece of code could have ever worked, unless it used to  be "0"/"1" values which used to be returned. Could this possibly be a db-specified issue? I am using sqlite for my dev environment

I have fixed this by using a helper method is_truthy?() to test whether a given value matches one of the common "truthy" expressions, and using this to determine the value of released