### PR TITLE
Fixes issue where released grades aren't shown on handin page

### DIFF
--- a/app/controllers/assessments_controller.rb
+++ b/app/controllers/assessments_controller.rb
@@ -486,7 +486,7 @@ class AssessmentsController < ApplicationController
         score: result["score"].to_f,
         feedback: result["feedback"],
         score_id: result["score_id"].to_i,
-        released: (result["released"] == "t") ? 1 : 0 # converts 't' to 1, everything else to 0
+        released: Utilities.is_truthy?(result["released"]) ? 1 : 0 # converts 't' to 1, "f" to 0
       }
     end
 

--- a/app/controllers/assessments_controller.rb
+++ b/app/controllers/assessments_controller.rb
@@ -475,7 +475,7 @@ class AssessmentsController < ApplicationController
               .joins("LEFT JOIN scores ON
         (submissions.id = scores.submission_id
         AND problems.id = scores.problem_id)")
-
+    
     # Process them to get into a format we want.
     @scores = {}
     for result in results do
@@ -486,7 +486,7 @@ class AssessmentsController < ApplicationController
         score: result["score"].to_f,
         feedback: result["feedback"],
         score_id: result["score_id"].to_i,
-        released: result["released"].to_i
+        released: (result["released"] == "t") ? 1 : 0 # converts 't' to 1, everything else to 0
       }
     end
 


### PR DESCRIPTION
Fixes the stated issue, by replacing to_i in assessment_controller. Because to_i no longer works to convert "t" to 1 and "f" to 0. 

![image](https://user-images.githubusercontent.com/5773562/82668089-9f85c800-9c6b-11ea-80df-a03ce179c1e2.png)
