### PR TITLE
Add basic frontend for risk metrics form

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem 'materialize-sass'
 gem 'bootstrap-sass', '>= 3.4.1'
 
 # Use for Metrics page
-gem 'semantic-ui-sass'
+gem 'fomantic-ui-sass'
 
 # Use Uglifier as compressor for JavaScript assets
 gem 'uglifier', '>= 1.3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -117,6 +117,12 @@ GEM
     faraday (1.0.1)
       multipart-post (>= 1.2, < 3)
     ffi (1.12.2)
+    fomantic-ui-sass (2.8.6)
+      autoprefixer-rails
+      rails (>= 3.2.0)
+      sassc (>= 2.2)
+      sassc-rails (>= 2.1)
+      sprockets-rails (>= 2.1.3)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     hashdiff (1.0.1)
@@ -349,6 +355,7 @@ DEPENDENCIES
   dynamic_form
   exception_notification (>= 4.1.0)
   factory_bot_rails
+  fomantic-ui-sass
   httparty
   jbuilder (>= 2.0)
   jquery-rails

--- a/app/assets/javascripts/metrics.js
+++ b/app/assets/javascripts/metrics.js
@@ -2,8 +2,9 @@
 //= require semantic-ui
 $(document).ready(function(){
     $('.tabular.menu .item').tab();
-    $('.ui.dropdown').dropdown();
-    $('.ui.checkbox').checkbox();
+		$('.ui.dropdown').dropdown();
+		$('.ui.checkbox').checkbox();
+		$('.ui.calendar').calendar({type: 'date'});
     $('.ui.form')
 	  .form({
 			inline: true,
@@ -33,5 +34,12 @@ $(document).ready(function(){
 
 		$('[type="checkbox"]').change(function() {
 			$('#save').removeClass('disabled');
+		});
+
+		
+		$(window).bind('beforeunload', function(){
+			if (!$('#save').hasClass('disabled')) {
+				return 'Make sure to save your changes';
+			}
 		});
 });

--- a/app/assets/javascripts/metrics.js
+++ b/app/assets/javascripts/metrics.js
@@ -35,7 +35,6 @@ $(document).ready(function(){
 		$('[type="checkbox"]').change(function() {
 			$('#save').removeClass('disabled');
 		});
-
 		
 		$(window).bind('beforeunload', function(){
 			if (!$('#save').hasClass('disabled')) {

--- a/app/assets/javascripts/metrics.js
+++ b/app/assets/javascripts/metrics.js
@@ -1,2 +1,23 @@
 // Loads all Semantic javascripts
 //= require semantic-ui
+$(document).ready(function(){
+    $('.tabular.menu .item').tab();
+    $('.ui.dropdown').dropdown();
+    $('.ui.checkbox').checkbox();
+    $('.ui.form')
+	  .form({
+	    fields: {
+	      percentage: {
+	        identifier: 'percentage',
+	        optional: 'true',
+	        rules: [
+	          {
+	            type   : 'integer[0..100]',
+	            prompt : 'Please enter an integer from 0 to 100 for percentages'
+	          }
+	        ]
+      	  }
+	    }
+	  })
+	;
+});

--- a/app/assets/javascripts/metrics.js
+++ b/app/assets/javascripts/metrics.js
@@ -6,9 +6,10 @@ $(document).ready(function(){
     $('.ui.checkbox').checkbox();
     $('.ui.form')
 	  .form({
+			inline: true,
 	    fields: {
-	      percentage: {
-	        identifier: 'percentage',
+	      percentage1: {
+	        identifier: 'percentage1',
 	        optional: 'true',
 	        rules: [
 	          {
@@ -16,8 +17,21 @@ $(document).ready(function(){
 	            prompt : 'Please enter an integer from 0 to 100 for percentages'
 	          }
 	        ]
-      	  }
+				},
+				percentage2: {
+	        identifier: 'percentage2',
+	        optional: 'true',
+	        rules: [
+	          {
+	            type   : 'integer[0..100]',
+	            prompt : 'Please enter an integer from 0 to 100 for percentages'
+	          }
+	        ]
+				},
 	    }
-	  })
-	;
+		});
+
+		$('[type="checkbox"]').change(function() {
+			$('#save').removeClass('disabled');
+		});
 });

--- a/app/assets/stylesheets/metrics.scss
+++ b/app/assets/stylesheets/metrics.scss
@@ -16,19 +16,19 @@ $autolab-subtle-red: #C87B7E;
 }
 
 .dropdown {
-     min-width: 20px !important;
+  min-width: 20px !important;
 }
 
 span:before {
-    content:" "; 
-    display:inline-block; 
-    width:10px;
+  content:" "; 
+  display:inline-block; 
+  width:10px;
 }
 
 span:after {
-    content:" "; 
-    display:inline-block; 
-    width:10px;
+  content:" "; 
+  display:inline-block; 
+  width:10px;
 }
 
 .checkbox label::after {
@@ -53,5 +53,9 @@ input[type="text"] {
 }
 
 .success {
-    color: black;
+  color: black;
+}
+
+.error {
+  color: black;
 }

--- a/app/assets/stylesheets/metrics.scss
+++ b/app/assets/stylesheets/metrics.scss
@@ -59,3 +59,11 @@ input[type="text"] {
 .error {
   color: black;
 }
+
+.ui.form .inline.fields .field .calendar:not(.popup), .ui.form .inline.field .calendar:not(.popup) {
+  display: inline-flex;
+}
+
+.ui.form .inline.fields .field:not(.wide) .ui.input, .ui.form .inline.field:not(.wide) .ui.input {
+  min-width: 200px !important;
+}

--- a/app/assets/stylesheets/metrics.scss
+++ b/app/assets/stylesheets/metrics.scss
@@ -2,3 +2,56 @@
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: https://sass-lang.com/
 @import "semantic-ui";
+$autolab-red: rgba(153, 0, 0, 0.9);
+$autolab-subtle-red: #C87B7E;
+
+.button.submit {
+  color: #FFFFFF !important;
+  background-color: $autolab-red !important;
+}
+
+.button.submit:hover {
+  color: #FFFFFF !important;
+  background-color: $autolab-subtle-red !important;
+}
+
+.dropdown {
+     min-width: 20px !important;
+}
+
+span:before {
+    content:" "; 
+    display:inline-block; 
+    width:10px;
+}
+
+span:after {
+    content:" "; 
+    display:inline-block; 
+    width:10px;
+}
+
+.checkbox label::after {
+	border:none;
+	transform:none;
+}
+
+.ui.checkbox .box, .ui.checkbox label {
+	border-top-width:2px;
+	border-left-width:2px;
+	border-bottom-width:2px;
+	border-right-width:2px;
+}
+
+div.metric {
+	font-size:16px;
+}
+
+input[type="text"] {
+  height: 20px !important;
+  width: 30px !important;
+}
+
+.success {
+    color: black;
+}

--- a/app/assets/stylesheets/metrics.scss
+++ b/app/assets/stylesheets/metrics.scss
@@ -67,3 +67,9 @@ input[type="text"] {
 .ui.form .inline.fields .field:not(.wide) .ui.input, .ui.form .inline.field:not(.wide) .ui.input {
   min-width: 200px !important;
 }
+
+.ui.pointing.label:before {
+  z-index: 0 !important;
+  width: 0 !important;
+  height: 0 !important;
+}

--- a/app/views/metrics/index.html.erb
+++ b/app/views/metrics/index.html.erb
@@ -6,3 +6,130 @@
 <% content_for :javascripts do %>
   <%= javascript_include_tag "metrics" %>
 <% end %>
+
+<div class="ui pointing secondary tabular menu">
+  <a class="item active" data-tab="watchlist">Watchlist</a>
+  <a class="item" data-tab="risk metrics">Risk Metrics</a>
+</div>
+<div class="ui tab active" data-tab="watchlist">
+  Watchlist goes here
+</div>
+<div class="ui tab" data-tab="risk metrics">
+  <h6> 
+  	Select one or more of the following risk conditions you want to apply. 
+  </h6>
+  <h6>
+  	<i> 
+  		These conditions will make up your risk metrics, which will be used to identify students who are at risk in this course. 
+  	</i>
+  </h6>
+  <br>
+  <div class="ui form">
+  	<div class="metric">
+		<div class="inline field">
+		  <div class="ui checkbox">
+		    <input type="checkbox" tabindex="0" class="hidden">
+		  </div>
+	      Students who have used
+	      <span>
+		      <div class="ui selection dropdown">
+		        <input type="hidden" name="late days">
+		        <i class="dropdown icon"></i>
+		        <div class="default text">#</div>
+		        <div class="menu">
+		          <div class="item" data-value="1">1</div>
+		          <div class="item" data-value="2">2</div>
+		          <div class="item" data-value="3">3</div>
+		        </div>
+		  	  </div>
+	  	  </span>
+	  	  late days by
+	  	  <span>
+		  	  <div class="ui selection dropdown">
+		        <input type="hidden" name="date">
+		        <i class="dropdown icon"></i>
+		        <div class="default text">Date</div>
+		        <div class="menu">
+		          <div class="item" data-value="1">Day 1</div>
+		          <div class="item" data-value="2">Day 2</div>
+		        </div>
+		  	  </div>
+	  	  </span>
+		</div>
+
+		<div class="metric">
+		<div class="inline field">
+		  <div class="ui checkbox">
+		    <input type="checkbox" tabindex="0" class="hidden">
+		  </div>
+	      Students whose grades have dropped by
+	      <span>
+		    <input type="text" placeholder="%" name="percentage">
+	  	  </span>
+	  	  percent within
+	  	  <span>
+		  	  <div class="ui selection dropdown">
+		        <input type="hidden" name="number">
+		        <i class="dropdown icon"></i>
+		        <div class="default text">#</div>
+		        <div class="menu">
+		          <div class="item" data-value="2">2</div>
+		          <div class="item" data-value="3">3</div>
+		          <div class="item" data-value="4">4</div>
+		        </div>
+		  	  </div>
+	  	  </span>
+	  	  consecutive assignments
+		</div>
+
+		<div class="metric">
+		<div class="inline field">
+		  <div class="ui checkbox">
+		    <input type="checkbox" tabindex="0" class="hidden">
+		  </div>
+	      Students who did not submit
+	      <span>
+		      <div class="ui selection dropdown">
+		        <input type="hidden" name="number">
+		        <i class="dropdown icon"></i>
+		        <div class="default text">#</div>
+		        <div class="menu">
+		          <div class="item" data-value="1">1</div>
+		          <div class="item" data-value="2">2</div>
+		          <div class="item" data-value="3">3</div>
+		        </div>
+		  	  </div>
+	  	  </span>
+	  	  assignments
+		</div>
+
+		<div class="metric">
+		<div class="inline field">
+		  <div class="ui checkbox">
+		    <input type="checkbox" tabindex="0" class="hidden">
+		  </div>
+	      Students with
+	      <span>
+		      <div class="ui selection dropdown">
+		        <input type="hidden" name="number">
+		        <i class="dropdown icon"></i>
+		        <div class="default text">#</div>
+		        <div class="menu">
+		          <div class="item" data-value="1">1</div>
+		          <div class="item" data-value="2">2</div>
+		          <div class="item" data-value="3">3</div>
+		        </div>
+		  	  </div>
+	  	  </span>
+	  	  submitted assignments below a percentage of
+	  	  <span>
+		    <input type="text" placeholder="%">
+	  	  </span>
+		</div>
+	</div>
+	<br>
+	<button class="ui submit button">SAVE</button>
+	<div class="ui error message"></div>
+  </div>
+
+</div>

--- a/app/views/metrics/index.html.erb
+++ b/app/views/metrics/index.html.erb
@@ -132,12 +132,6 @@
 		</div>
 		<br>
 	
-		<div class="ui warning message" id="warning">
-			<div class="header">Your changes have not been saved</div>
-			<ul class="list">
-				<li>Are you sure you want to abandon these changes?</li>
-			</ul>
-		</div>
 		<button class="ui disabled submit button" id="save">SAVE</button>
 	</div>
 </div>

--- a/app/views/metrics/index.html.erb
+++ b/app/views/metrics/index.html.erb
@@ -11,7 +11,7 @@
   <a class="item active" data-tab="watchlist">Watchlist</a>
   <a class="item" data-tab="risk metrics">Risk Metrics</a>
 </div>
-<div class="ui tab active" data-tab="watchlist">
+<div class="ui tab active" data-tab="watchlist" id="watchlist_tab">
   Watchlist goes here
 </div>
 <div class="ui tab" data-tab="risk metrics">
@@ -19,117 +19,128 @@
   	Select one or more of the following risk conditions you want to apply. 
   </h6>
   <h6>
-  	<i> 
-  		These conditions will make up your risk metrics, which will be used to identify students who are at risk in this course. 
+    <i> 
+  	  These conditions will make up your risk metrics, which will be used to identify students who are at risk in this course. 
   	</i>
   </h6>
   <br>
   <div class="ui form">
   	<div class="metric">
-		<div class="inline field">
-		  <div class="ui checkbox">
-		    <input type="checkbox" tabindex="0" class="hidden">
-		  </div>
-	      Students who have used
-	      <span>
-		      <div class="ui selection dropdown">
-		        <input type="hidden" name="late days">
-		        <i class="dropdown icon"></i>
-		        <div class="default text">#</div>
-		        <div class="menu">
-		          <div class="item" data-value="1">1</div>
-		          <div class="item" data-value="2">2</div>
-		          <div class="item" data-value="3">3</div>
-		        </div>
-		  	  </div>
-	  	  </span>
-	  	  late days by
-	  	  <span>
-		  	  <div class="ui selection dropdown">
-		        <input type="hidden" name="date">
-		        <i class="dropdown icon"></i>
-		        <div class="default text">Date</div>
-		        <div class="menu">
-		          <div class="item" data-value="1">Day 1</div>
-		          <div class="item" data-value="2">Day 2</div>
-		        </div>
-		  	  </div>
-	  	  </span>
+			<div class="inline field">
+				<div class="ui checkbox">
+					<input type="checkbox" tabindex="0" class="hidden" name="checkbox1">
+				</div>
+				Students who have used
+				<span>
+					<div class="ui selection dropdown">
+						<input type="hidden" name="grace_days">
+						<i class="dropdown icon"></i>
+						<div class="default text">0</div>
+						<div class="menu">
+							<div class="item" data-value="1">1</div>
+							<div class="item" data-value="2">2</div>
+							<div class="item" data-value="3">3</div>
+						</div>
+					</div>
+				</span>
+				grace days by
+				<span>
+					<div class="ui selection dropdown">
+						<input type="hidden" name="date">
+						<i class="dropdown icon"></i>
+						<div class="default text">Date</div>
+						<div class="menu">
+							<div class="item" data-value="1">1</div>
+							<div class="item" data-value="2">2</div>
+						</div>
+					</div>
+				</span>
+			</div>
 		</div>
+		<br>
 
 		<div class="metric">
-		<div class="inline field">
-		  <div class="ui checkbox">
-		    <input type="checkbox" tabindex="0" class="hidden">
-		  </div>
-	      Students whose grades have dropped by
-	      <span>
-		    <input type="text" placeholder="%" name="percentage">
-	  	  </span>
-	  	  percent within
-	  	  <span>
-		  	  <div class="ui selection dropdown">
-		        <input type="hidden" name="number">
-		        <i class="dropdown icon"></i>
-		        <div class="default text">#</div>
-		        <div class="menu">
-		          <div class="item" data-value="2">2</div>
-		          <div class="item" data-value="3">3</div>
-		          <div class="item" data-value="4">4</div>
-		        </div>
-		  	  </div>
-	  	  </span>
-	  	  consecutive assignments
+			<div class="inline field">
+				<div class="ui checkbox">
+					<input type="checkbox" tabindex="0" class="hidden" name="checkbox2">
+				</div>
+				Students whose grades have dropped by
+				<span>
+					<input type="text" placeholder="0" name="percentage1">
+				</span>
+				percent within
+				<span>
+					<div class="ui selection dropdown">
+						<input type="hidden" name="number">
+						<i class="dropdown icon"></i>
+						<div class="default text">0</div>
+						<div class="menu">
+							<div class="item" data-value="2">2</div>
+							<div class="item" data-value="3">3</div>
+							<div class="item" data-value="4">4</div>
+						</div>
+					</div>
+				</span>
+				consecutive assignments
+			</div>
 		</div>
+		<br>
 
 		<div class="metric">
-		<div class="inline field">
-		  <div class="ui checkbox">
-		    <input type="checkbox" tabindex="0" class="hidden">
-		  </div>
-	      Students who did not submit
-	      <span>
-		      <div class="ui selection dropdown">
-		        <input type="hidden" name="number">
-		        <i class="dropdown icon"></i>
-		        <div class="default text">#</div>
-		        <div class="menu">
-		          <div class="item" data-value="1">1</div>
-		          <div class="item" data-value="2">2</div>
-		          <div class="item" data-value="3">3</div>
-		        </div>
-		  	  </div>
-	  	  </span>
-	  	  assignments
+			<div class="inline field">
+				<div class="ui checkbox">
+					<input type="checkbox" tabindex="0" class="hidden" name="checkbox3">
+				</div>
+				Students who did not submit
+				<span>
+					<div class="ui selection dropdown">
+						<input type="hidden" name="number">
+						<i class="dropdown icon"></i>
+						<div class="default text">0</div>
+						<div class="menu">
+							<div class="item" data-value="1">1</div>
+							<div class="item" data-value="2">2</div>
+							<div class="item" data-value="3">3</div>
+						</div>
+					</div>
+				</span>
+				assignments
+			</div>
 		</div>
+		<br>
 
 		<div class="metric">
-		<div class="inline field">
-		  <div class="ui checkbox">
-		    <input type="checkbox" tabindex="0" class="hidden">
-		  </div>
-	      Students with
-	      <span>
-		      <div class="ui selection dropdown">
-		        <input type="hidden" name="number">
-		        <i class="dropdown icon"></i>
-		        <div class="default text">#</div>
-		        <div class="menu">
-		          <div class="item" data-value="1">1</div>
-		          <div class="item" data-value="2">2</div>
-		          <div class="item" data-value="3">3</div>
-		        </div>
-		  	  </div>
-	  	  </span>
-	  	  submitted assignments below a percentage of
-	  	  <span>
-		    <input type="text" placeholder="%">
-	  	  </span>
+			<div class="inline field">
+				<div class="ui checkbox">
+					<input type="checkbox" tabindex="0" class="hidden" name="checkbox4">
+				</div>
+				Students with
+				<span>
+					<div class="ui selection dropdown">
+						<input type="hidden" name="number">
+						<i class="dropdown icon"></i>
+						<div class="default text">0</div>
+						<div class="menu">
+							<div class="item" data-value="1">1</div>
+							<div class="item" data-value="2">2</div>
+							<div class="item" data-value="3">3</div>
+						</div>
+					</div>
+				</span>
+				submitted assignments below a percentage of
+				<span>
+					<input type="text" placeholder="0" name="percentage2">
+				</span>
+			</div>
 		</div>
+		<br>
+	
+		<div class="ui warning message" id="warning">
+			<div class="header">Your changes have not been saved</div>
+			<ul class="list">
+				<li>Are you sure you want to abandon these changes?</li>
+			</ul>
+		</div>
+		<button class="ui disabled submit button" id="save">SAVE</button>
 	</div>
-	<br>
-	<button class="ui submit button">SAVE</button>
-	<div class="ui error message"></div>
-  </div>
-
 </div>

--- a/app/views/metrics/index.html.erb
+++ b/app/views/metrics/index.html.erb
@@ -4,7 +4,7 @@
 <% end %>
 
 <% content_for :javascripts do %>
-  <%= javascript_include_tag "metrics" %>
+	<%= javascript_include_tag "metrics" %>
 <% end %>
 
 <div class="ui pointing secondary tabular menu">
@@ -45,13 +45,10 @@
 				</span>
 				grace days by
 				<span>
-					<div class="ui selection dropdown">
-						<input type="hidden" name="date">
-						<i class="dropdown icon"></i>
-						<div class="default text">Date</div>
-						<div class="menu">
-							<div class="item" data-value="1">1</div>
-							<div class="item" data-value="2">2</div>
+					<div class="ui calendar" id="date">
+						<div class="ui input left icon">
+							<i class="calendar icon"></i>
+							<input type="text" placeholder="Date">
 						</div>
 					</div>
 				</span>


### PR DESCRIPTION
This PR creates the basic frontend functionality for the risk metrics form, which goes into the "risk metrics" tab of the metrics feature.

## Description
I added to the index.html.erb file in the view for metrics, which is supported by the metrics.js and metrics.scss files. It creates a form that consists of Semantic UI components with metrics that instructors can select and specify for the purpose of identifying at-risk students. It also uses [Fomantic UI](https://fomantic-ui.com/modules/calendar.html) to make use of the calendar module for datepicking.

## Motivation and Context
This is one part of the new Autolab metrics feature that allows professors to pick metrics by which to identify students.

## How Has This Been Tested?
I tested this locally by navigating to the metrics page and filling out form fields.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/13857201/98265379-0582b500-1f57-11eb-8b59-13027809d868.png)
![image](https://user-images.githubusercontent.com/13857201/98265613-47abf680-1f57-11eb-89c3-44e7cc3141bb.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, and here is the corresponding pull request to Autolab Docs -> 

## Other issues / help required
Form validation logic could be more thorough such that any metric that has been checked requires that its fields be non-empty and valid.
