### PR TITLE
Annotation position bug fixes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -312,6 +312,8 @@ GEM
     ttfunk (1.0.3)
     tzinfo (1.2.7)
       thread_safe (~> 0.1)
+    tzinfo-data (1.2020.1)
+      tzinfo (>= 1.0.0)
     uglifier (4.2.0)
       execjs (>= 0.3.0, < 3)
     unicode-display_width (1.7.0)
@@ -380,6 +382,7 @@ DEPENDENCIES
   sprockets-rails (>= 3.2.1)
   sqlite3 (~> 1.3.6)
   thin
+  tzinfo-data
   uglifier (>= 1.3.0)
   webmock
   yard

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -312,8 +312,6 @@ GEM
     ttfunk (1.0.3)
     tzinfo (1.2.7)
       thread_safe (~> 0.1)
-    tzinfo-data (1.2020.1)
-      tzinfo (>= 1.0.0)
     uglifier (4.2.0)
       execjs (>= 0.3.0, < 3)
     unicode-display_width (1.7.0)
@@ -382,7 +380,6 @@ DEPENDENCIES
   sprockets-rails (>= 3.2.1)
   sqlite3 (~> 1.3.6)
   thin
-  tzinfo-data
   uglifier (>= 1.3.0)
   webmock
   yard

--- a/app/assets/javascripts/annotations.js
+++ b/app/assets/javascripts/annotations.js
@@ -13,7 +13,7 @@ $(document).ready(function () {
   }
   
   resizeCodeTable();
-  });
+});
 
 /* On Window Reisze */ 
 $(window).on('resize', function(){
@@ -204,7 +204,7 @@ function fillAnnotationBox() {
 
       // Standardized scrollToFileLine behavior
       // annotation.line + 1 because the line numbers on editor starts with 1 not 0
-      annotationElement.attr('onclick', `scrollToFileLine(${annotation.position}, ${annotation.line + 1})`);
+      annotationElement.attr('onclick', `scrollToFileLine(${annotation.position ? annotation.position : 0}, ${annotation.line + 1})`);
 
       var pointBadge = $('<span />');
       pointBadge.addClass('point_badge');
@@ -453,7 +453,7 @@ function createAnnotation() {
     submitted_by: cudEmailStr,
   };
 
-  if (currentHeaderPos) {
+  if (currentHeaderPos || currentHeaderPos === 0) {
     annObj.position = currentHeaderPos
   }
 

--- a/app/assets/javascripts/annotations.js
+++ b/app/assets/javascripts/annotations.js
@@ -13,7 +13,7 @@ $(document).ready(function () {
   }
   
   resizeCodeTable();
-});
+  });
 
 /* On Window Reisze */ 
 $(window).on('resize', function(){
@@ -204,7 +204,7 @@ function fillAnnotationBox() {
 
       // Standardized scrollToFileLine behavior
       // annotation.line + 1 because the line numbers on editor starts with 1 not 0
-      annotationElement.attr('onclick', `scrollToFileLine(${annotation.position ? annotation.position : 0}, ${annotation.line + 1})`);
+      annotationElement.attr('onclick', `scrollToFileLine(${annotation.position}, ${annotation.line + 1})`);
 
       var pointBadge = $('<span />');
       pointBadge.addClass('point_badge');
@@ -453,7 +453,7 @@ function createAnnotation() {
     submitted_by: cudEmailStr,
   };
 
-  if (currentHeaderPos || currentHeaderPos === 0) {
+  if (currentHeaderPos) {
     annObj.position = currentHeaderPos
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
`if (currentHeaderPos)` is `false` when `currentHeaderPos == 0`, and `annObj.position` will be undefined as a result. This results in links in annotation pane being sent to `null`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes a bug where annotation pane where `header_position` is `null`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
