### PR TITLE
Remove errant newline from manage_submissions.js

### DIFF
--- a/app/assets/javascripts/manage_submissions.js
+++ b/app/assets/javascripts/manage_submissions.js
@@ -35,8 +35,7 @@ jQuery(function($) {
     'sPaginationType': 'full_numbers',
     'iDisplayLength': 100,
     'oLanguage': {
-      'sLengthMenu':'
-      <label><input type="checkbox" id="only-latest">' +
+      'sLengthMenu':'<label><input type="checkbox" id="only-latest">' +
         '<span>Show only latest</span></label>'
     },
     "columnDefs": [{


### PR DESCRIPTION
Commit a94f7cb6581fe3d4826449075b4fd17a9eb19c2b inserted a newline into a string literal. This is not allowed inside '' or "". This causes an Uncaught SyntaxError: Invalid or unexpected token when navigating to /courses/x/assessments/y/submissions and also prevents asset precompilation from succeeding