### PR TITLE
Hotfix for gradebook not displaying

### DIFF
--- a/app/views/gradebooks/view.html.erb
+++ b/app/views/gradebooks/view.html.erb
@@ -60,7 +60,6 @@
 
 
 <% content_for :js_widget_patch do %>
-  <%= external_javascript_include_tag "jquery-ui", "1.10.2" %>
   <%# jQuery UI is required for SlickGrid, but Bootstrap provides a tooltip plugin %>
   <%# The following must come after jQuery UI but before Bootstrap 3 is loaded %>
   <%# to resolve namespace issues %>
@@ -70,10 +69,11 @@
 <% end %>
 
 <% content_for :javascripts do %>
-  <%= javascript_include_tag "jquery.event.drag-2.2.js" %>
-  <%= javascript_include_tag "SlickGrid/2.02/slick.core.js" %>
-  <%= javascript_include_tag "SlickGrid/2.02/slick.grid.js" %>
-  <%= javascript_include_tag "SlickGrid/2.02/slick.dataview.js" %>
+  <%= external_javascript_include_tag "jquery-ui", "1.11.4" %>
+  <%= javascript_include_tag "jquery.event.drag-2.2.js"%>
+  <%= javascript_include_tag "SlickGrid/2.02/slick.core.js"  %>
+  <%= javascript_include_tag "SlickGrid/2.02/slick.grid.js"  %>
+  <%= javascript_include_tag "SlickGrid/2.02/slick.dataview.js"  %>
   <%= javascript_include_tag "SlickGrid/2.02/controls/slick.columnpicker.js" %>
 
   <script type="text/javascript">
@@ -82,7 +82,7 @@
     var options = <%== @options.to_json %>
   </script>
 
-  <%= javascript_include_tag "gradebook" %>
+  <%= javascript_include_tag "gradebook" ,:async => true %>
 <% end %>
 
 <% if not @course.gb_message.blank? %>

--- a/app/views/gradebooks/view.html.erb
+++ b/app/views/gradebooks/view.html.erb
@@ -72,7 +72,7 @@
     var options = <%== @options.to_json %>
   </script>
 
-  <%= javascript_include_tag "gradebook" ,:async => true %>
+  <%= javascript_include_tag "gradebook" %>
 <% end %>
 
 <% if not @course.gb_message.blank? %>

--- a/app/views/gradebooks/view.html.erb
+++ b/app/views/gradebooks/view.html.erb
@@ -58,16 +58,6 @@
   </style>
 <% end %>
 
-
-<% content_for :js_widget_patch do %>
-  <%# jQuery UI is required for SlickGrid, but Bootstrap provides a tooltip plugin %>
-  <%# The following must come after jQuery UI but before Bootstrap 3 is loaded %>
-  <%# to resolve namespace issues %>
-  <script>
-    $.widget.bridge('uitooltip', $.ui.tooltip);
-  </script>
-<% end %>
-
 <% content_for :javascripts do %>
   <%= external_javascript_include_tag "jquery-ui", "1.11.4" %>
   <%= javascript_include_tag "jquery.event.drag-2.2.js"%>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This change updates the jquery-ui used, and also removed the leftover fix meant for bootstrap

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

As of the current master, the gradebook is not displaying, as per a feedback from CMU instructor:
With the recent update to Autolab, the gradebook does not display. If I export, I can see the student grades, but I cannot view or search for a single student, which seems to be a defect.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested as both an instructor and course assistant 

## Screenshots (if appropriate):

Before:
![image](https://user-images.githubusercontent.com/5773562/91463888-80c44c80-e8be-11ea-905b-6e2fc5ba22db.png)

After:
![image](https://user-images.githubusercontent.com/5773562/91463843-730ec700-e8be-11ea-9040-1802f07c1dec.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)