### PR TITLE
Hide tango vm status if unprivileged

### DIFF
--- a/app/views/jobs/index.html.erb
+++ b/app/views/jobs/index.html.erb
@@ -3,8 +3,10 @@
 <% end %>
 
 <p>
-This page shows you the status of current and recent autograding jobs.<br />
-<%= link_to "Click here", tango_status_course_jobs_path %> to view the overall status of Tango VMs.
+  This page shows you the status of current and recent autograding jobs.<br />
+  <% if @cud.user.administrator? or @cud.instructor? %>
+    <%= link_to "Click here", tango_status_course_jobs_path %> to view the overall status of Tango VMs.
+  <% end %>
 </p>
 
 <h2>Currently Running Jobs</h2>


### PR DESCRIPTION
This fixes the issue where students and CAs are able to see the following message on the jobs page:

`Click here to view the overall status of Tango VMs.`

even though they are unauthorized to view the status of all Tango VMs, which results in an unauthorized error. This PR makes sure that only instructors and CAs will be able to view them.
