### PR TITLE
Check for malformed handins early

### DIFF
--- a/app/controllers/assessment/handin.rb
+++ b/app/controllers/assessment/handin.rb
@@ -301,6 +301,14 @@ private
   # submission file is okay to submit.
   #
   def validateHandin_forHTML
+    if params[:submission].blank?
+        flash[:error] = "Submission was blank - please upload again."
+        return false
+    end
+    if params[:submission]["file"].blank?
+        flash[:error] = "Submission was blank (file upload missing) - please upload again."
+        return false
+    end
     # check for custom form first
 		if @assessment.has_custom_form
       for i in 0..@assessment.getTextfields.size-1

--- a/app/controllers/assessment/handin.rb
+++ b/app/controllers/assessment/handin.rb
@@ -310,7 +310,7 @@ private
         return false
     end
     # check for custom form first
-		if @assessment.has_custom_form
+    if @assessment.has_custom_form
       for i in 0..@assessment.getTextfields.size-1
           if params[:submission][("formfield" + (i+1).to_s).to_sym].blank?
             flash[:error] = @assessment.getTextfields[i] + " is a required field."


### PR DESCRIPTION
`validateHandin_forHTML` needs to check for malformed handins or missing handin files before dereferencing `params[:submission]`

For the original commit see https://github.com/cg2v/Autolab/commit/df5e132d63eb25dade8911329ffb2cc777da4baa

Addresses #1134, but we should also look into why dragging and dropping files sometimes fail to upload correctly