### PR TITLE
Add additional missing file data to :missing_autograder_file error

### DIFF
--- a/app/controllers/assessment/autograde.rb
+++ b/app/controllers/assessment/autograde.rb
@@ -201,7 +201,7 @@ module AssessmentAutograde
           flash[:error] += " (Verify the autograding properties at #{link}.)\nErrorMsg: " + e.additional_data
         end
       when :missing_autograder_file
-        flash[:error] = "One or more files in the Autograder module don't exist. Contact the instructor."
+        flash[:error] = "One or more files are missing in the server. Please contact the instructor. The missing files are: " + e.additional_data
       else
         flash[:error] = "Autograding failed because of an unexpected exception in the system."
       end


### PR DESCRIPTION
As per Vittorio's suggestion in Slack (thanks!), provide additional missing file data when autograding fails with a `:missing_autograder_file` error