### PR TITLE
Improves Edit Assessment Layout and Datetime Pickr Experience

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,10 @@
+# tmp files
 log/
 tmp/cache/
+tmp/
+!tmp/restart.txt
+
+# autolab configs
 config/autogradeConfig.rb
 assessmentConfig/
 courseConfig/
@@ -11,24 +16,32 @@ coverage/
 /gradebooks/
 config/database.yml
 config/school.yml
+
+# autolab user documents
+app/views/home/_topannounce.html.erb
+attachments/
+doc/
+out.txt
+
+# compiled assets
 public/images/CourseSubmissions.png
 public/images/HourlySubmissions.png
 public/assets/
 public/stylesheets/
 vendor/
-tmp/
-!tmp/restart.txt
-*.swp
+
+# sqlite databases
+db/autolab_development
+db/autolab_test
 db/*.sqlite3
+
+# misc
+*.swp
 tags
 .DS_Store
 .idea/
 .yardoc
 /docker/nginx.conf
-app/views/home/_topannounce.html.erb
-attachments/
-doc/
-out.txt
 .vscode/
 .byebug_history
 .env

--- a/app/assets/javascripts/init_handin_datetimepickers.js
+++ b/app/assets/javascripts/init_handin_datetimepickers.js
@@ -1,3 +1,10 @@
+// Adds addDays function to Date prototype
+Date.prototype.addDays = function(days) {
+  var date = new Date(this.valueOf());
+  date.setDate(date.getDate() + days);
+  return date;
+}
+
 // Initialize all Flatpicker Datetime Pickers on the page
 
 $(document).ready(function() {
@@ -14,13 +21,21 @@ $(document).ready(function() {
     return flatpickr(selector, defaults)
   }
 
-  /* Create all 3 date pickers */
-  createDatePicker('#assessment_start_at')
-  var end_at_pickr = createDatePicker('#assessment_end_at')
-  var grading_deadline_pickr = createDatePicker('#assessment_grading_deadline')
+  /* Create all 4 date pickers */
+  var grading_deadline_pickr = createDatePicker('#assessment_grading_deadline');
+  
+  function endAtOnCloseHandler(selected_dates, date_str, flatpickr_inst) {
+    var cur_date = selected_dates[0];
+    if (grading_deadline_pickr.selectedDates[0].getTime() < cur_date.getTime()) {
+      grading_deadline_pickr.setDate(cur_date, true);
+    }
+  }
+  
+  /* Add custom onClose handler for end at date picker */
+  var end_at_pickr = createDatePicker('#assessment_end_at',{onClose:endAtOnCloseHandler});
 
-  function onCloseHandler(selected_dates, date_str, flatpickr_inst) {
-      var cur_date = selected_dates[0]
+  function dueAtOnCloseHandler(selected_dates, date_str, flatpickr_inst) {
+      var cur_date = selected_dates[0];
       if (grading_deadline_pickr.selectedDates[0].getTime() < cur_date.getTime()) {
         grading_deadline_pickr.setDate(cur_date, true);
       }
@@ -28,10 +43,30 @@ $(document).ready(function() {
       if (end_at_pickr.selectedDates[0].getTime() < cur_date.getTime()) {
         end_at_pickr.setDate(cur_date, true);
       }
-
   }
-  /* Add custom onClose handler for due at date picker */
-  var due_at_pickr = createDatePicker('#assessment_due_at', {onClose : onCloseHandler})
 
+  /* Add custom onClose handler for due at date picker */
+  /* Adds 7 days between start_at and end_at */
+  var due_at_pickr = createDatePicker('#assessment_due_at', {onClose : dueAtOnCloseHandler});
+  const daysBetweenStartEnd = 7;
+
+  function startAtPickronCloseHandler(selected_dates, date_str, flatpickr_inst){
+    var cur_date = selected_dates[0];
+    
+    if (due_at_pickr.selectedDates[0].getTime() < cur_date.getTime()) {
+      due_at_pickr.setDate(cur_date.addDays(daysBetweenStartEnd), true);
+    }
+
+    if (grading_deadline_pickr.selectedDates[0].getTime() < cur_date.getTime()) {
+      grading_deadline_pickr.setDate(cur_date.addDays(daysBetweenStartEnd), true);
+    }
+
+    if (end_at_pickr.selectedDates[0].getTime() < cur_date.getTime()) {
+      end_at_pickr.setDate(cur_date.addDays(daysBetweenStartEnd), true);
+    }
+  }
+
+  /* Add custom onClose handler for start_at date picker */
+  createDatePicker('#assessment_start_at', {onClose: startAtPickronCloseHandler});
 })
 

--- a/app/assets/javascripts/init_handin_datetimepickers.js
+++ b/app/assets/javascripts/init_handin_datetimepickers.js
@@ -1,4 +1,3 @@
-
 // Initialize all Flatpicker Datetime Pickers on the page
 
 $(document).ready(function() {
@@ -20,6 +19,7 @@ $(document).ready(function() {
   
   function endAtOnCloseHandler(selected_dates, date_str, flatpickr_inst) {
     var cur_date = selected_dates[0];
+    
     if (grading_deadline_pickr.selectedDates[0].getTime() < cur_date.getTime()) {
       grading_deadline_pickr.setDate(cur_date, true);
     }
@@ -30,6 +30,7 @@ $(document).ready(function() {
 
   function dueAtOnCloseHandler(selected_dates, date_str, flatpickr_inst) {
       var cur_date = selected_dates[0];
+      
       if (grading_deadline_pickr.selectedDates[0].getTime() < cur_date.getTime()) {
         grading_deadline_pickr.setDate(cur_date, true);
       }

--- a/app/assets/javascripts/init_handin_datetimepickers.js
+++ b/app/assets/javascripts/init_handin_datetimepickers.js
@@ -46,10 +46,10 @@ $(document).ready(function() {
   }
 
   /* Add custom onClose handler for due at date picker */
-  /* Adds 7 days between start_at and end_at */
   var due_at_pickr = createDatePicker('#assessment_due_at', {onClose : dueAtOnCloseHandler});
+  
+  /* Adds 7 days between start_at and end_at */
   const daysBetweenStartEnd = 7;
-
   function startAtPickronCloseHandler(selected_dates, date_str, flatpickr_inst){
     var cur_date = selected_dates[0];
     

--- a/app/assets/javascripts/init_handin_datetimepickers.js
+++ b/app/assets/javascripts/init_handin_datetimepickers.js
@@ -1,9 +1,3 @@
-// Adds addDays function to Date prototype
-Date.prototype.addDays = function(days) {
-  var date = new Date(this.valueOf());
-  date.setDate(date.getDate() + days);
-  return date;
-}
 
 // Initialize all Flatpicker Datetime Pickers on the page
 
@@ -47,22 +41,20 @@ $(document).ready(function() {
 
   /* Add custom onClose handler for due at date picker */
   var due_at_pickr = createDatePicker('#assessment_due_at', {onClose : dueAtOnCloseHandler});
-  
-  /* Adds 7 days between start_at and end_at */
-  const daysBetweenStartEnd = 7;
+
   function startAtPickronCloseHandler(selected_dates, date_str, flatpickr_inst){
     var cur_date = selected_dates[0];
     
     if (due_at_pickr.selectedDates[0].getTime() < cur_date.getTime()) {
-      due_at_pickr.setDate(cur_date.addDays(daysBetweenStartEnd), true);
+      due_at_pickr.setDate(cur_date, true);
     }
 
     if (grading_deadline_pickr.selectedDates[0].getTime() < cur_date.getTime()) {
-      grading_deadline_pickr.setDate(cur_date.addDays(daysBetweenStartEnd), true);
+      grading_deadline_pickr.setDate(cur_date, true);
     }
 
     if (end_at_pickr.selectedDates[0].getTime() < cur_date.getTime()) {
-      end_at_pickr.setDate(cur_date.addDays(daysBetweenStartEnd), true);
+      end_at_pickr.setDate(cur_date, true);
     }
   }
 

--- a/app/form_builders/form_builder_with_date_time_input.rb
+++ b/app/form_builders/form_builder_with_date_time_input.rb
@@ -49,19 +49,18 @@ class FormBuilderWithDateTimeInput < ActionView::Helpers::FormBuilder
   def check_box(name, *args)
     options = args.extract_options!
 
-    # display_name = options[:display_name]
+    display_name = options[:display_name].nil? ? name : options[:display_name]
     
-    display_span = "<span>" + name.to_s.humanize + "</span>"
+    display_span = "<span>" + display_name.to_s.humanize + "</span>"
     # Materalize requires the label to be in a span
     field = super name, *(args + [options])
 
-    unless options.include?(:help_text)
-        options[:help_text] = " "
-    end
-
     @template.content_tag :div do
-           label(name, field + display_span.html_safe, class: "control-label") +
-            help_text(name, options[:help_text])
+      if options.include?(:help_text)
+        label(name, field + display_span.html_safe, class: "control-label") + help_text(name, options[:help_text])
+      else
+        label(name, field + display_span.html_safe, class: "control-label") 
+      end 
     end
   end
 

--- a/app/views/assessments/_edit_advanced.html.erb
+++ b/app/views/assessments/_edit_advanced.html.erb
@@ -1,33 +1,37 @@
 <%= f.text_field :group_size,
-  display_name: "Group Size",
+  display_name: "Group size",
   help_text: "Set the maximum size of groups for this assessment.  If group size is 1, the assessment is solo.  If the size is decreased, groups that are too large will not be broken up.  If the size is set to 1, groups will be saved, but the assessment will be solo.", placeholder: "1" %>
 
+<% unless f.object.disable_handins %>
+<%= f.text_field :handin_directory, help_text: "The subdirectory in the assessment directory where student submissions will be store. You generally shouldn't need to change this.", placeholder: "Default: handin" %>
+
+      <%= f.text_field :remote_handin_path, placeholder: "(Optional)", help_text: "The directory outside the assessment directory where student submissions directly from local machines will be copied." %>
+      <% end %>
+
+<%= f.check_box :allow_unofficial, help_text: "Allow unofficial submission. Unless you know what you're doing, leave this unchecked." %>
+
 <div class="embedded-form">
-  <%= f.check_box :embedded_quiz, display_name: "Embedded Form", style: "margin-top: 0.8rem;", onclick: "boxClicked();" %>
+  <%= f.check_box :embedded_quiz, display_name: "Enable Embedded Form", onclick: "boxClicked();" %>
 
-    <label class="custom-file-upload">
-          <span class = "btn primary" id="upload_button" style="clear:both;">
-            Embedded Form
-            <%= f.file_field_nowrap :embedded_quiz_form, class: "upload_embedded" %>
-          </span>
-    </label>
-
+    <div style="margin-top: 0.5rem;">
+      <label class="custom-file-upload">
+            <span class = "btn primary" id="upload_button" style="clear:both;">
+                  <% if @assessment.embedded_quiz_form_data.nil? %>
+                        Upload Embedded Form
+                  <% else %>
+                        Replace Exisiting Embedded Form
+                  <% end %>
+              <%= f.file_field_nowrap :embedded_quiz_form, class: "upload_embedded" %>
+            </span>
+      </label>
+    </div>
     <p class="file_name">
         <span id="file_name"></span>
     </p>
 
-    <% if @assessment.embedded_quiz_form_data.nil? %>
-        <p class="help-text">
-            Select to Upload a File.
-        </p>
-    <% else %>
-        <p class="help-text red-text">
-            Upload will replace existing file.
-        </p>
-    <% end %>
-  <p class="help-block">
-    For more information on Embedded Forms, visit our new
-    <a href="https://autolab.github.io/docs/features/#embedded-forms" target="_blank"> docs page.</a>
+    <p class="help-block">
+      For more information on Embedded Forms, visit our new
+      <a href="https://autolab.github.io/docs/features/#embedded-forms" target="_blank"> docs page.</a>
     </p>
 </div>
 
@@ -36,14 +40,6 @@
         document.getElementById("file_name").textContent = "File Selected: " + document.getElementById("assessment_embedded_quiz_form").value.split(/(\\|\/)/g).pop();
     }
 </script>
-
-<%= f.check_box :allow_unofficial, help_text: "Allow unofficial submission. Unless you know what you're doing, leave this unchecked." %>
-
-<% unless f.object.disable_handins %>
-<%= f.text_field :handin_directory, help_text: "The subdirectory in the assessment directory where student submissions will be store. You generally shouldn't need to change this.", placeholder: "Default: handin" %>
-
-      <%= f.text_field :remote_handin_path, placeholder: "(Optional)", help_text: "The directory outside the assessment directory where student submissions directly from local machines will be copied." %>
-      <% end %>
 
 <div class="action_buttons">
   <%= f.submit "Save", :name=>"advanced" %>

--- a/app/views/assessments/_edit_handin.html.erb
+++ b/app/views/assessments/_edit_handin.html.erb
@@ -15,7 +15,7 @@
   greater_than: "assessment_start_at",
   less_than: "assessment_end_at assessment_grading_deadline" %>
 
-<%= f.datetime_select :end_at, class: "datepicker",
+<%= f.datetime_select :end_at,
   style: "margin-top: 0 !important;",
   help_text: "Last possible time that students can submit (except those granted extensions.)",
   greater_than: "assessment_start_at assessment_due_at",
@@ -26,14 +26,14 @@
   help_text: "Time after which final scores are included in the gradebook",
   greater_than: "assessment_start_at assessment_due_at assessment_end_at", placeholder: Date.current %>
 
-  <%= f.check_box :disable_handins,
-    help_text: "Check this to disallow handins through Autolab. This option can be used to track scores for assignments that are not submitted through Autolab such as midterms and written assignments." %>
-
-  <% unless f.object.disable_handins %>
-      <%= f.text_field :handin_filename, help_text: "The suffix that is appended to student submission files. Autolab stores submission files in the handin directory as email_version_fname", placeholder: "E.g. mm.c" %>
-  <% end %>
+<% unless f.object.disable_handins %>
+    <%= f.text_field :handin_filename, help_text: "The suffix that is appended to student submission files. Autolab stores submission files in the handin directory as email_version_fname", placeholder: "E.g. mm.c" %>
+<% end %>
 
 <%= f.text_field :max_size, help_text: "The maximum size that a handin file can have in megabytes (MB)." %>
+
+<%= f.check_box :disable_handins,
+  help_text: "Check this to disallow handins through Autolab. This option can be used to track scores for assignments that are not submitted through Autolab such as midterms and written assignments." %>
 
 <div class="action_buttons">
   <%= f.submit "Save", :name=>"handin" %>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR improves the order and layout of the settings in the edit assessment page, specifically the **Handin** and **Advanced** tabs.

At the same time, it makes the datetime pickr time selection process better by adjusting the subsequent datetimes in a cascading fashion, as follows:

- **Start at** on selected, adjusts **due at, end at** and **grading deadline** to be at least on **start at**. 
- **Due at**  on selected, adjusts **end at** and **grading deadline** to be at least on **due at**. 
- **End at**  on selected, adjusts **grading deadline** to be at least on **end at**. 
- **Grading deadline**: No change

Note that the cascading is only in one direction. If the due at is selected, it does not affect affect the start at date for the datepickr (if user selects a due at before start at, the user will be informed that this is not allowed upon saving). At the same time, if due at is already after start at, selecting start at will not make any adjustments to due at.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This enhancement is a result from our team's user interviews with professors who uses Autolab, who felt that the edit assessment page's layout were confusing. At the same time, to address the feedback that it took too many clicks to adjust the start at, due at, end at and grading deadline dates.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Testing for the sections that are rearranged under the handin and advanced tab layout was done
### Handin
1. Disable handin button still works as expected
### Advanced
1. Allow unofficial checkbox still works as expected
2. Embedded form checkbox and button still works as expected

The datetime pickr has been tested to follow the rules as mentioned above

## Screenshots (if appropriate):

| Old Tab | New Tab |
| -------- | --------- |
| ![image](https://user-images.githubusercontent.com/5773562/90972920-b0d2bf00-e54f-11ea-9d14-c09724986e07.png) | ![image](https://user-images.githubusercontent.com/5773562/90972939-f42d2d80-e54f-11ea-971d-a3bd26c9cce2.png) |
| ![image](https://user-images.githubusercontent.com/5773562/90972955-22127200-e550-11ea-83e1-9c9392ab074d.png) | ![image](https://user-images.githubusercontent.com/5773562/90972959-2dfe3400-e550-11ea-914b-776284e25b1e.png) |

| Before uploading an embedded form | An embedded form has already been uploaded |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/5773562/90973019-c1376980-e550-11ea-90c8-29dd57ece56c.png) | ![image](https://user-images.githubusercontent.com/5773562/90973021-cb596800-e550-11ea-83f4-bfdf9508e1cb.png) |

 
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, and here is the corresponding pull request to Autolab Docs -> 
