### PR TITLE
Remove duplicated import of Materialize

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -15,7 +15,6 @@
 //= require moment
 //= require bootstrap-datetimepicker
 //= require app-level
-//= require materialize
 //= require materialize-sprockets
 //= require js.cookie
 //= require jstz


### PR DESCRIPTION
I chose to keep `materialize-sprockets` since it provides "individual Materialize components for ease of debugging" (see [docs](https://github.com/mkhairi/materialize-sass#b-javascript))

Closes #1174