### PR TITLE
Fix silliness in old code

### DIFF
--- a/app/helpers/assessment_autograde_core.rb
+++ b/app/helpers/assessment_autograde_core.rb
@@ -289,7 +289,7 @@ module AssessmentAutogradeCore
     autograde = { "localFile" => local_autograde, "destFile" => "autograde.tar" }
     settings_config = { "localFile" => local_settings_config, "destFile" => "settings.json" }
 
-    if assessment.has_custom_form.to_s == "true"
+    if assessment.has_custom_form
         [handin, makefile, autograde, settings_config]
     else
         [handin, makefile, autograde]

--- a/app/views/assessments/edit.html.erb
+++ b/app/views/assessments/edit.html.erb
@@ -8,27 +8,11 @@
 <% content_for :javascripts do %>
   <%= javascript_include_tag "confirm_discard_changes" %>
   <script type="text/javascript">
-    function validate(){
-        var checkbox = document.getElementById('assessment_has_custom_form');
-        var moreOptions = document.getElementById('moreOptions');
-        var showMoreOptions = function(){
-          if(checkbox.checked) {
-              moreOptions.style['display'] = 'block';
-          } else {
-              moreOptions.style['display'] = 'none';
-          }
-        }
-        checkbox.onclick = showMoreOptions;
-        showMoreOptions();
-    };
-    
     // Initializes Materialize JS's tabs
     $(document).ready(function(){
       $('.tabs').tabs();
     });
-    
-    validate();
-  </script>
+    </script>
 <% end %>
 
 <div class="row">

--- a/app/views/assessments/edit.html.erb
+++ b/app/views/assessments/edit.html.erb
@@ -12,7 +12,7 @@
     $(document).ready(function(){
       $('.tabs').tabs();
     });
-    </script>
+  </script>
 <% end %>
 
 <div class="row">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Remove dead and redundant code, closes #1201

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`validate()` was causing errors to console because `document.getElementById('assessment_has_custom_form');` is returning `nil`. In the course of checking through the code I also discovered this silly boolean to string snippet

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Visited the edit assessment page in question, verified no behavior change

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, and here is the corresponding pull request to Autolab Docs
