### PR TITLE
Grade Section text not breaking up

### DIFF
--- a/app/views/courses/index.html.erb
+++ b/app/views/courses/index.html.erb
@@ -37,6 +37,7 @@
 
               <% if course_cud %>
                 <% if not_student && !course_cud.section.blank? %>
+                  <hr>
                   <%= link_to "Grade Section", [:view, course, course_cud, :gradebook, section: course_cud.section], title: "Grade your section", class: "red-text text-darken-3", style: "white-space: nowrap" %>
                 <% elsif !not_student %>
                   <%= link_to "Gradebook", [course, course_cud, :gradebook], title: "View your gradebook", class: "red-text text-darken-3" %>

--- a/app/views/courses/index.html.erb
+++ b/app/views/courses/index.html.erb
@@ -37,7 +37,7 @@
 
               <% if course_cud %>
                 <% if not_student && !course_cud.section.blank? %>
-                  <%= link_to "Grade Section", [:view, course, course_cud, :gradebook, section: course_cud.section], title: "Grade your section", class: "red-text text-darken-3" %>
+                  <%= link_to "Grade Section", [:view, course, course_cud, :gradebook, section: course_cud.section], title: "Grade your section", class: "red-text text-darken-3", style: "white-space: nowrap" %>
                 <% elsif !not_student %>
                   <%= link_to "Gradebook", [course, course_cud, :gradebook], title: "View your gradebook", class: "red-text text-darken-3" %>
                 <% end %>


### PR DESCRIPTION
"Grade Section" is no longer cut off mid way through the words

![image](https://user-images.githubusercontent.com/31053044/75616922-6daa0d00-5b25-11ea-873e-f84bffbaf21e.png)