### PR TITLE
Check if req in callback is nil

### DIFF
--- a/app/controllers/device_flow_activation_controller.rb
+++ b/app/controllers/device_flow_activation_controller.rb
@@ -41,6 +41,11 @@ class DeviceFlowActivationController < ApplicationController
   def authorization_callback
     req = OauthDeviceFlowRequest.find_by(user_code: params[:state])
 
+    if req.nil?
+      flash[:error] = "Invalid request"
+      redirect_to(action: :index) && return
+    end
+
     if params.has_key?(:error)
       # encountered error
       req.deny_request(current_user.id)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Turns not `req` isn't guaranteed to be non-nil, e.g. when accessing `/device_flow_auth_cb` directly from a browser. Adds a check for nil here before proceeding.

## Description
<!--- Describe your changes in detail -->
Check if `req` is `nil`, and if it is, redirect to `:index` (which is `/activate`) with an error message. Guarantees that `req` will be non-nil in the subsequent calls.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
See Chaskiel's email dated Aug 5, 2020

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally by accessing  `/device_flow_auth_cb` directly from a browser.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, and here is the corresponding pull request to Autolab Docs -> 

## Other issues / help required
<!--- Do you have any other relevant issues / questions? --->
<!--- For example, if you require assistance for a certain part of your PR --->
<!--- or are facing specific issues while creating the pull request that you would like to highlight --->

If unsure, feel free to submit first and we'll help you along.
