### PR TITLE
Course dashboard update #2

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -447,7 +447,7 @@ private
   end
 
   def edit_course_params
-    params.require(:editCourse).permit(:name, :semester, :late_slack, :grace_days, :display_name, :start_date, :end_date,
+    params.require(:editCourse).permit(:name, :semester, :website, :late_slack, :grace_days, :display_name, :start_date, :end_date,
                                        :disabled, :exam_in_progress, :version_threshold, :gb_message,
                                        late_penalty_attributes: [:kind, :value],
                                        version_penalty_attributes: [:kind, :value])

--- a/app/models/assessment_user_datum.rb
+++ b/app/models/assessment_user_datum.rb
@@ -224,6 +224,10 @@ class AssessmentUserDatum < ApplicationRecord
     connection.execute insert_sql
   end
 
+  def global_cumulative_grace_days_used
+    cumulative_grace_days_used
+  end
+
 protected
 
   def cumulative_grace_days_used

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -10,6 +10,8 @@ class Course < ApplicationRecord
   validates_numericality_of :version_threshold, only_integer: true, greater_than_or_equal_to: -1
   validate :order_of_dates
   validates_format_of :name, with: /\A(\w|-)+\z/, on: :create
+  # validates course website format if there exists one
+  validate :valid_website?
 
   has_many :course_user_data, dependent: :destroy
   has_many :assessments, dependent: :destroy
@@ -106,6 +108,19 @@ class Course < ApplicationRecord
 
   def order_of_dates
     errors.add(:start_date, "must come before end date") if start_date > end_date
+  end
+
+  def valid_website?
+    if website.nil? || website.eql?("")
+      return true
+    else
+      if website[0..7].eql?("https://")
+        return true
+      else
+        errors.add("website", "needs to start with https://")
+        return false
+      end
+    end
   end
 
   def temporal_status(now = DateTime.now)

--- a/app/models/course_user_datum.rb
+++ b/app/models/course_user_datum.rb
@@ -161,6 +161,15 @@ class CourseUserDatum < ApplicationRecord
       return "student"
     end
   end
+  
+  def global_grace_days_left
+    course = Course.find_by(id: course_id)
+    latest_asmt = course.assessments.ordered.last
+    return course.grace_days if latest_asmt.nil?
+    cur_aud = AssessmentUserDatum.where(course_user_datum_id: id, assessment_id: latest_asmt.id).first
+    return course.grace_days if cur_aud.nil?
+    return (course.grace_days - cur_aud.global_cumulative_grace_days_used)
+  end
 
   #
   # User Attribute Wrappers - these functions get attributes from the CUD's

--- a/app/views/assessments/index.html.erb
+++ b/app/views/assessments/index.html.erb
@@ -27,12 +27,37 @@
     <p class="attention">An exam is in progress. Uncheck Admin > Edit Course > Exam In Progress after it's administered.</p>
 <% end %>
 
+<!-- General course information including COURSE NAME, (COURSE WEB),
+     SECTION NAME, GRACE DAY INFO -->
+
+<div class="row" style="margin-bottom: 0; padding-top: 20px">
+  <div class="col s12 m12" style="margin-bottom: 0">
+    <div class="card" style="margin-bottom: 0">
+      <div class="card-content white">
+       <span class="card-title black-text" style="font-size: 40px"><b><%= "#{@course.display_name} (#{@course.semester})" %></b></span>
+       <h3 style="border-bottom: 4px solid #dddddd"></h3>
+          <p style="font-size: 18px">Section: <b><%= "#{@cud.section}" %></b></p>
+          <p style="font-size: 18px">Number of grace days remaining: <b><%="#{@cud.global_grace_days_left}"%></b></p></br>
+          <% if @course.website.nil? || @course.website.eql?("") %>
+          <span class="btn btn-large disabled"><%= "<i class='material-icons left'>web</i> Course Website".html_safe %></span>
+          <% else %>
+          <%= link_to "<i class='material-icons left'>web</i> Course Website".html_safe, @course.website, target: "_blank", title: "Go to course website", :class => "btn btn-large red darken-3" %>
+          <% end %>
+          <% if @cud.instructor? || !(@cud.course_assistant? && !@cud.section.blank?) %>
+           <%= link_to "<i class='material-icons left'>assessment</i> Gradebook".html_safe, [@course, @cud, :gradebook], title: "View your gradebook", :class => "btn btn-large red darken-3" %>
+          <% end %>
+      </div>
+      </div>
+    </div>
+  </div>
+</div>
+
 <% if @is_instructor %>
 <div class="section">
   <h3 class="section-title"><span class="white">Instructor Actions</span></h4>
-  <%= link_to 'Install Assessment',
+  <span style="padding-left: 10px"><%= link_to 'Install Assessment',
                     {:action=>"installAssessment"},
-                    {:title=>"Install Assessment", :class => "btn btn-large red darken-3" } %>
+                    {:title=>"Install Assessment", :class => "btn btn-large red darken-3" } %></span>
 
 <% end %>
 

--- a/app/views/courses/_courseFields.html.erb
+++ b/app/views/courses/_courseFields.html.erb
@@ -10,6 +10,9 @@
   help_text: "Descriptive course name for displaying. Example: 15-213: Intro to
   Computer Systems" %>
 
+<%= f.text_field :website,
+  help_text: "Official course website. Example: https://www.cs.cmu.edu/~213/" %>
+
 <%= f.text_field :late_slack,
   help_text: "This is the number of seconds after a deadline that the server
   will still accept a submission and not count it as late. Example: 3600" %>

--- a/db/migrate/20200423012337_add_website_to_course.rb
+++ b/db/migrate/20200423012337_add_website_to_course.rb
@@ -1,0 +1,9 @@
+class AddWebsiteToCourse < ActiveRecord::Migration[5.2]
+  def up
+  	add_column :courses, :website, :string
+  end
+
+  def down
+  	remove_column :courses, :website
+  end
+end


### PR DESCRIPTION
This PR adds the course dashboard feature to the Autolab application. Compared with the previous PR, this one fixes the following issues:
1. Grace day calculation scheme is corrected. Current scheme: find the latest assessment of the course (the last one in the dependency chain of the assessments), get the corresponding assessment user datum and the number of grace days used cumulatively up until that assessment, and subtract that number from the course grace day number. When there is no assessment, the number of course grace days is returned.
2. When the course website button is clicked on the dashboard, it will create a new tab, instead of refreshing the current tab directly.

I tested locally by creating a new course with three assessments that are past deadline. After submitting for each assessment, I come back to check the new grace day number displayed on the dashboard and it seems to be consistent this time. But further testing is needed. Once this PR is approved, I will close the old one and delete the other compromised branch. Thanks! 