### PR TITLE
Guard against nil error in Gradebook

### DIFF
--- a/app/helpers/gradebook_helper.rb
+++ b/app/helpers/gradebook_helper.rb
@@ -88,6 +88,11 @@ module GradebookHelper
         row["#{a.name}_grade_type"] = cell["grade_type"]
         row["#{a.name}_end_at"] = cell["end_at"]
 
+        grace_days += cell["grace_days"]
+        late_days += cell["late_days"]
+        # Specify default option of 0, because it is possible to end up getting
+        # a cell that contains nil sometimes. Currently all other row entries above
+        # are able to accept nil values.
         grace_days += cell["grace_days"] || 0
         late_days += cell["late_days"] || 0
       end

--- a/app/helpers/gradebook_helper.rb
+++ b/app/helpers/gradebook_helper.rb
@@ -88,8 +88,8 @@ module GradebookHelper
         row["#{a.name}_grade_type"] = cell["grade_type"]
         row["#{a.name}_end_at"] = cell["end_at"]
 
-        grace_days += cell["grace_days"]
-        late_days += cell["late_days"]
+        grace_days += cell["grace_days"] || 0
+        late_days += cell["late_days"] || 0
       end
 
       course.assessment_categories.each do |cat|

--- a/app/helpers/gradebook_helper.rb
+++ b/app/helpers/gradebook_helper.rb
@@ -88,8 +88,6 @@ module GradebookHelper
         row["#{a.name}_grade_type"] = cell["grade_type"]
         row["#{a.name}_end_at"] = cell["end_at"]
 
-        grace_days += cell["grace_days"]
-        late_days += cell["late_days"]
         # Specify default option of 0, because it is possible to end up getting
         # a cell that contains nil sometimes. Currently all other row entries above
         # are able to accept nil values.


### PR DESCRIPTION
This guards against the issue
```
  nil can't be coerced into Integer
  app/helpers/gradebook_helper.rb:91:in `+'
```
when we get a reference to an empty cell. I'm guessing this is most likely due to deletion of data somewhere that got it into an inconsistent state. Unfortunately, I have tried to delete an assessment with submissions but was not able to replicate the error. 