### PR TITLE
Course Dashboard Update

### DIFF
--- a/app/views/assessments/_handin_form.html.erb
+++ b/app/views/assessments/_handin_form.html.erb
@@ -15,7 +15,7 @@
     <%   else %>
     <%     grace_late_info = "submitting #{pluralize(days_late, "day")} late using #{pluralize(days_late, "penalty late day")}" %>
     <%   end %>
-    <%   late_confirm = " and that I'm #{grace_late_info} under the late policy as defined in the syllabus" %>
+    <%   late_confirm = " and that I am #{grace_late_info} under the late policy as defined in the syllabus" %>
       <p><b>Warning:</b> Submitting late may result in the usage of a grace day or a grade penalty!</p>
     <% end %>
 

--- a/app/views/assessments/_handin_form.html.erb
+++ b/app/views/assessments/_handin_form.html.erb
@@ -9,13 +9,13 @@
     <%   days_late = (days_late / 1.day).ceil %>
     <%   grace_days_left = @aud.grace_days_usable %>
     <%   if grace_days_left >= days_late %>
-    <%     grace_late_info = "using #{pluralize(days_late, "grace day")}" %>
+    <%     grace_late_info = "submitting #{pluralize(days_late, "day")} late using #{pluralize(days_late, "grace day")}" %>
     <%   elsif grace_days_left > 0 %>
-    <%     grace_late_info = "using #{pluralize(grace_days_left, "grace day")} with #{pluralize(days_late - grace_days_left, "additional late day")}" %>
+    <%     grace_late_info = "submitting #{pluralize(days_late, "day")} late using #{pluralize(grace_days_left, "grace day")} with #{pluralize(days_late - grace_days_left, "penalty late day")}" %>
     <%   else %>
-    <%     grace_late_info = "using #{pluralize(days_late, "late day")}" %>
+    <%     grace_late_info = "submitting #{pluralize(days_late, "day")} late using #{pluralize(days_late, "penalty late day")}" %>
     <%   end %>
-    <%   late_confirm = " and that I'm submitting #{grace_late_info} under the late policy as defined in the syllabus" %>
+    <%   late_confirm = " and that I'm #{grace_late_info} under the late policy as defined in the syllabus" %>
       <p><b>Warning:</b> Submitting late may result in the usage of a grace day or a grade penalty!</p>
     <% end %>
 

--- a/app/views/assessments/_handin_form.html.erb
+++ b/app/views/assessments/_handin_form.html.erb
@@ -1,8 +1,23 @@
 <div id="<%= id %>" data-cansubmit="<%= @can_submit %> " class="card-action">
   <% if @can_submit %>
+    <% late_confirm ="" %>
+    <% grace_late_info = "" %>
 
     <% if @aud.past_due_at? %>
+    <%   currentTime = Time.zone.now %>
+    <%   days_late = currentTime - @aud.due_at + (currentTime.utc_offset - @aud.due_at.utc_offset) %>
+    <%   days_late = (days_late / 1.day).ceil %>
+    <%   grace_days_left = @aud.grace_days_usable %>
+    <%   if grace_days_left >= days_late %>
+    <%     grace_late_info = "using #{pluralize(days_late, "grace day")}" %>
+    <%   elsif grace_days_left > 0 %>
+    <%     grace_late_info = "using #{pluralize(grace_days_left, "grace day")} with #{pluralize(days_late - grace_days_left, "additional late day")}" %>
+    <%   else %>
+    <%     grace_late_info = "using #{pluralize(days_late, "late day")}" %>
+    <%   end %>
+    <%   late_confirm = " and that I'm submitting #{grace_late_info} under the late policy as defined in the syllabus" %>
       <p><b>Warning:</b> Submitting late may result in the usage of a grace day or a grade penalty!</p>
+      <!-- <p>You are currently <b><%= "#{days_late}"%></b> days late and you have <b><%= "#{@aud.grace_days_usable}"%></b> grace days left.</p> -->
     <% end %>
 
     <div class="row">
@@ -13,7 +28,7 @@
             <!-- Academic integrity checkbox -->
             <%= label_tag(:integrity_checkbox) do %>
                 <%= check_box_tag(:integrity_checkbox) %>
-                <%= content_tag("span", "I affirm that I have complied with this course's academic integrity policy as defined in the syllabus.") %>
+                <%= content_tag("span", "I affirm that I have complied with this course's academic integrity policy as defined in the syllabus#{late_confirm}.") %>
             <% end %>
 
             <% if @aud.past_due_at? then %>
@@ -203,7 +218,7 @@
 
 						<%= label_tag(:integrity_checkbox) do %>
 							<%= check_box_tag(:integrity_checkbox) %>
-							<%= content_tag("span", "I affirm that I have complied with this course's academic integrity policy as defined in the syllabus.") %>
+							<%= content_tag("span", "I affirm that I have complied with this course's academic integrity policy as defined in the syllabus#{late_confirm}.") %>
 						<% end %>
 
             <%= f.file_field :file %>
@@ -217,7 +232,8 @@
             </div>
             <div class="row">
               <div class="smallText col s6 offset-s6 m4 offset-m8 center-align" style="padding-top: 6px">
-                <%= remainingSubmissionsMsg(@submissions, @assessment) %>
+                <%= remainingSubmissionsMsg(@submissions, @assessment) %><br>
+                <b><%= grace_late_info %></b>
               </div>
             </div>
           <% end %>

--- a/app/views/assessments/_handin_form.html.erb
+++ b/app/views/assessments/_handin_form.html.erb
@@ -17,7 +17,6 @@
     <%   end %>
     <%   late_confirm = " and that I'm submitting #{grace_late_info} under the late policy as defined in the syllabus" %>
       <p><b>Warning:</b> Submitting late may result in the usage of a grace day or a grade penalty!</p>
-      <!-- <p>You are currently <b><%= "#{days_late}"%></b> days late and you have <b><%= "#{@aud.grace_days_usable}"%></b> grace days left.</p> -->
     <% end %>
 
     <div class="row">


### PR DESCRIPTION
This PR creates the user interface for the course dashboard, adds the column "website" for course, and has updated the edit and update view pages accordingly. Currently, the course dashboard looks as below.
![Screen Shot 2020-04-23 at 5 43 38 PM](https://user-images.githubusercontent.com/54905587/80152689-26228900-858a-11ea-92d3-1adb10b2620f.png)
![Screen Shot 2020-04-23 at 5 44 19 PM](https://user-images.githubusercontent.com/54905587/80152694-2753b600-858a-11ea-8136-c87e9bb2ab65.png)
The website button is enabled only if the instructor has set a non-trivial website. But here's a design concern: Right now instructors are enforced to enter a link with leading "https://", which is the easiest way for rails to handle. But should we make it more flexible?
Another concern: The gradebook button is not removed from _navbar.html.erb since it actually shows up on other non-course-dashboard page as well. Since it's part of the application layout, I don't consider changing it a good idea. But that gives us two gradebook buttons on the course dashboard. What do you think?
Thanks in advance!