### PR TITLE
lines with over 80 chars are now highlighted

### DIFF
--- a/app/assets/javascripts/annotations.js
+++ b/app/assets/javascripts/annotations.js
@@ -292,17 +292,17 @@ function make_editable($editable) {
 
 /* Highlights lines longer than 80 characters autolab red color */
 var highlightLines = function(highlight) {
-  var highlightColor = "rgba(200, 200, 0, 0.9)"
-  $("#code-list > li > code").each(function() {
+  var highlightColor = "rgba(255, 255, 0, 0.3)"
+  $("#code-box > .code-table > .code-line > .code").each(function() {
     var text = $(this).text();
     // To account for lines that have 80 characters and a line break
     var diff = text[text.length - 1] === "\n" ? 1 : 0;
     if (text.length - diff > 80 && highlight) {
-      $(this).css("background-color", highlightColor);
-      $(this).prev().css("background-color", highlightColor);
+      $(this).css("background", highlightColor);
+      $(this).prev().css("background", highlightColor);
     } else {
-      $(this).css("background-color", "white");
-      $(this).prev().css("background-color", "white");
+      $(this).css("background", "inherit");
+      $(this).prev().css("background", "inherit");
     }
   });
 };
@@ -323,6 +323,8 @@ function displayAnnotations() {
 }
 
 function attachEvents() {
+  var status = $('#highlightLongLines')[0].checked;
+  highlightLines(status);
 
   $(".add-button").on("click", function(e) {
 

--- a/app/assets/stylesheets/annotations.css
+++ b/app/assets/stylesheets/annotations.css
@@ -513,6 +513,7 @@
   box-shadow: none;
   border: none;
   margin: 10px 0;
+  max-height: 350px;
 }
 
 .annotationSummary .collapsible-header{

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -400,6 +400,8 @@ class SubmissionsController < ApplicationController
       end
     end
 
+    @problemReleased = @submission.scores.pluck(:released).all?
+
     @annotations = @submission.annotations.to_a
     @annotations.sort! { |a, b| a.line.to_i <=> b.line.to_i }
 
@@ -419,12 +421,12 @@ class SubmissionsController < ApplicationController
       line = annotation.line
       problem = annotation.problem ? annotation.problem.name : "General"
 
-
       @problemSummaries[problem] ||= []
       @problemSummaries[problem] << [description, value, line, annotation.submitted_by, annotation.id]
 
       @problemGrades[problem] ||= 0
       @problemGrades[problem] += value
+
     end
 
 

--- a/app/views/submissions/_annotation.html.erb
+++ b/app/views/submissions/_annotation.html.erb
@@ -1,3 +1,4 @@
+<% if @cud.instructor? or @cud.course_assistant? or @problemReleased %>
 <div class="base-annotation-line annotation-line">
   <div class="line-sticky">
     <div class="line-number"></div>
@@ -49,3 +50,4 @@
     </div>
   </div>
 </div>
+<% end %>

--- a/app/views/submissions/_annotation_pane.html.erb
+++ b/app/views/submissions/_annotation_pane.html.erb
@@ -1,6 +1,4 @@
 <div id="annotationPane">
-  <%# TODO: Bring back highlight lines longer than 80 characters %>
-
   <div class="annotationSummary">
     <h1>Annotations</h1>
     <ul class="collapsible expandable">

--- a/app/views/submissions/_annotation_pane.html.erb
+++ b/app/views/submissions/_annotation_pane.html.erb
@@ -4,19 +4,26 @@
   <div class="annotationSummary">
     <h1>Annotations</h1>
     <ul class="collapsible expandable">
-      <%# TODO: Confirm that unreleased annotations are hidden for non-instructors %>
         <% @problemSummaries.each do |problem, descriptTuples| %>
           <li id="li-problem-<%= problem %>">
             <div class="collapsible-header active">
               <h4> <%= problem.capitalize %>
-                  <div class="summary_score"> <%= plus_fix(@problemGrades[problem]) %></div>
+                  <div class="summary_score">
+                    <% if @cud.instructor? or @cud.course_assistant? or @problemReleased%>
+                      <%= plus_fix(@problemGrades[problem]) %>
+                    <% end %>
+                  </div>
               </h4>
             </div>
             <div class="collapsible-body">
-              <% descriptTuples.each do |description, value, line, user, id| %>
-                <div class="descript" id="li-annotation-<%= id %>" onclick="scrollToLine(<%= (line.nil? ? nil : line+1) %>)"> <!-- Line + 1 because the code line numbers starts with 1 not. -->
-                  <span class="point_badge <%= value > 0 ? "positive" : value < 0 ? "negative" : "neutral" %>"><%= plus_fix(value) %></span> <%= description %>
-                </div>
+              <% if @cud.instructor? or @cud.course_assistant? or @problemReleased%>
+                <% descriptTuples.each do |description, value, line, user, id| %>
+                  <div class="descript" id="li-annotation-<%= id %>" onclick="scrollToLine(<%= (line.nil? ? nil : line+1) %>)"> <!-- Line + 1 because the code line numbers starts with 1 not. -->
+                    <span class="point_badge <%= value > 0 ? "positive" : value < 0 ? "negative" : "neutral" %>"><%= plus_fix(value) %></span> <%= description %>
+                  </div>
+                <% end %>
+                <% else %>
+                <i>Unreleased</i>
               <% end %>
             </div>
           </li>
@@ -27,15 +34,18 @@
   <div class="problemGrades">
     <h1>Grades</h1>
     <div class="collection">
-    <%# TODO: Hide unreleased scores for non-instructors %>
       <% p_scores = @submission.problems_to_scores %>
       <% @assessment.problems.each_with_index do |p,i| %>
         <% p_score = p_scores[p.id] %>
         <div class="problem-grade-item collection-item">
           <div class="problem_name"> <%= p.name.capitalize %>: </div>
           <div class="problem_score">
-            <a href="#!" data-problem-id="<%= p.id %>" data-submission-id="<%= @submission.id %>"> <%= p_score && p_score.score ? p_score.score : raw("&ndash;") %> </a>
-            <b>/ <%= p.max_score %> </b>
+            <% if @cud.instructor? or @cud.course_assistant? %>
+              <a href="#!" data-problem-id="<%= p.id %>" data-submission-id="<%= @submission.id %>"> <%= p_score && p_score.score ? p_score.score : raw("&ndash;") %> </a>
+            <% else %>
+              <b><%= if p_score && p_score.released then p_score.score else raw("&ndash;") end %></b>
+            <% end %>
+            <b> / <%= p.max_score %></b>
           </div>
         </div>
       <% end %>

--- a/app/views/submissions/view.html.erb
+++ b/app/views/submissions/view.html.erb
@@ -131,6 +131,11 @@
       </div>
     </div>
     <div class="col s8">
+      <label>
+        <input type="checkbox" id="highlightLongLines" checked>
+        <span>Highlight lines longer than 80 characters</span>
+      </label>
+      <br>
       <%= render "code_viewer" %>
     </div>
     <div class="col s2">

--- a/app/views/submissions/view.html.erb
+++ b/app/views/submissions/view.html.erb
@@ -131,10 +131,8 @@
       </div>
     </div>
     <div class="col s8">
-      <label>
         <input type="checkbox" id="highlightLongLines" checked>
-        <span>Highlight lines longer than 80 characters</span>
-      </label>
+        <label for="highlightLongLines">Highlight lines longer than 80 characters</label>
       <br>
       <%= render "code_viewer" %>
     </div>

--- a/app/views/submissions/view.html.erb
+++ b/app/views/submissions/view.html.erb
@@ -133,7 +133,6 @@
     <div class="col s8">
         <input type="checkbox" id="highlightLongLines" checked>
         <label for="highlightLongLines">Highlight lines longer than 80 characters</label>
-      <br>
       <%= render "code_viewer" %>
     </div>
     <div class="col s2">


### PR DESCRIPTION
On default, the checkbox that highlights lines over 80 characters is on. Users are able to turn it that off by unchecking the box.

![image](https://user-images.githubusercontent.com/31053044/73603381-afa85900-454f-11ea-805c-4f9893fa5e96.png)
