### PR TITLE
Hide instructor/CA's score from scoreboard

### DIFF
--- a/app/controllers/scoreboards_controller.rb
+++ b/app/controllers/scoreboards_controller.rb
@@ -46,6 +46,7 @@ class ScoreboardsController < ApplicationController
       uid = row["course_user_datum_id"].to_i
       unless @grades.key?(uid)
         user = @course.course_user_data.find(uid)
+        next unless user.student?
         @grades[uid] = {}
         @grades[uid][:nickname] = user.nickname
         @grades[uid][:andrewID] = user.email


### PR DESCRIPTION
Bypass any record from instructors/CAs so the records passed on to the template will only be those of the students.