### PR TITLE
Add correct timestamps to contents of zip file

### DIFF
--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -178,17 +178,17 @@ class SubmissionsController < ApplicationController
     paths = submissions.collect(&:handin_file_path)
     paths = paths.select { |p| !p.nil? && File.exist?(p) && File.readable?(p) }
 
-    result = Archive.create_zip paths
+    result = Archive.create_zip paths # result is stringIO to be sent
 
     if result.nil?
       flash[:error] = "There are no submissions to download."
       redirect_to([@course, @assessment, :submissions]) && return
     end
 
-    send_file(result.path,
+    send_data(result.read, # to read from stringIO object returned by create_zip
               type: "application/zip",
-              stream: false, # So we can delete the file immediately.
-              filename: File.basename(result.path)) && return
+              disposition: "attachment", # tell browser to download
+              filename: "#{@course.name}_#{@course.semester}_#{@assessment.name}_submissions.zip") && return
   end
 
   # Action to be taken when the user wants do download a submission but

--- a/lib/archive.rb
+++ b/lib/archive.rb
@@ -204,14 +204,18 @@ module Archive
   def self.create_zip(paths)
     return nil if paths.nil? || paths.empty?
 
-    Tempfile.open(["submissions", ".zip"]) do |t|
-      Zip::File.open(t.path, Zip::File::CREATE) do |z|
-        paths.each { |p| z.add(File.basename(p), p) }
-        z
+    # don't create a tempfile, just stream it to client for download
+    zip_stream = Zip::OutputStream.write_buffer do |zos|
+      paths.each do |filepath|
+        ctimestamp = Zip::DOSTime.at(File.open(filepath,"r").ctime) # use creation time of submitted file
+        zip_entry = Zip::Entry.new(zos, "#{File.basename(filepath)}", nil, nil, nil, nil, nil, nil,
+                    ctimestamp)
+        zos.put_next_entry(zip_entry)
+        zos.print IO.read(filepath)
       end
-      t
     end
-    # the return value should be the return value of the outer block, which is the tempfile
+    zip_stream.rewind
+    zip_stream
   end
 
   def self.looks_like_directory?(pathname)


### PR DESCRIPTION
I noticed that the contents of a zip file downloaded with the
"Download All Submissions" or "Download Final Submissions" links
would not preserve the timestamp of the submitted files. After
unzipping, the files would have the time stamp of when the zip
file was created, not the time when the file was handed in by
the student. This is useful information which should be preserved
when the zip archive is created.

Making this change has a few side effects which I also consider
to be improvements:

- previously a temporary file was created in /tmp with Tempfile.open
  which could end up hanging around after it is downloaded. What I
  do here is create a `Zip::OutputStream` and return that with send_data
  so no temporary file needs to be written to disk.

- also, the filename of the downloaded file used to be be something
  like: `submissions20200220-79247-1k7kzv1.zip` This is confusing to an
  instructor with multiple assessments or multiple courses, since
  the name doesn't specify which course or which assessment. Instead
  I use this filename: `#{@course.name}_#{@course.semester}_#{@assessment.name}_submissions.zip`