### PR TITLE
Makes annotation summary collapsible. Adds correct padding

### DIFF
--- a/app/assets/javascripts/annotations.js
+++ b/app/assets/javascripts/annotations.js
@@ -2,7 +2,7 @@
 
 $(document).ready(function () {
   $(".collapsible-body").show(); //expands all collapsible initially
-
+  $('.collapsible').collapsible();
   //get line number in URL, if it exists
   var urlParams = new URLSearchParams(location.search);
   if (urlParams.has("line")) {

--- a/app/assets/stylesheets/annotations.css
+++ b/app/assets/stylesheets/annotations.css
@@ -520,6 +520,8 @@
   min-height: inherit;
   line-height: inherit;
   border: none;
+  padding: 5px;
+  padding-left: 10px;
 }
 
 .annotationSummary .collapsible-header h4{
@@ -777,4 +779,8 @@
 
 .descript {
   cursor: pointer;
+}
+
+.summary_score{
+  padding-left: 10px;
 }


### PR DESCRIPTION
- Makes annotation box summary collapsible by initializing it
- Fixes padding issue with the internal elements in the annotation summary box

![image](https://user-images.githubusercontent.com/5773562/75100980-ba309e00-55a3-11ea-9e38-8b5e60943190.png)
