### PR TITLE
Loosen API rate limiting

### DIFF
--- a/config/initializers/rack-attack.rb
+++ b/config/initializers/rack-attack.rb
@@ -39,24 +39,6 @@ class Rack::Attack
 
   ### Throttle Requests ###
 
-  # Throttle setup requests by user id
-  #
-  # Key: "rack::attack:#{Time.now.to_i/:period}:api/general:#{req.user_id}"
-  throttle('api/setup', :limit => 1500, :period => 0.seconds) do |req|
-    if req.path.start_with?("/api/")
-      req.user_id
-    end
-  end
-
-  # Throttle all requests by user id
-  #
-  # Key: "rack::attack:#{Time.now.to_i/:period}:api/general:#{req.user_id}"
-  throttle('api/general', :limit => 10, :period => 30.seconds) do |req|
-    if req.path.start_with?("/api/")
-      req.user_id
-    end
-  end
-
   # Throttle requests for assessment submission endpoint
   #
   # Key: "rack::attack:#{Time.now.to_i/:period}:api/submit:#{req.user_id}"

--- a/config/initializers/rack-attack.rb
+++ b/config/initializers/rack-attack.rb
@@ -51,7 +51,7 @@ class Rack::Attack
   # Throttle requests for device_flow_init
   #
   # Key: "rack::attack:#{Time.now.to_i/:period}:oauth/device_flow_init:#{req.user_id}"
-  throttle("oauth/device_flow_init", :limit => 1, :period => 30.seconds) do |req|
+  throttle("oauth/device_flow_init", :limit => 1000, :period => 30.seconds) do |req|
     if req.path.start_with?("/oauth/device_flow_init")
       req.ip
     end
@@ -60,7 +60,7 @@ class Rack::Attack
   # Throttle requests for device_flow_authorize
   #
   # Key: "rack::attack:#{Time.now.to_i/:period}:oauth/device_flow_authorize:#{req.user_id}"
-  throttle("oauth/device_flow_authorize", :limit => 1, :period => 5.seconds) do |req|
+  throttle("oauth/device_flow_authorize", :limit => 1000, :period => 5.seconds) do |req|
     if req.path.start_with?("/oauth/device_flow_authorize")
       req.ip
     end

--- a/config/initializers/rack-attack.rb
+++ b/config/initializers/rack-attack.rb
@@ -24,7 +24,7 @@ class Rack::Attack
   # whitelisting). It must implement .increment and .write like
   # ActiveSupport::Cache::Store
 
-  # Rack::Attack.cache.store = ActiveSupport::Cache::MemoryStore.new 
+  # Rack::Attack.cache.store = ActiveSupport::Cache::MemoryStore.new
 
   ### Safelist Requests ###
 
@@ -38,6 +38,15 @@ class Rack::Attack
   end
 
   ### Throttle Requests ###
+
+  # Throttle setup requests by user id
+  #
+  # Key: "rack::attack:#{Time.now.to_i/:period}:api/general:#{req.user_id}"
+  throttle('api/setup', :limit => 1500, :period => 0.seconds) do |req|
+    if req.path.start_with?("/api/")
+      req.user_id
+    end
+  end
 
   # Throttle all requests by user id
   #


### PR DESCRIPTION
Two changes here:
 - Removed rate limiting on general api routes
     - All routes except file upload
     - These are cached in the CLI, so putting a cli call in a bash for loop would only generate one request anyways.
     - Students could use curl to make raw HTTP requests to the API, but that's just as difficult as making requests to normal GUI routes that aren't rate-limited anyways.
 - Increased /oauth/device_flow_* limits to 1000
    - This should accommodate situations where every student in a class sets up the Autolab CLI at once.