### PR TITLE
Tentative radio button fix

### DIFF
--- a/app/views/assessment_user_data/edit.html.erb
+++ b/app/views/assessment_user_data/edit.html.erb
@@ -3,20 +3,26 @@
 
   <%= form_for @aud, :url => { :action => :update } do |f| %>
     <%= f.error_messages %>
-
+      
       <p>
-        <%= f.radio_button :grade_type, AssessmentUserDatum::NORMAL %>
-        <%= f.label :grade_type, "Normal", :value => AssessmentUserDatum::NORMAL %>
+        <%= f.label(:grade_type, :value => AssessmentUserDatum::NORMAL) do %>
+          <%= f.radio_button :grade_type, AssessmentUserDatum::NORMAL %>
+          <span>Normal</span>
+        <% end %>
       </p>
 
       <p>
-        <%= f.radio_button :grade_type, AssessmentUserDatum::ZEROED %>
-        <%= f.label :grade_type, "Zeroed", :value => AssessmentUserDatum::ZEROED %>
+        <%= f.label(:grade_type, :value => AssessmentUserDatum::ZEROED) do %>
+          <%= f.radio_button :grade_type, AssessmentUserDatum::ZEROED %>
+          <span>Zero</span>
+        <% end %>
       </p>
 
       <p>
-        <%= f.radio_button :grade_type, AssessmentUserDatum::EXCUSED %>
-        <%= f.label :grade_type, "Excused", :value => AssessmentUserDatum::EXCUSED %>
+        <%= f.label(:grade_type, :value => AssessmentUserDatum::EXCUSED) do %>
+          <%= f.radio_button :grade_type, AssessmentUserDatum::EXCUSED %>
+          <span>Excused</span>
+        <% end %>
       </p>
 
     <%= f.submit "Save" , {:class=>"btn primary"} %>

--- a/app/views/assessments/_bulkGrade_initial.html.erb
+++ b/app/views/assessments/_bulkGrade_initial.html.erb
@@ -13,19 +13,18 @@ Choose a file that contain rows of problem scores or feedback in the following c
     <%= f.file_field :file %>
 
     <div class="radio">
-      <label>
+      <%= f.label(:data_type_scores) do %>
         <%= f.radio_button :data_type, "scores", { :checked => true } %>
-        <label for="upload_data_type_scores">Scores</label>	
-		<!-- Scores -->
-      </label>
+        <span>Scores</span>
+      <% end %>
     </div>
 
     <div class="radio">
-      <label>
+      <%= f.label(:data_type_feedback) do %>
         <%= f.radio_button :data_type, "feedback" %>
-		<label for="upload_data_type_feedback">Feedback</label></br>
+		<span>Feedback</span></br>
 		<span class="info">use escape characters in place of newlines (\n) and tabs (\t)</span>
-      </label>
+      <% end %>
     </div>
   </div>
 


### PR DESCRIPTION
This PR addresses issue #1172. The issue was due to an inappropriate use of rails' label and radio_button helpers. According to https://materializecss.com/radio-buttons.html, the label needs to strictly wraps the radio button input tag and the text next to the button needs to be wrapped by a span tag. (I've experimented on this and it does seem to be the case.) However, the original code block generates HTML like this.
![Screen Shot 2020-05-30 at 11 51 11 AM](https://user-images.githubusercontent.com/54905587/83333115-f4799d80-a26c-11ea-8a84-79028b667761.png)
Which moves the button tag from inside the label tag. I've decided to adopt the use of Ruby code block to fix this problem in that this preserves Rails helpers and their features at best. However, we also have the option of writing raw HTML code. But I'm not sure about whether that will break some of Rails helpers' functionality. But just in terms of the front end button clicking, both strategies work. I definitely need more opinion on this and further testing and check regarding my current use of code block is required.
P.S. _bulkGrade_initial.html.erb has the same issue. But I want to confirm how we want to fix this first before making further modification.