### PR TITLE
Fix for student can view Speedgrader scores/annotations before it is released

### DIFF
--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -400,6 +400,8 @@ class SubmissionsController < ApplicationController
       end
     end
 
+    @problemReleased = @submission.scores.pluck(:released).all?
+
     @annotations = @submission.annotations.to_a
     @annotations.sort! { |a, b| a.line.to_i <=> b.line.to_i }
 
@@ -418,7 +420,6 @@ class SubmissionsController < ApplicationController
       value = annotation.value || 0
       line = annotation.line
       problem = annotation.problem ? annotation.problem.name : "General"
-      isReleased = @submission.scores.pluck(:released).all?
 
       @problemSummaries[problem] ||= []
       @problemSummaries[problem] << [description, value, line, annotation.submitted_by, annotation.id]
@@ -426,7 +427,6 @@ class SubmissionsController < ApplicationController
       @problemGrades[problem] ||= 0
       @problemGrades[problem] += value
 
-      @problemReleased = isReleased
     end
 
 

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -418,13 +418,15 @@ class SubmissionsController < ApplicationController
       value = annotation.value || 0
       line = annotation.line
       problem = annotation.problem ? annotation.problem.name : "General"
-
+      isReleased = @submission.scores.pluck(:released).all?
 
       @problemSummaries[problem] ||= []
       @problemSummaries[problem] << [description, value, line, annotation.submitted_by, annotation.id]
 
       @problemGrades[problem] ||= 0
       @problemGrades[problem] += value
+
+      @problemReleased = isReleased
     end
 
 

--- a/app/views/submissions/_annotation.html.erb
+++ b/app/views/submissions/_annotation.html.erb
@@ -1,3 +1,4 @@
+<% if @cud.instructor? or @cud.course_assistant? or @problemReleased %>
 <div class="base-annotation-line annotation-line">
   <div class="line-sticky">
     <div class="line-number"></div>
@@ -49,3 +50,4 @@
     </div>
   </div>
 </div>
+<% end %>

--- a/app/views/submissions/_annotation_pane.html.erb
+++ b/app/views/submissions/_annotation_pane.html.erb
@@ -4,7 +4,6 @@
   <div class="annotationSummary">
     <h1>Annotations</h1>
     <ul class="collapsible expandable">
-      <%# TODO: Confirm that unreleased annotations are hidden for non-instructors %>
         <% @problemSummaries.each do |problem, descriptTuples| %>
           <li id="li-problem-<%= problem %>">
             <div class="collapsible-header active">

--- a/app/views/submissions/_annotation_pane.html.erb
+++ b/app/views/submissions/_annotation_pane.html.erb
@@ -27,15 +27,18 @@
   <div class="problemGrades">
     <h1>Grades</h1>
     <div class="collection">
-    <%# TODO: Hide unreleased scores for non-instructors %>
       <% p_scores = @submission.problems_to_scores %>
       <% @assessment.problems.each_with_index do |p,i| %>
         <% p_score = p_scores[p.id] %>
         <div class="problem-grade-item collection-item">
           <div class="problem_name"> <%= p.name.capitalize %>: </div>
           <div class="problem_score">
-            <a href="#!" data-problem-id="<%= p.id %>" data-submission-id="<%= @submission.id %>"> <%= p_score && p_score.score ? p_score.score : raw("&ndash;") %> </a>
-            <b>/ <%= p.max_score %> </b>
+            <% if @cud.instructor? or @cud.course_assistant? %>
+              <a href="#!" data-problem-id="<%= p.id %>" data-submission-id="<%= @submission.id %>"> <%= p_score && p_score.score ? p_score.score : raw("&ndash;") %> </a>
+            <% else %>
+              <b><%= if p_score.released then p_score.score else raw("&ndash;") end %></b>
+            <% end %>
+            <b> / <%= p.max_score %></b>
           </div>
         </div>
       <% end %>

--- a/app/views/submissions/_annotation_pane.html.erb
+++ b/app/views/submissions/_annotation_pane.html.erb
@@ -43,7 +43,7 @@
             <% if @cud.instructor? or @cud.course_assistant? %>
               <a href="#!" data-problem-id="<%= p.id %>" data-submission-id="<%= @submission.id %>"> <%= p_score && p_score.score ? p_score.score : raw("&ndash;") %> </a>
             <% else %>
-              <b><%= if p_score.released then p_score.score else raw("&ndash;") end %></b>
+              <b><%= if p_score && p_score.released then p_score.score else raw("&ndash;") end %></b>
             <% end %>
             <b> / <%= p.max_score %></b>
           </div>

--- a/app/views/submissions/_annotation_pane.html.erb
+++ b/app/views/submissions/_annotation_pane.html.erb
@@ -9,14 +9,22 @@
           <li id="li-problem-<%= problem %>">
             <div class="collapsible-header active">
               <h4> <%= problem.capitalize %>
-                  <div class="summary_score"> <%= plus_fix(@problemGrades[problem]) %></div>
+                  <div class="summary_score">
+                    <% if @cud.instructor? or @cud.course_assistant? or @problemReleased%>
+                      <%= plus_fix(@problemGrades[problem]) %>
+                    <% end %>
+                  </div>
               </h4>
             </div>
             <div class="collapsible-body">
-              <% descriptTuples.each do |description, value, line, user, id| %>
-                <div class="descript" id="li-annotation-<%= id %>" onclick="scrollToLine(<%= (line.nil? ? nil : line+1) %>)"> <!-- Line + 1 because the code line numbers starts with 1 not. -->
-                  <span class="point_badge <%= value > 0 ? "positive" : value < 0 ? "negative" : "neutral" %>"><%= plus_fix(value) %></span> <%= description %>
-                </div>
+              <% if @cud.instructor? or @cud.course_assistant? or @problemReleased%>
+                <% descriptTuples.each do |description, value, line, user, id| %>
+                  <div class="descript" id="li-annotation-<%= id %>" onclick="scrollToLine(<%= (line.nil? ? nil : line+1) %>)"> <!-- Line + 1 because the code line numbers starts with 1 not. -->
+                    <span class="point_badge <%= value > 0 ? "positive" : value < 0 ? "negative" : "neutral" %>"><%= plus_fix(value) %></span> <%= description %>
+                  </div>
+                <% end %>
+                <% else %>
+                <i>Unreleased</i>
               <% end %>
             </div>
           </li>


### PR DESCRIPTION
Students are currently able to view annotations, grade changes, and scores by going to the View tab of the submission, even before the grades are released. This PR ensures that only instructors and course assistants are able to view and modify these details before they are released.