### PR TITLE
API endpoint for updating metrics condition

### DIFF
--- a/app/controllers/metrics_controller.rb
+++ b/app/controllers/metrics_controller.rb
@@ -48,23 +48,35 @@ class MetricsController < ApplicationController
 		# The request parameters must take on the following format:
 		# params[type_a] is nil if instructor does not want to include a risk condition of type_a during update
 		# params[type_a] is an object satisfying the parameter requirement for type_a condition
-		# e.g. params[1] should have form { :grace_day_threshold => 3, :date => "2020-03-05" }
+		# e.g. params["grace_day_usage"] should have form { "grace_day_threshold" => 3, "date" => "2020-03-05" }
 		# Currently, four types of risk conditions are supported:
-		# 1 for :grace_day_usage with parameters :grace_day_threshold, :date
-		# 2 for :grade_drop with parameters :percentage_drop, :consecutive_counts
-		# 3 for :no_submission with parameter :no_submissions_threshold
-		# 4 for :low_grades with parameters :grade_threshold, :count_threshold
-		# 0 is reserved for when a course assistant deselects all conditions; user of this endpoint doesn't need to account for this
-		# On error, a flash error message will be shown and nil gets returned
+		# "grace_day_usage" with parameters "grace_day_threshold", "date"
+		# "grade_drop" with parameters "percentage_drop", "consecutive_counts"
+		# "no_submissions" with parameter "no_submissions_threshold"
+		# "low_grades" with parameters "grade_threshold", "count_threshold"
+		# On error, a flash error message will be rendered and nil gets returned
 		begin
 			course_name = params[:course_name]
-			# TODO: need to further investigate what form data passed in takes on
-			conditions = RiskCondition.update_current_for_course(course_name, params.except(:course_name))
-			# TODO: what exactly does render do?
+			params_filtered = new_metrics_params
+			if params_filtered.nil?
+				params_filtered = {}
+			else
+				params_filtered = params_filtered.to_h
+			end
+			conditions = RiskCondition.update_current_for_course(course_name, params_filtered)
 			render json: conditions
 		rescue => error
-			flash[:error] => error.message
-			return
+			flash[:error] = error.message
+			render json: {}
 		end
+	end
+
+private
+	
+	def new_metrics_params
+		return params.require(:metric).permit(:grace_day_usage => [:grace_day_threshold, :date],
+											  :grade_drop => [:percentage_drop, :consecutive_counts],
+											  :no_submissions => [:no_submissions_threshold],
+											  :low_grades => [:grade_threshold, :count_threshold]) if params[:metric].present?
 	end
 end

--- a/app/controllers/metrics_controller.rb
+++ b/app/controllers/metrics_controller.rb
@@ -17,7 +17,7 @@ class MetricsController < ApplicationController
 			conditions = RiskCondition.get_current_for_course(course_name)
 			render json: conditions
 		rescue => error
-			flash[:error] = error.message
+			render :text => 'Not Found', :status => '404'
 			return
 		end
 	end
@@ -63,11 +63,14 @@ class MetricsController < ApplicationController
 			else
 				params_filtered = params_filtered.to_h
 			end
+			if params_filtered != params[:metric]
+				raise "Invalid update parameters for risk conditions! Make sure your request body fits the criteria!"
+			end
 			conditions = RiskCondition.update_current_for_course(course_name, params_filtered)
 			render json: conditions
 		rescue => error
-			flash[:error] = error.message
-			render json: {}
+			render json: { error: error.message }, status: :bad_request
+			return
 		end
 	end
 

--- a/app/controllers/metrics_controller.rb
+++ b/app/controllers/metrics_controller.rb
@@ -24,7 +24,18 @@ class MetricsController < ApplicationController
 
 	action_auth_level :update_current_metrics, :instructor
 	def update_current_metrics
-		# The code below assumes the post data is consistent with the type/parameter relation as is defined in risk_condition.rb
+		# This API endpoint aims to update current/latest risk conditions for a particular course
+		# On success, a JSON list of condition objects that are freshly created out of the request parameters will be returned
+		# The request parameters must take on the following format:
+		# params[type_a] is nil if instructor does not want to include a risk condition of type_a during update
+		# params[type_a] is an object satisfying the parameter requirement for type_a condition
+		# e.g. params[0] should have form { :grace_day_threshold => 3, :date => "2020-03-05" }
+		# Currently, four types of risk conditions are supported:
+		# 0 for :grace_day_usage with parameters :grace_day_threshold, :date
+		# 1 for :grade_drop with parameters :percentage_drop, :consecutive_counts
+		# 2 for :no_submission with parameter :no_submissions_threshold
+		# 3 for :low_grades with parameters :grade_threshold, :count_threshold
+		# On error, a flash error message will be shown and nil gets returned
 		begin
 			course_name = params[:course_name]
 			conditions = RiskCondition.update_current_for_course(course_name, params)

--- a/app/controllers/metrics_controller.rb
+++ b/app/controllers/metrics_controller.rb
@@ -48,19 +48,22 @@ class MetricsController < ApplicationController
 		# The request parameters must take on the following format:
 		# params[type_a] is nil if instructor does not want to include a risk condition of type_a during update
 		# params[type_a] is an object satisfying the parameter requirement for type_a condition
-		# e.g. params[0] should have form { :grace_day_threshold => 3, :date => "2020-03-05" }
+		# e.g. params[1] should have form { :grace_day_threshold => 3, :date => "2020-03-05" }
 		# Currently, four types of risk conditions are supported:
-		# 0 for :grace_day_usage with parameters :grace_day_threshold, :date
-		# 1 for :grade_drop with parameters :percentage_drop, :consecutive_counts
-		# 2 for :no_submission with parameter :no_submissions_threshold
-		# 3 for :low_grades with parameters :grade_threshold, :count_threshold
+		# 1 for :grace_day_usage with parameters :grace_day_threshold, :date
+		# 2 for :grade_drop with parameters :percentage_drop, :consecutive_counts
+		# 3 for :no_submission with parameter :no_submissions_threshold
+		# 4 for :low_grades with parameters :grade_threshold, :count_threshold
+		# 0 is reserved for when a course assistant deselects all conditions; user of this endpoint doesn't need to account for this
 		# On error, a flash error message will be shown and nil gets returned
 		begin
 			course_name = params[:course_name]
-			conditions = RiskCondition.update_current_for_course(course_name, params)
+			# TODO: need to further investigate what form data passed in takes on
+			conditions = RiskCondition.update_current_for_course(course_name, params.except(:course_name))
+			# TODO: what exactly does render do?
 			render json: conditions
 		rescue => error
-			flash[:error] = error.message
+			flash[:error] => error.message
 			return
 		end
 	end

--- a/app/controllers/metrics_controller.rb
+++ b/app/controllers/metrics_controller.rb
@@ -21,4 +21,17 @@ class MetricsController < ApplicationController
 			return
 		end
 	end
+
+	action_auth_level :update_current_metrics, :instructor
+	def update_current_metrics
+		# The code below assumes the post data is consistent with the type/parameter relation as is defined in risk_condition.rb
+		begin
+			course_name = params[:course_name]
+			conditions = RiskCondition.update_current_for_course(course_name, params)
+			render json: conditions
+		rescue => error
+			flash[:error] = error.message
+			return
+		end
+	end
 end

--- a/app/models/risk_condition.rb
+++ b/app/models/risk_condition.rb
@@ -11,7 +11,7 @@ class RiskCondition < ApplicationRecord
   # :no_submissions => :no_submissions_threshold
   # :low_grades => :grade_threshold, :count_threshold
 
-  def self.create_condition_for_course_with_type(course_id, type, params)
+  def self.create_condition_for_course_with_type(course_id, type, params, version)
   	# parameter check shouldn't surface to user and is for sanity check during development only
     if (type == :grace_day_usage && (params[:grace_day_threshold].nil? || params[:date].nil? || params.length != 2)) ||
        (type == :grade_drop && (params[:percentage_drop].nil? || params[:consecutive_counts].nil? || params.length != 2)) ||
@@ -20,22 +20,40 @@ class RiskCondition < ApplicationRecord
       raise "Parameters for risk condition does not match type!"
     end
 
-    version = RiskCondition.get_version(course_id, type)
     options = { course_id: course_id, condition_type: type, parameters: params, version: version }
     newRiskCondition = RiskCondition.new(options)
     if not newRiskCondition.save
       raise "Fail to create new risk condition with type #{type} for course #{course_id}"
     end
+    return newRiskCondition
   end
 
   def self.get_current_for_course(course_name)
     conditions = []
     course_id = Course.find_by(name: course_name).id
-    conditions_for_course = RiskCondition.where(course_id: course_id)
+    max_version = RiskCondition.get_max_version(course_id)
+    conditions_for_course = RiskCondition.where(course_id: course_id, :version => max_version)
+    # for type in RiskCondition.condition_types do
+    #   condition = conditions_for_course.where(condition_type: type[1]).order("version DESC").first
+    #   if not condition.nil?
+    #     conditions << condition
+    #   end
+    # end
+    # condition_versions = conditions.map { |h| h.version }
+    # max_version = condition_versions.max()
+    # conditions = conditions.select { |c| c.version == max_version }
+    return conditions_for_course
+  end
+
+  def self.update_current_for_course(course_name, params)
+    # The code below assumes params[type] contains a hash of the parameters needed for the type
+    conditions = []
+    course_id = Course.find_by(name: course_name).id
+    max_version = RiskCondition.get_max_version(course_id)
     for type in RiskCondition.condition_types do
-      condition = conditions_for_course.where(condition_type: type[1]).order("version DESC").first
-      if not condition.nil?
-        conditions << condition
+      if params[type[1]]
+        new_condition = create_condition_for_course_with_type(course_id, type[1], params[type[1]], max_version + 1)
+        conditions << new_condition;
       end
     end
     return conditions
@@ -50,6 +68,22 @@ private
     else
       return 1
     end
+  end
+
+  def self.get_max_version(course_id)
+    conditions = []
+    conditions_for_course = RiskCondition.where(course_id: course_id)
+    max_version = 0
+    for type in RiskCondition.condition_types do
+      condition = conditions_for_course.where(condition_type: type[1]).order("version DESC").first
+      if not condition.nil?
+        if condition.version > max_version
+          max_version = condition.version
+        end
+      end
+    end
+    
+    return max_version
   end
 
 end

--- a/app/models/risk_condition.rb
+++ b/app/models/risk_condition.rb
@@ -1,6 +1,6 @@
 class RiskCondition < ApplicationRecord
   serialize :parameters, Hash
-  enum condition_type: [:grace_day_usage, :grade_drop, :no_submissions, :low_grades]
+  enum condition_type: [:no_condition_selected, :grace_day_usage, :grade_drop, :no_submissions, :low_grades]
 
   has_many :watchlist_instances, dependent: :destroy
   belongs_to :course
@@ -13,10 +13,10 @@ class RiskCondition < ApplicationRecord
 
   def self.create_condition_for_course_with_type(course_id, type, params, version)
   	# parameter check shouldn't surface to user and is for sanity check during development only
-    if (type == :grace_day_usage && (params[:grace_day_threshold].nil? || params[:date].nil? || params.length != 2)) ||
-       (type == :grade_drop && (params[:percentage_drop].nil? || params[:consecutive_counts].nil? || params.length != 2)) ||
-       (type == :no_submissions && (params[:no_submissions_threshold].nil? || params.length != 1)) ||
-       (type == :low_grades && (params[:grade_threshold].nil? || params[:count_threshold].nil? || params.length != 2))
+    if (type == 1 && (params[:grace_day_threshold].nil? || params[:date].nil? || params.length != 2)) ||
+       (type == 2 && (params[:percentage_drop].nil? || params[:consecutive_counts].nil? || params.length != 2)) ||
+       (type == 3 && (params[:no_submissions_threshold].nil? || params.length != 1)) ||
+       (type == 4 && (params[:grade_threshold].nil? || params[:count_threshold].nil? || params.length != 2))
       raise "Parameters for risk condition does not match type!"
     end
 
@@ -32,22 +32,76 @@ class RiskCondition < ApplicationRecord
     conditions = []
     course_id = Course.find_by(name: course_name).id
     max_version = RiskCondition.get_max_version(course_id)
-    conditions_for_course = RiskCondition.where(course_id: course_id, :version => max_version)
-    return conditions_for_course
+    
+    return [] if max_version == 0
+    
+    conditions_for_course = RiskCondition.where(course_id: course_id, version: max_version)
+    condition_types = conditions_for_course.map { |condition| condition.condition_type.to_sym }
+    if condition_types.any? { |type| type == :no_condition_selected }
+      return []
+    else
+      return conditions_for_course
+    end
   end
 
   def self.update_current_for_course(course_name, params)
     # The code below assumes params[type] contains a hash of the parameters needed for the type
-    conditions = []
+    # where type is the actual enumeration number
+    # params should also be stripped off of the course_name key for ease of process
+
     course_id = Course.find_by(name: course_name).id
     max_version = RiskCondition.get_max_version(course_id)
-    for type in RiskCondition.condition_types do
-      if params[type[1]]
-        new_condition = create_condition_for_course_with_type(course_id, type[1], params[type[1]], max_version + 1)
-        conditions << new_condition;
+    # Is params empty?
+    if params.length == 0 and max_version == 0
+      puts "case 1: max_version = 0 (no previous conditons have been set) and instructor doesn't want any at this point"
+      return []
+    elsif max_version > 0
+      previous_conditions = RiskCondition.where(course_id: course_id, version: max_version)
+      previous_types = previous_conditions.map { |c| c.condition_type.to_sym }
+      if params.length == 0
+        unless previous_types.any? { |t| t == :no_condition_selected }
+          puts "case 2: previous conditions set to something and instructor doesn't want any this time"
+          create_condition_for_course_with_type(course_id, 0, {}, max_version + 1)
+        else
+          puts "case 3: previous conditions set to nothing selected and instructor doesn't want any this time either"
+        end
+        # indicator row for "currently no conditions selected" that user doesn't need to access
+        return []
+      else
+        conditions = []
+        no_change = true
+        condition_types = self.condition_types
+        if params.length == previous_types.length
+          previous_conditions.map do |c|
+            type_num = condition_types[c.condition_type]
+            unless params[type_num] == c.parameters
+              no_change = false
+            end
+          end
+        else
+          no_change = false
+        end
+
+        unless no_change
+          puts "case 4: instructor changed conditions this time; previous conditions were either unset, or different from current parameters"
+          params.map do |k, v|
+            new_condition = create_condition_for_course_with_type(course_id, k, v, max_version + 1)
+            conditions << new_condition
+          end
+        else
+          puts "case 5: previous conditions and current conditions match and no update is needed"
+        end
+        return conditions
       end
+    else
+      puts "case 6: previous conditions were not set (i.e. max_version == 0) and instructor wants to set it to something"
+      conditions = []
+      params.map do |k, v|
+        new_condition = create_condition_for_course_with_type(course_id, k, v, max_version + 1)
+        conditions << new_condition
+      end
+      return conditions
     end
-    return conditions
   end
 
 private

--- a/app/models/risk_condition.rb
+++ b/app/models/risk_condition.rb
@@ -33,15 +33,6 @@ class RiskCondition < ApplicationRecord
     course_id = Course.find_by(name: course_name).id
     max_version = RiskCondition.get_max_version(course_id)
     conditions_for_course = RiskCondition.where(course_id: course_id, :version => max_version)
-    # for type in RiskCondition.condition_types do
-    #   condition = conditions_for_course.where(condition_type: type[1]).order("version DESC").first
-    #   if not condition.nil?
-    #     conditions << condition
-    #   end
-    # end
-    # condition_versions = conditions.map { |h| h.version }
-    # max_version = condition_versions.max()
-    # conditions = conditions.select { |c| c.version == max_version }
     return conditions_for_course
   end
 
@@ -61,29 +52,16 @@ class RiskCondition < ApplicationRecord
 
 private
 
-  def self.get_version(course_id, type)
-    previous = RiskCondition.where(course_id: course_id, condition_type: type).order("version DESC")
-    if previous.first
-      return previous.first.version + 1
-    else
-      return 1
-    end
-  end
-
   def self.get_max_version(course_id)
     conditions = []
     conditions_for_course = RiskCondition.where(course_id: course_id)
-    max_version = 0
-    for type in RiskCondition.condition_types do
-      condition = conditions_for_course.where(condition_type: type[1]).order("version DESC").first
-      if not condition.nil?
-        if condition.version > max_version
-          max_version = condition.version
-        end
-      end
+    versions = conditions_for_course.map { |each| each.version }
+    max_version = versions.max
+    if max_version.nil?
+      return 0
+    else
+      return max_version
     end
-    
-    return max_version
   end
 
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -71,6 +71,7 @@ Rails.application.routes.draw do
     
     get "metrics", to: 'metrics#index'
     get 'metrics/get_current_metrics', to: 'metrics#get_current_metrics'
+    post 'metrics/update_current_metrics', to: 'metrics#update_current_metrics'
     get 'metrics/get_watchlist_instances', to: 'metrics#get_watchlist_instances'
 
     resources :jobs, only: :index do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -71,7 +71,6 @@ Rails.application.routes.draw do
     
     get "metrics", to: 'metrics#index'
     get 'metrics/get_current_metrics', to: 'metrics#get_current_metrics'
-    get 'metrics/update_current_metrics', to: 'metrics#update_current_metrics'
 
     resources :jobs, only: :index do
       get "getjob", on: :member

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -71,6 +71,7 @@ Rails.application.routes.draw do
     
     get "metrics", to: 'metrics#index'
     get 'metrics/get_current_metrics', to: 'metrics#get_current_metrics'
+    get 'metrics/update_current_metrics', to: 'metrics#update_current_metrics'
 
     resources :jobs, only: :index do
       get "getjob", on: :member


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR adds the API endpoint for updating metrics conditions for the metrics feature.

## Motivation and Context
When instructor submits the form to update their current risk metrics conditions, they need a way for the backend to update the database information accordingly. This PR does exactly that.

## How Has This Been Tested?
1. Due to Autolab's level of security, to test this PR with the fetch API in console, you need to disable protect_from_forgery temporarily. This is located at app/controllers/application_controller.rb. Comment out the relevant lines as below. Remember to uncomment them back once you are done with testing. (Let me know if this is not the legit way to get around the problem of authentication.)
![Screen Shot 2020-11-10 at 4 46 03 PM](https://user-images.githubusercontent.com/54905587/98650798-5ab63080-2374-11eb-8986-b0fe217d84cc.png)
2. The update_current_for_course method in app/models/risk_condition.rb has some commented-out debug print statements. Feel free to uncomment them during testing. Request me to remove these once you think this PR is ready to merge.
![Screen Shot 2020-11-10 at 4 51 12 PM](https://user-images.githubusercontent.com/54905587/98651268-fe9fdc00-2374-11eb-9da6-2d477ed0d93f.png)

3. Start your rails server. Go to 'courses/AutoPopulated/metrics'. Open up your console. The parameter requirement has been stated in the documentation of the API endpoint in app/controllers/metrics_controller.rb. Use fetch API to simulate POST requests with url 'courses/AutoPopulated/metrics/update_current_metrics' and offer a body according to the parameter criteria. For example,
![Screen Shot 2020-11-10 at 4 56 54 PM](https://user-images.githubusercontent.com/54905587/98651866-c51ba080-2375-11eb-83bc-4982ab89290f.png)
Check back on your terminal. If you uncommented the debug statements, you should see relevant information printed out.
![Screen Shot 2020-11-10 at 4 59 14 PM](https://user-images.githubusercontent.com/54905587/98652130-26437400-2376-11eb-8959-2552d9dca78b.png)
Otherwise, you can also go to 'courses/AutoPopulated/metrics/get_current_metrics' using the previously defined API to verify the latest risk conditions.
4. Start from no risk conditions defined at all. Perform the following basic test:
- Send a request with no parameter; no change is made to database and get_current_metrics returns nothing.
- Send a request with some parameter of your choice; database is updated to reflect that change and get_current_metrics returns the conditions consistent with your parameters.
- Send a request with the same parameter as above; no change is made to database; get_current_metrics returns the same conditions as before.
- Send a request with some different non-empty parameters; change is made to database; get_current_metrics returns conditions consistent with the new parameters.
- Send a request with an empty parameter; change is made to database; get_current_metrics returns nothing.
- Send a request with an empty parameter again; no change; get_current_metrics returns nothing.
- Send a request with non-empty parameter; change; get_current_metrics returns conditions consistent with your parameters.
5. Use fetch API to either break the parameter format or do another cascade of test similar to the one above. When format breaks, no change is made to database and refreshing 'courses/AutoPopulated/metrics' should display the error in the flash message.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR

## Other issues / help required
1. What should the POST API return at the end? Should it still be render json:?
2. Because the error cases are more complicated and varied for this API call, how should I surface these errors? In addition, most of the errors will be for the sake of debugging when developing, do we need to consider how to surface those to potential users?
