### PR TITLE
Secret generation without rake

### DIFF
--- a/bin/setup.sh
+++ b/bin/setup.sh
@@ -190,7 +190,7 @@ autolab_setup() {
     cp $AUTOLAB_PATH/config/school.yml.template $AUTOLAB_PATH/config/school.yml
 
     cp $AUTOLAB_PATH/config/initializers/devise.rb.template $AUTOLAB_PATH/config/initializers/devise.rb
-    sed -i "s/<YOUR-SECRET-KEY>/`bundle exec rake secret`/g" $AUTOLAB_PATH/config/initializers/devise.rb
+    sed -i "s/<YOUR-SECRET-KEY>/`sh generate_secret.sh 128`/g" $AUTOLAB_PATH/config/initializers/devise.rb
 
     cp $AUTOLAB_PATH/config/autogradeConfig.rb.template $AUTOLAB_PATH/config/autogradeConfig.rb
 

--- a/generate_secret.sh
+++ b/generate_secret.sh
@@ -1,0 +1,1 @@
+LC_ALL=C tr -dc 'A-Za-z0-9' </dev/urandom | head -c $1


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This is for the one-click setup script. Since the host machine might not have bundle, we cannot use `bundle exec rake secret` to generate a random secret key. Hence a new script that uses /dev/urandom to generate a random key is added to replace the old method. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, and here is the corresponding pull request to Autolab Docs -> 

## Other issues / help required
<!--- Do you have any other relevant issues / questions? --->
<!--- For example, if you require assistance for a certain part of your PR --->
<!--- or are facing specific issues while creating the pull request that you would like to highlight --->

If unsure, feel free to submit first and we'll help you along.
