### PR TITLE
Specify whitelisted parameters to avoid using to_unsafe_h

### DIFF
--- a/app/views/submissions/view.html.erb
+++ b/app/views/submissions/view.html.erb
@@ -71,7 +71,7 @@
 
   <script>
     var newFile = {};
-    newFile.url = '<%= url_for(params.to_unsafe_h) %>'
+    newFile.url = '<%= url_for(params.permit(:action, :controller).to_h) %>'
 
     <% if @is_pdf %>
     newFile.pdf = true;

--- a/app/views/submissions/view.html.erb
+++ b/app/views/submissions/view.html.erb
@@ -71,7 +71,7 @@
 
   <script>
     var newFile = {};
-    newFile.url = '<%= url_for(params.permit(:action, :controller).to_h) %>'
+    newFile.url = '<%= url_for(params.permit(:header_position, :action, :controller).to_h) %>'
 
     <% if @is_pdf %>
     newFile.pdf = true;

--- a/app/views/submissions/view.js.erb
+++ b/app/views/submissions/view.js.erb
@@ -5,7 +5,7 @@ newFile.symbolTree = null
 <% if !@ctag_obj.nil? && !@ctag_obj.empty? %>
 newFile.symbolTree = '<%= j render("submissions/code_symbol_tree", ctag_obj: @ctag_obj) %>'
 <% end %>
-newFile.url = '<%= url_for(params.to_unsafe_h) %>'
+newFile.url = '<%= url_for(params.permit(:action, :controller).to_h) %>'
 
 <% if @is_pdf %>
 newFile.pdf = true;

--- a/app/views/submissions/view.js.erb
+++ b/app/views/submissions/view.js.erb
@@ -5,7 +5,7 @@ newFile.symbolTree = null
 <% if !@ctag_obj.nil? && !@ctag_obj.empty? %>
 newFile.symbolTree = '<%= j render("submissions/code_symbol_tree", ctag_obj: @ctag_obj) %>'
 <% end %>
-newFile.url = '<%= url_for(params.permit(:action, :controller).to_h) %>'
+newFile.url = '<%= url_for(params.permit(:header_position, :action, :controller).to_h) %>'
 
 <% if @is_pdf %>
 newFile.pdf = true;


### PR DESCRIPTION
`to_h` will only convert the specified permitted parameters to a hashmap (and also logging unpermitted parameters in the development and test environment), while `to_unsafe_h` will convert all parameters to a hashmap. So in this case we simply specify what we need for `to_url`, and other parameters will not be passed

See more info on `to_h` vs `to_unsafe_h` at https://stackoverflow.com/questions/38710904/how-do-i-resolve-the-deprecation-warning-method-to-hash-is-deprecated-and-will.