### PR TITLE
Caching Global Grace Days

### DIFF
--- a/app/models/assessment_user_datum.rb
+++ b/app/models/assessment_user_datum.rb
@@ -143,6 +143,7 @@ class AssessmentUserDatum < ApplicationRecord
 
   # TODO
   # Refer to https://github.com/autolab/autolab-src/wiki/Caching
+  # invalidate ggl for cud as well
   def invalidate_cgdubs_for_assessments_after
     CourseUserDatum.transaction do
       # acquire lock
@@ -152,6 +153,9 @@ class AssessmentUserDatum < ApplicationRecord
       auds_for_assessments_after.each do |aud|
         Rails.cache.delete aud.cgdub_cache_key
       end
+
+      cud = CourseUserDatum.find_by(id: course_user_datum_id)
+      Rails.cache.delete cud.ggl_cache_key
     end # release lock
   end
 

--- a/app/models/assessment_user_datum.rb
+++ b/app/models/assessment_user_datum.rb
@@ -22,8 +22,6 @@ class AssessmentUserDatum < ApplicationRecord
   #   submissions associated with AUDs with Zeroed and Excused grade types aren't counted as late
   #   even if they were submitted past the due date whereas Normal grade type AUD submissions are.
   after_save :invalidate_cgdubs_for_assessments_after, if: :saved_change_to_latest_submission_id? or :saved_change_to_grade_type?
-  # after_save :invalidate_cgdubs_for_assessments_after, if: :latest_submission_id_changed?
-  # after_save :invalidate_cgdubs_for_assessments_after, if: :grade_type_changed?
 
   NORMAL = 0
   ZEROED = 1

--- a/app/models/assessment_user_datum.rb
+++ b/app/models/assessment_user_datum.rb
@@ -144,6 +144,7 @@ class AssessmentUserDatum < ApplicationRecord
   # TODO
   # Refer to https://github.com/autolab/autolab-src/wiki/Caching
   def invalidate_cgdubs_for_assessments_after
+    # puts "INVALIDATING CGDUBS"
     CourseUserDatum.transaction do
       # acquire lock
       CourseUserDatum.lock(true).find(course_user_datum_id)
@@ -153,8 +154,7 @@ class AssessmentUserDatum < ApplicationRecord
         Rails.cache.delete aud.cgdub_cache_key
       end
 
-      cud = CourseUserDatum.find_by(id: course_user_datum_id)
-      Rails.cache.delete cud.ggl_cache_key
+      Rails.cache.delete course_user_datum.ggl_cache_key
     end # release lock
   end
 
@@ -262,6 +262,7 @@ private
     cache_key = cgdub_cache_key
     
     unless (cgdub = Rails.cache.read cache_key)
+      # puts "FRESHLY CALCULATED CGDUB"
       CourseUserDatum.transaction do
         # acquire lock on user
         CourseUserDatum.lock(true).find(course_user_datum_id)
@@ -283,6 +284,8 @@ private
         end
         Rails.cache.write(ggl_cache_key, ggl)
       end # release lock
+    # else
+      # puts "READ FROM CACHE CGDUB"
     end
 
     @cgdub = cgdub

--- a/app/models/assessment_user_datum.rb
+++ b/app/models/assessment_user_datum.rb
@@ -145,7 +145,6 @@ class AssessmentUserDatum < ApplicationRecord
   # TODO
   # Refer to https://github.com/autolab/autolab-src/wiki/Caching
   def invalidate_cgdubs_for_assessments_after
-    puts "INVALIDATING CGDUBS"
     CourseUserDatum.transaction do
       # acquire lock
       CourseUserDatum.lock(true).find(course_user_datum_id)

--- a/app/models/course_user_datum.rb
+++ b/app/models/course_user_datum.rb
@@ -168,9 +168,15 @@ class CourseUserDatum < ApplicationRecord
     cache_key = ggl_cache_key
 
     unless (ggl = Rails.cache.read cache_key)
-      ggl = global_grace_days_left!
-      # puts "FRESHLY CALCULATED"
-    else
+      CourseUserDatum.transaction do
+        reload(lock: true)
+
+        ggl = global_grace_days_left!
+        # puts "FRESHLY CALCULATED"
+
+        Rails.cache.write(ggl_cache_key, ggl)
+      end # release lock
+    # else
       # puts "READ FROM CACHE"
     end
 

--- a/app/models/course_user_datum.rb
+++ b/app/models/course_user_datum.rb
@@ -169,6 +169,9 @@ class CourseUserDatum < ApplicationRecord
 
     unless (ggl = Rails.cache.read cache_key)
       ggl = global_grace_days_left!
+      # puts "FRESHLY CALCULATED"
+    else
+      # puts "READ FROM CACHE"
     end
 
     @ggl = ggl


### PR DESCRIPTION
1. This PR adds the caching feature for global grace days left on the course dashboard. This is achieved similar to how cgdub (cumulative grace days used before) is cached in assessment_user_datum.rb. Writing to cache is done in course_user_datum.rb when the number of global grace days is requested. 
2. Deleting from cache is performed along with the update of latest_submission in assessment_user_datum.rb. I have tested locally by enabling the caching feature and putting in print statements to indicate whether the quantity is freshly calculated or not (I have commented out the print statements but please feel free to uncomment to test on your end!). It seems to be working fine when the submissions to the assessment follow the assessment dependency chain order.
3. However, suppose I have asmt2 whose previous assessment is asmt1, then submitting to asmt1 after asmt2 does not correctly update the global grace days left, even though the printing record indicates that the previous global grace days has been correctly deleted. I've spent some time testing and the conclusion is that invalidate_cgdubs_for_assessments_after is not executed after latest_submission_id has changed. I don't really understand why and am not sure if this is just a local problem on my end. This PR is definitely not ready due to this issue so I've pushed it here to ask for help. Any insight would be greatly appreciated!
(4. Once the problem is solved and everything is tested, I will clean up the code a little bit! Sorry for the comments everywhere.)