### PR TITLE
GDU/PLD Surfacing Improvement

### DIFF
--- a/app/views/assessments/_handin_form.html.erb
+++ b/app/views/assessments/_handin_form.html.erb
@@ -15,7 +15,7 @@
     <%   else %>
     <%     grace_late_info = "submitting #{pluralize(days_late, "day")} late using #{pluralize(days_late, "penalty late day")}" %>
     <%   end %>
-    <%   late_confirm = " and that I'm #{grace_late_info} under the late policy as defined in the syllabus" %>
+    <%   late_confirm = " and that I am #{grace_late_info} under the late policy as defined in the syllabus" %>
       <p><b>Warning:</b> Submitting late may result in the usage of a grace day or a grade penalty!</p>
     <% end %>
 

--- a/app/views/assessments/_handin_form.html.erb
+++ b/app/views/assessments/_handin_form.html.erb
@@ -9,13 +9,13 @@
     <%   days_late = (days_late / 1.day).ceil %>
     <%   grace_days_left = @aud.grace_days_usable %>
     <%   if grace_days_left >= days_late %>
-    <%     grace_late_info = "using #{pluralize(days_late, "grace day")}" %>
+    <%     grace_late_info = "submitting #{pluralize(days_late, "day")} late using #{pluralize(days_late, "grace day")}" %>
     <%   elsif grace_days_left > 0 %>
-    <%     grace_late_info = "using #{pluralize(grace_days_left, "grace day")} with #{pluralize(days_late - grace_days_left, "additional late day")}" %>
+    <%     grace_late_info = "submitting #{pluralize(days_late, "day")} late using #{pluralize(grace_days_left, "grace day")} with #{pluralize(days_late - grace_days_left, "penalty late day")}" %>
     <%   else %>
-    <%     grace_late_info = "using #{pluralize(days_late, "late day")}" %>
+    <%     grace_late_info = "submitting #{pluralize(days_late, "day")} late using #{pluralize(days_late, "penalty late day")}" %>
     <%   end %>
-    <%   late_confirm = " and that I'm submitting #{grace_late_info} under the late policy as defined in the syllabus" %>
+    <%   late_confirm = " and that I'm #{grace_late_info} under the late policy as defined in the syllabus" %>
       <p><b>Warning:</b> Submitting late may result in the usage of a grace day or a grade penalty!</p>
     <% end %>
 

--- a/app/views/assessments/_handin_form.html.erb
+++ b/app/views/assessments/_handin_form.html.erb
@@ -1,8 +1,23 @@
 <div id="<%= id %>" data-cansubmit="<%= @can_submit %> " class="card-action">
   <% if @can_submit %>
+    <% late_confirm ="" %>
+    <% grace_late_info = "" %>
 
     <% if @aud.past_due_at? %>
+    <%   currentTime = Time.zone.now %>
+    <%   days_late = currentTime - @aud.due_at + (currentTime.utc_offset - @aud.due_at.utc_offset) %>
+    <%   days_late = (days_late / 1.day).ceil %>
+    <%   grace_days_left = @aud.grace_days_usable %>
+    <%   if grace_days_left >= days_late %>
+    <%     grace_late_info = "using #{pluralize(days_late, "grace day")}" %>
+    <%   elsif grace_days_left > 0 %>
+    <%     grace_late_info = "using #{pluralize(grace_days_left, "grace day")} with #{pluralize(days_late - grace_days_left, "additional late day")}" %>
+    <%   else %>
+    <%     grace_late_info = "using #{pluralize(days_late, "late day")}" %>
+    <%   end %>
+    <%   late_confirm = " and that I'm submitting #{grace_late_info} under the late policy as defined in the syllabus" %>
       <p><b>Warning:</b> Submitting late may result in the usage of a grace day or a grade penalty!</p>
+      <!-- <p>You are currently <b><%= "#{days_late}"%></b> days late and you have <b><%= "#{@aud.grace_days_usable}"%></b> grace days left.</p> -->
     <% end %>
 
     <div class="row">
@@ -13,7 +28,7 @@
             <!-- Academic integrity checkbox -->
             <%= label_tag(:integrity_checkbox) do %>
                 <%= check_box_tag(:integrity_checkbox) %>
-                <%= content_tag("span", "I affirm that I have complied with this course's academic integrity policy as defined in the syllabus.") %>
+                <%= content_tag("span", "I affirm that I have complied with this course's academic integrity policy as defined in the syllabus#{late_confirm}.") %>
             <% end %>
 
             <% if @aud.past_due_at? then %>
@@ -203,7 +218,7 @@
 
 						<%= label_tag(:integrity_checkbox) do %>
 							<%= check_box_tag(:integrity_checkbox) %>
-							<%= content_tag("span", "I affirm that I have complied with this course's academic integrity policy as defined in the syllabus.") %>
+							<%= content_tag("span", "I affirm that I have complied with this course's academic integrity policy as defined in the syllabus#{late_confirm}.") %>
 						<% end %>
 
             <%= f.file_field :file %>
@@ -217,7 +232,8 @@
             </div>
             <div class="row">
               <div class="smallText col s6 offset-s6 m4 offset-m8 center-align" style="padding-top: 6px">
-                <%= remainingSubmissionsMsg(@submissions, @assessment) %>
+                <%= remainingSubmissionsMsg(@submissions, @assessment) %><br>
+                <b><%= grace_late_info %></b>
               </div>
             </div>
           <% end %>

--- a/app/views/assessments/_handin_form.html.erb
+++ b/app/views/assessments/_handin_form.html.erb
@@ -17,7 +17,6 @@
     <%   end %>
     <%   late_confirm = " and that I'm submitting #{grace_late_info} under the late policy as defined in the syllabus" %>
       <p><b>Warning:</b> Submitting late may result in the usage of a grace day or a grade penalty!</p>
-      <!-- <p>You are currently <b><%= "#{days_late}"%></b> days late and you have <b><%= "#{@aud.grace_days_usable}"%></b> grace days left.</p> -->
     <% end %>
 
     <div class="row">


### PR DESCRIPTION
This PR improves the surfacing of late-day/grace-day information to students when they are submitting late. It adds extra information to the academic integrity confirmation statement as well as under "number of submissions left" message. And this information does not show up if a student is not submitting late.