### PR TITLE
Get Number of New Watchlist Instance Endpoint

### DIFF
--- a/app/controllers/metrics_controller.rb
+++ b/app/controllers/metrics_controller.rb
@@ -33,10 +33,25 @@ class MetricsController < ApplicationController
 		# On error, a 404 error is returned
 		begin
 			course_name = params[:course_name]
-			conditions = WatchlistInstance.get_instances_for_course(course_name)
-			render json: conditions
+			instances = WatchlistInstance.get_instances_for_course(course_name)
+			render json: instances
 		rescue => error
-			render :text => 'Not Found', :status => '404'
+			render json: {error:error.message}, status: :not_found
+			return
+		end
+	end
+
+	action_auth_level :get_number_new_instances, :instructor
+	def get_number_new_instances
+		# This API endpoint retrieves the number of new watchlist instances for a particular course
+		# On success, a JSON containing num_new will be returned
+		# On error, a 404 error is returned
+		begin
+			course_name = params[:course_name]
+			number = WatchlistInstance.get_num_new_instance_for_course(course_name)
+			render json: {"num_new":number}, :status=> :ok
+		rescue => error
+			render json: {error:error.message}, status: :not_found
 			return
 		end
 	end

--- a/app/controllers/metrics_controller.rb
+++ b/app/controllers/metrics_controller.rb
@@ -41,8 +41,8 @@ class MetricsController < ApplicationController
 		end
 	end
 
-	action_auth_level :get_number_new_instances, :instructor
-	def get_number_new_instances
+	action_auth_level :get_num_new_instances, :instructor
+	def get_num_new_instances
 		# This API endpoint retrieves the number of new watchlist instances for a particular course
 		# On success, a JSON containing num_new will be returned
 		# On error, a 404 error is returned

--- a/app/controllers/metrics_controller.rb
+++ b/app/controllers/metrics_controller.rb
@@ -15,9 +15,9 @@ class MetricsController < ApplicationController
 		begin
 			course_name = params[:course_name]
 			conditions = RiskCondition.get_current_for_course(course_name)
-			render json: conditions
+			render json: conditions, status: :ok
 		rescue => error
-			flash[:error] = error.message
+			render json: {error:error.message}, status: :not_found
 			return
 		end
 	end
@@ -34,7 +34,7 @@ class MetricsController < ApplicationController
 		begin
 			course_name = params[:course_name]
 			instances = WatchlistInstance.get_instances_for_course(course_name)
-			render json: instances
+			render json: instances, status: :ok
 		rescue => error
 			render json: {error:error.message}, status: :not_found
 			return
@@ -49,7 +49,7 @@ class MetricsController < ApplicationController
 		begin
 			course_name = params[:course_name]
 			number = WatchlistInstance.get_num_new_instance_for_course(course_name)
-			render json: {"num_new":number}, :status=> :ok
+			render json: {"num_new":number}, status: :ok
 		rescue => error
 			render json: {error:error.message}, status: :not_found
 			return

--- a/app/models/watchlist_instance.rb
+++ b/app/models/watchlist_instance.rb
@@ -11,6 +11,15 @@ class WatchlistInstance < ApplicationRecord
       raise "Course #{course_name} cannot be found"
     end 
     return WatchlistInstance.where(course_id:course_id)
+  end
+  
+  def self.get_num_new_instance_for_course(course_name)
+    begin
+      course_id = Course.find_by(name:course_name).id
+    rescue NoMethodError
+      raise "Course #{course_name} cannot be found"
+    end 
+    return WatchlistInstance.where(course_id:course_id,status: :new).count()
   end 
 
   def archive_watchlist_instance

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -69,10 +69,13 @@ Rails.application.routes.draw do
         get "run"
     end
     
-    get "metrics", to: 'metrics#index'
-    get 'metrics/get_current_metrics', to: 'metrics#get_current_metrics'
-    get 'metrics/get_watchlist_instances', to: 'metrics#get_watchlist_instances'
-
+    resource :metrics, only: :index do
+      get "index"
+      get 'get_current_metrics'
+      get 'get_watchlist_instances'
+      get 'get_number_new_instances'
+      post 'update_watchlist_instances'
+    end
     resources :jobs, only: :index do
       get "getjob", on: :member
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -73,7 +73,7 @@ Rails.application.routes.draw do
       get "index"
       get 'get_current_metrics'
       get 'get_watchlist_instances'
-      get 'get_number_new_instances'
+      get 'get_num_new_instances'
       post 'update_watchlist_instances'
     end
     resources :jobs, only: :index do


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This endpoint allows you to get the number of new watchlist instance

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This is for the purpose of the notification badge on the course page, as we would prefer not needing to get all watchlist instances just to get the number of new ones.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Started with no new watchlist instances in the records
1. called endpoint, returns `{num_new:0}`
1. Add a new instance, called endpoint, returns `{num_new:1}`
1. Add another new instance, called endpoint, returns `{num_new:2}`
1. Call with invalid course, gets redirected to 404.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR
