### PR TITLE
Removed white footer in speedgrader page

### DIFF
--- a/app/assets/stylesheets/annotations.css
+++ b/app/assets/stylesheets/annotations.css
@@ -9,7 +9,6 @@
 
 .row {
   max-height: calc(100vh - 205px);
-  overflow: hidden;
 }
 
 #code-loader {
@@ -489,6 +488,11 @@
 }
 
 /* Annotation Pane Styling CSS */
+#annotationPane{
+  display: flex;
+  flex-flow: column;
+  height: 100%;
+}
 .annotationSummary{
   border: solid 2px #569ff7;
   margin-bottom: 15px;
@@ -561,6 +565,7 @@
 
 .problemGrades{
   border: solid 2px #ebebeb;
+  overflow: auto;
 }
 .problemGrades h1{
   margin: 0px;

--- a/app/assets/stylesheets/annotations.css
+++ b/app/assets/stylesheets/annotations.css
@@ -8,7 +8,7 @@
 }
 
 .row {
-  max-height: calc(100vh - 205px);
+  max-height: calc(100vh - 190px);
 }
 
 #code-loader {

--- a/app/views/submissions/view.html.erb
+++ b/app/views/submissions/view.html.erb
@@ -137,7 +137,7 @@
         <br>
       <%= render "code_viewer" %>
     </div>
-    <div class="col s2">
+    <div class="col s2" style="height: 100%;">
       <%= render "annotation_pane" %>
     </div>
   <% else %>
@@ -149,7 +149,7 @@
       </label>
       <%= render "code_viewer" %>
     </div>
-    <div class="col s2">
+    <div class="col s2" style="height: 100%;">
       <%= render "annotation_pane" %>
     </div>
   <% end %>


### PR DESCRIPTION
White footer at the bottom of the speedgrader page is removed. "Grades" section becomes scrollable if there are too many annotations.

![Screen Shot 2020-04-09 at 5 30 48 PM](https://user-images.githubusercontent.com/31053044/78946296-f783b900-7a87-11ea-9d23-770a9581c45c.png)
