### PR TITLE
Fixes month selection not showing on the edit assessment handin tab / Fixes travis issue with regards to migration happening after setup.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,8 @@ before_script:
 #    - mysql -e "SET GLOBAL sql_mode=(SELECT REPLACE(@@sql_mode,'ONLY_FULL_GROUP_BY',''));"
     - RAILS_ENV=test bundle exec rails generate devise:install --skip --quiet
     - RAILS_ENV=test bundle exec rake db:create --trace
-    - RAILS_ENV=test bundle exec rake db:setup --trace
     - RAILS_ENV=test bundle exec rake db:migrate --trace
+    - RAILS_ENV=test bundle exec rake db:setup --trace
     - RAILS_ENV=test bundle exec rake autolab:populate
 script:
     - RAILS_ENV=test CODECLIMATE_REPO_TOKEN=d37a8b9e09642cb73cfcf4ecfb4115fc3d6a55a7714110187ac59856ae4ab5ad

--- a/app/assets/stylesheets/style.css.scss
+++ b/app/assets/stylesheets/style.css.scss
@@ -806,6 +806,10 @@ input[type=search] {
   padding-top: 0 !important;
 }
 
+.flatpickr-monthDropdown-months {
+  display: inline;
+}
+ 
 .chosen-search input {
   box-sizing: border-box;
 }


### PR DESCRIPTION
Originally the month is hidden due to inheritance from materialize-css
![image](https://user-images.githubusercontent.com/5773562/81999940-59d46880-9689-11ea-89f6-3708c85ce1ce.png)

This PR addresses it by overriding the css inherited
![image](https://user-images.githubusercontent.com/5773562/81999952-6789ee00-9689-11ea-91d9-dd5b5d7f43d8.png)
