### PR TITLE
Show Grace Days and Penalty Late Days used in gradebook

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -3,3 +3,9 @@
 //= link_directory ../stylesheets .css
 //= link highlightjs-styles/vs.css
 //= link assessments/create_edit.css
+//= link SlickGrid/2.02/slick.grid.css
+//= link SlickGrid/2.02/controls/slick.columnpicker.css
+//= link SlickGrid/2.02/slick.core.js
+//= link SlickGrid/2.02/slick.grid.js
+//= link SlickGrid/2.02/slick.dataview.js
+//= link SlickGrid/2.02/controls/slick.columnpicker.js

--- a/app/helpers/gradebook_helper.rb
+++ b/app/helpers/gradebook_helper.rb
@@ -15,7 +15,11 @@ module GradebookHelper
         sortable: true, width: 100, cssClass: "last_name",
         headerCssClass: "last_name" },
       { id: "section", name: "Sec", field: "section",
-        sortable: true, width: 50 }
+        sortable: true, width: 50 },
+      { id: "grace_days", name: "Grace Days Used", field: "grace_days",
+        sortable: true, width: 50},
+      { id: "late_days", name: "Penalty Late Days", field: "late_days",
+        sortable: true, width: 50},
     ]
 
     course.assessment_categories.each do |cat|
@@ -64,6 +68,8 @@ module GradebookHelper
       sgb_link = url_for controller: :gradebooks, action: :student, id: cud.id
 
       row = {}
+      grace_days_used = 0
+      penalty_late_days = 0
 
       row["id"] = cud.id
       row["email"] = cud.user.email
@@ -81,6 +87,9 @@ module GradebookHelper
         row["#{a.name}_submission_status"] = cell["submission_status"]
         row["#{a.name}_grade_type"] = cell["grade_type"]
         row["#{a.name}_end_at"] = cell["end_at"]
+
+        grace_days_used += cell["grace_days"]
+        penalty_late_days += cell["late_days"]
       end
 
       course.assessment_categories.each do |cat|
@@ -91,6 +100,8 @@ module GradebookHelper
       end
 
       row["course_average"] = round matrix.course_average(cud.id)
+      row["grace_days"] = grace_days_used
+      row["late_days"] = penalty_late_days
 
       rows << row
     end

--- a/app/helpers/gradebook_helper.rb
+++ b/app/helpers/gradebook_helper.rb
@@ -19,7 +19,7 @@ module GradebookHelper
       { id: "grace_days", name: "Grace Days Used", field: "grace_days",
         sortable: true, width: 50},
       { id: "late_days", name: "Penalty Late Days", field: "late_days",
-        sortable: true, width: 50},
+        sortable: true, width: 50}
     ]
 
     course.assessment_categories.each do |cat|

--- a/app/models/grade_matrix.rb
+++ b/app/models/grade_matrix.rb
@@ -126,6 +126,8 @@ private
     info["final_score"] = aud.final_score @as_seen_by
     info["grade_type"] = (AssessmentUserDatum.grade_type_to_sym aud.grade_type).to_s
     info["submission_status"] = aud.submission_status.to_s
+    info["grace_days"] = aud.grace_days_used
+    info["late_days"] = aud.penalty_late_days
 
     # TODO: need to convert this to local time on *client*
     # TODO: convert to 12-hour time


### PR DESCRIPTION
Surface GDU & PLD to instructors as a column in gradebook as well as CSV export

Course Assistants (TAs) will be able to see the columns too (for their section)

`manifest.js` file had the added lines because the updated sprockets gem needs the new entries for the gradebook to work (uh oh not good but oh well - closes #1137 )

Cursory testing indicates that the GDU & PDU feature is working right now, but should be tested further