### PR TITLE
Changes deprecated render text to render plain

### DIFF
--- a/app/controllers/assessment/grading.rb
+++ b/app/controllers/assessment/grading.rb
@@ -241,7 +241,7 @@ public
 
     updateScore(score.submission.course_user_datum_id, score)
 
-    render text: score.score
+    render plain: score.score
 
   # see http://stackoverflow.com/questions/6163125/duplicate-records-created-by-find-or-create-by
   # and http://barelyenough.org/blog/2007/11/activerecord-race-conditions/
@@ -271,7 +271,7 @@ public
 
     updateScore(score.submission.course_user_datum_id, score)
 
-    render text: score.id
+    render plain: score.id
 
   # see http://stackoverflow.com/questions/6163125/duplicate-records-created-by-find-or-create-by
   # and http://barelyenough.org/blog/2007/11/activerecord-race-conditions/
@@ -309,7 +309,7 @@ end
     # get submission and problem IDs
     sub_id = params[:submission_id].to_i
 
-    render text: Submission.find(sub_id).final_score(@cud)
+    render plain: Submission.find(sub_id).final_score(@cud)
   end
 
   def statistics

--- a/app/views/submissions/_annotation_pane.html.erb
+++ b/app/views/submissions/_annotation_pane.html.erb
@@ -39,7 +39,7 @@
           <div class="problem_name"> <%= p.name.capitalize %>: </div>
           <div class="problem_score">
             <% if @cud.instructor? or @cud.course_assistant? %>
-              <a href="#!" data-problem-id="<%= p.id %>" data-submission-id="<%= @submission.id %>"> <%= p_score && p_score.score ? p_score.score : raw("&ndash;") %> </a>
+              <a data-problem-id="<%= p.id %>" data-submission-id="<%= @submission.id %>"> <%= p_score && p_score.score ? p_score.score : raw("&ndash;") %> </a>
             <% else %>
               <b><%= if p_score && p_score.released then p_score.score else raw("&ndash;") end %></b>
             <% end %>


### PR DESCRIPTION
This fixes the issue of the scores not rendering correctly after updating them on the
1. view page
2. grade submissions page

It should update correctly now