### PR TITLE
Hide contents of binary files on speedgrader

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ env:
         - secure: Z6YE6NuDeuraasd5gFG+x7PU3rKxhLjL6VZ7HJfZJEVyxFucRz8Hv4xlxkQV3P61w6S0uyp/reXwKy8meYAQLzVZ4pBpK7sEeSZ5w00WRH8NCGeMJmwdQi2JLCYRZ/KdOc0o5l5bbND+JG1o/U9HtG2cHO2G8M6hVGbARn+ywLg=
 before_script:
     - AUTOLAB=`pwd`; echo $AUTOLAB;
-    - sudo apt-get install libmagic-dev
     - cd $AUTOLAB
     - cp config/initializers/devise.rb.template config/initializers/devise.rb
     - mv config/database.travis.yml config/database.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ env:
         - secure: Z6YE6NuDeuraasd5gFG+x7PU3rKxhLjL6VZ7HJfZJEVyxFucRz8Hv4xlxkQV3P61w6S0uyp/reXwKy8meYAQLzVZ4pBpK7sEeSZ5w00WRH8NCGeMJmwdQi2JLCYRZ/KdOc0o5l5bbND+JG1o/U9HtG2cHO2G8M6hVGbARn+ywLg=
 before_script:
     - AUTOLAB=`pwd`; echo $AUTOLAB;
+    - sudo apt-get install libmagic-dev
     - cd $AUTOLAB
     - cp config/initializers/devise.rb.template config/initializers/devise.rb
     - mv config/database.travis.yml config/database.yml

--- a/Gemfile
+++ b/Gemfile
@@ -131,3 +131,6 @@ gem 'net-ldap'
 gem 'sprockets-rails', '>=3.2.1'
 
 gem "jstz-rails3-plus", ">= 1.0"
+
+# For getting file types 
+gem 'ruby-filemagic', '>= 0.7.2'

--- a/Gemfile
+++ b/Gemfile
@@ -133,4 +133,4 @@ gem 'sprockets-rails', '>=3.2.1'
 gem "jstz-rails3-plus", ">= 1.0"
 
 # For getting file types 
-gem 'ruby-filemagic', '>= 0.7.2'
+gem 'mimemagic', '>= 0.3.5'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -154,7 +154,7 @@ GEM
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2019.1009)
-    mimemagic (0.3.4)
+    mimemagic (0.3.5)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     mini_racer (0.2.9)
@@ -271,7 +271,6 @@ GEM
       rexml
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 2.0)
-    ruby-filemagic (0.7.2)
     ruby-progressbar (1.10.1)
     ruby-rc4 (0.1.5)
     rubyzip (2.3.0)
@@ -354,6 +353,7 @@ DEPENDENCIES
   js_cookie_rails
   jstz-rails3-plus (>= 1.0)
   materialize-sass
+  mimemagic (>= 0.3.5)
   mini_racer
   momentjs-rails (>= 2.9.0)
   mysql2 (~> 0.4.10)
@@ -372,7 +372,6 @@ DEPENDENCIES
   rake (>= 10.3.2)
   rspec-rails (>= 3.5.0)
   rubocop
-  ruby-filemagic (>= 0.7.2)
   rubyzip
   sass-rails (>= 4.0.3)
   sdoc (>= 0.4.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -271,6 +271,7 @@ GEM
       rexml
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 2.0)
+    ruby-filemagic (0.7.2)
     ruby-progressbar (1.10.1)
     ruby-rc4 (0.1.5)
     rubyzip (2.3.0)
@@ -371,6 +372,7 @@ DEPENDENCIES
   rake (>= 10.3.2)
   rspec-rails (>= 3.5.0)
   rubocop
+  ruby-filemagic (>= 0.7.2)
   rubyzip
   sass-rails (>= 4.0.3)
   sdoc (>= 0.4.0)
@@ -387,4 +389,4 @@ RUBY VERSION
    ruby 2.6.3p62
 
 BUNDLED WITH
-   1.17.2
+   1.17.3

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -322,12 +322,8 @@ class SubmissionsController < ApplicationController
       @displayFilename = @submission.filename
     end
 
-    filetype = FileMagic.open(:mime) { |fm|
-      fm.buffer(file)
-    }
-
-    # Do not display binary files, unless if they are PDF
-    if (filetype =~ /pdf/).nil? and (filetype =~ /(binary|executable)/).present?
+    mm = MimeMagic.by_magic(file)
+    if not mm.text? and not mm.subtype == "pdf"
         file = "Binary file not displayed"
     end
 

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -309,15 +309,6 @@ class SubmissionsController < ApplicationController
         redirect_to [@course, @assessment] and return false
       end
 
-      filetype = FileMagic.open(:mime) { |fm|
-        fm.buffer(file)
-      }
-
-      # Do not display binary files
-      if not (filetype =~ /(binary|executable)/).nil?
-        file = "Binary file not displayed"
-      end
-
       @displayFilename = pathname
     else
       # auto-set header position for archives
@@ -330,6 +321,16 @@ class SubmissionsController < ApplicationController
 
       @displayFilename = @submission.filename
     end
+
+    filetype = FileMagic.open(:mime) { |fm|
+      fm.buffer(file)
+    }
+
+    # Do not display binary files, unless if they are PDF
+    if (filetype =~ /pdf/).nil? and (filetype =~ /(binary|executable)/).present?
+        file = "Binary file not displayed"
+    end
+
     return unless file
 
     if !PDF.pdf?(file)

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -309,6 +309,15 @@ class SubmissionsController < ApplicationController
         redirect_to [@course, @assessment] and return false
       end
 
+      filetype = FileMagic.open(:mime) { |fm|
+        fm.buffer(file)
+      }
+
+      # Do not display binary files
+      if not (filetype =~ /(binary|executable)/).nil?
+        file = "Binary file not displayed"
+      end
+
       @displayFilename = pathname
     else
       # auto-set header position for archives

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -322,12 +322,14 @@ class SubmissionsController < ApplicationController
       @displayFilename = @submission.filename
     end
 
-    mm = MimeMagic.by_magic(file)
-    if not mm.text? and not mm.subtype == "pdf"
-        file = "Binary file not displayed"
-    end
-
     return unless file
+
+    mm = MimeMagic.by_magic(file)
+    if mm.present?
+      if not mm.text? and not mm.subtype == "pdf"
+        file = "Binary file not displayed"
+      end
+    end
 
     if !PDF.pdf?(file)
       # begin


### PR DESCRIPTION
This fixes the issue where we obtain an error when navigating to binary files on the Speedgrader interface:

`submissions view (ActionView::Template::Error) "invalid byte sequence in UTF-8"`

This is achieved by simply not displaying the invalid byte sequences at all, as they are binary and not UTF-8 formatted. Instead, a message "Binary files not displayed" is shown. This also helps to improve overall user experience, and speed up loading times when users accidentally navigate to a large binary file.

Original UI:
![DeepinScreenshot_select-area_20200514163751](https://user-images.githubusercontent.com/9707110/81912623-67dea680-9601-11ea-859b-12274f418e4f.png)

After this fix:
![DeepinScreenshot_select-area_20200514163806](https://user-images.githubusercontent.com/9707110/81912746-98264500-9601-11ea-85a8-32278e9d26ca.png)
