### PR TITLE
production.rb.template fixes 

### DIFF
--- a/app/assets/javascripts/manage_submissions.js
+++ b/app/assets/javascripts/manage_submissions.js
@@ -35,8 +35,7 @@ jQuery(function($) {
     'sPaginationType': 'full_numbers',
     'iDisplayLength': 100,
     'oLanguage': {
-      'sLengthMenu':'
-      <label><input type="checkbox" id="only-latest">' +
+      'sLengthMenu':'<label><input type="checkbox" id="only-latest">' +
         '<span>Show only latest</span></label>'
     },
     "columnDefs": [{

--- a/config/environments/production.template.rb
+++ b/config/environments/production.template.rb
@@ -15,7 +15,8 @@ Autolab3::Application.configure do
 
   config.assets.enabled = true
   # Compress JavaScripts and CSS
-  config.assets.js_compressor = :uglifier
+  config.assets.js_compressor = :uglify
+  # config.assets.js_compressor = Uglifier.new(harmony: true)
   config.assets.css_compressor = :sass
 
   # Don't fallback to assets pipeline if a precompiled asset is missed
@@ -52,6 +53,7 @@ Autolab3::Application.configure do
   # config.action_controller.asset_host = "http://assets.example.com"
 
   # Precompile additional assets (application.js, application.css, and all non-JS/CSS are already added)
+  byebug
   config.assets.precompile << /(^[^_\/]|\/[^_])[^\/]*$/
 
   # Disable delivery errors, bad email addresses will be ignored

--- a/config/environments/production.template.rb
+++ b/config/environments/production.template.rb
@@ -15,8 +15,7 @@ Autolab3::Application.configure do
 
   config.assets.enabled = true
   # Compress JavaScripts and CSS
-  config.assets.js_compressor = :uglify
-  # config.assets.js_compressor = Uglifier.new(harmony: true)
+  config.assets.js_compressor = Uglifier.new(harmony: true)
   config.assets.css_compressor = :sass
 
   # Don't fallback to assets pipeline if a precompiled asset is missed
@@ -51,10 +50,6 @@ Autolab3::Application.configure do
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server
   # config.action_controller.asset_host = "http://assets.example.com"
-
-  # Precompile additional assets (application.js, application.css, and all non-JS/CSS are already added)
-  byebug
-  config.assets.precompile << /(^[^_\/]|\/[^_])[^\/]*$/
 
   # Disable delivery errors, bad email addresses will be ignored
   # config.action_mailer.raise_delivery_errors = false

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -8,7 +8,6 @@ Rails.application.config.assets.version = '1.0'
 
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in app/assets folder are already added.
-# Rails.application.config.assets.precompile += %w( search.js )
 Rails.application.config.assets.precompile += %w( *.js )
 Rails.application.config.assets.precompile += %w( animate.css )
 Rails.application.config.assets.precompile += %w( gradesheet.css.scss )


### PR DESCRIPTION
This PR fixes some issues with production.rb.template that causes assets pre-compilation to fail, mentioned in https://github.com/autolab/Autolab/issues/1142

The `config.assets.precompile` was removed since we already specify the list of all assets to precompile in assets.rb, and it is therefore no longer necessary