### PR TITLE
GDU/PLD fix when bulk importing grades for non-existent submission

### DIFF
--- a/app/controllers/assessment/grading.rb
+++ b/app/controllers/assessment/grading.rb
@@ -112,7 +112,8 @@ private
             sub = asmt.submissions.create!(
               course_user_datum_id: user.id,
               assessment_id: asmt.id,
-              submitted_by_id: @cud.id
+              submitted_by_id: @cud.id,
+              created_at: asmt.due_at
             )
           end
 


### PR DESCRIPTION
This PR fixes the bug where bulk imports for students with currently non-existent submissions results in the creation of a submission that is considered created at the time that the bulk import was performed.

As a result, the student incurs a late day penalty equivalent to the number of days between the assessment due-date and the time the import was performed.

This PR fixes it by setting the creation time to be the assessment due date, so no PLD/GDU is incurred.