### PR TITLE
Handin history late days used

### DIFF
--- a/app/assets/stylesheets/style.css.scss
+++ b/app/assets/stylesheets/style.css.scss
@@ -1185,3 +1185,6 @@ div.center {
   padding: 0 0 5px 15px;
 }
 
+.nobr {
+  white-space: nowrap;
+}

--- a/app/views/assessments/_submission_history_row.html.erb
+++ b/app/views/assessments/_submission_history_row.html.erb
@@ -43,7 +43,9 @@
 
   <% if @course.grace_days >= 0 then %>
     <td title="Submitted <%= submission.days_late %> days late" >
-      </nobr>
+      <span class="nobr">
+      <%= "Submitted #{submission.days_late} days late" %>
+      </span>
     </td>
   <% end %>
 

--- a/app/views/assessments/_submission_summary_row.html.erb
+++ b/app/views/assessments/_submission_summary_row.html.erb
@@ -91,7 +91,9 @@
 
   <% if @course.grace_days >= 0 then %>
     <td title="Submitted <%= submission.days_late %> days late" >
-      </nobr>
+      <span class="nobr">
+      <%= "Submitted #{submission.days_late} days late" %>
+      </span>
     </td>
   <% end %>
 


### PR DESCRIPTION
This PR addresses the issue in #1173. The issue was probably due to a lack of content in between the td tags in _submission_history_row.html.erb and _submission_summary_row.html.erb so I've added the information back in. In addition, the Internet seems to be mixed about the use of nobr tag in HTML (https://stackoverflow.com/questions/28532076/why-is-the-nobr-deprecated). I decided to keep it the way it is in HTML but we also have the option of redefining it in style.css.scss. Does anybody have any strong opinion about this? I tested by randomly navigating to handin history page and assessment index page. It seems to yield the content fine. Further check is needed.