### PR TITLE
Change view submission title and breadcrumb based on user role

### DIFF
--- a/app/views/submissions/view.html.erb
+++ b/app/views/submissions/view.html.erb
@@ -1,4 +1,4 @@
-<% @title = "Annotate Submission" %>
+<% @title = (@cud.instructor || @cud.course_assistant) ? "Annotate Submission" : "View Submission" %>
 
 <% content_for :stylesheets do %>
   <%= stylesheet_link_tag "annotations" %>

--- a/app/views/submissions/viewPDF.html.erb
+++ b/app/views/submissions/viewPDF.html.erb
@@ -1,4 +1,4 @@
-<% @title = "Annotate Submission" %>
+<% @title = (@cud.instructor || @cud.course_assistant) ? "Annotate Submission" : "View Submission" %>
 
 <% content_for :stylesheets do %>
 <%= stylesheet_link_tag "annotations" %>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

As of current, the title and breadcrumb is annotate submission for all users. This PR changes it to view submission for student, annotation submission for instructors and course assistants.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes https://github.com/autolab/Autolab/issues/1088

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested by acting as different roles on Chrome browser.

## Screenshots (if appropriate):
Instructor
![image](https://user-images.githubusercontent.com/5773562/89779255-82adb200-db41-11ea-8782-1e1ecff66d6b.png)
Course Assistant
![image](https://user-images.githubusercontent.com/5773562/89779196-6a3d9780-db41-11ea-8e7f-e968ad209aab.png)
Student
![image](https://user-images.githubusercontent.com/5773562/89779303-99ec9f80-db41-11ea-8e50-5b41273802a6.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, and here is the corresponding pull request to Autolab Docs -> 
