### PR TITLE
Standardize blue colors (accessibility)

### DIFF
--- a/app/assets/stylesheets/annotations.css
+++ b/app/assets/stylesheets/annotations.css
@@ -494,13 +494,13 @@
   height: 100%;
 }
 .annotationSummary{
-  border: solid 2px #569ff7;
+  border: solid 2px #0882af;
   margin-bottom: 15px;
   color: #4f4f4f;
 }
 .annotationSummary h1{
   margin: 0px;
-  background-color: #569ff7;
+  background-color: #0882af;
   padding: 8px;
   border-right: none;
   border-left: none;

--- a/app/assets/stylesheets/gradesheet.css.scss
+++ b/app/assets/stylesheets/gradesheet.css.scss
@@ -286,5 +286,5 @@ td.id {
 }
 
 #interaction_badge{
-    color: #039be5
+    color: #0882af;
 }

--- a/app/assets/stylesheets/instructor_gradebook.css
+++ b/app/assets/stylesheets/instructor_gradebook.css
@@ -21,7 +21,6 @@
 
 #last_updated a {
   font: inherit;
-  color: #1874cd;
 }
 
 #last_updated a.regenerate {
@@ -105,7 +104,7 @@
 }
 
 #gradebook .slick-cell.andrew a {
-  color: #1874cd;
+  color: #0882af;
   text-decoration: none;
   font: inherit;
 }

--- a/app/assets/stylesheets/student_gradebook.css.scss
+++ b/app/assets/stylesheets/student_gradebook.css.scss
@@ -33,7 +33,6 @@ h1#courseTitle {
   }
 
   a {
-    color: #08c;
     font: inherit;
   }
 

--- a/app/assets/stylesheets/style.css.scss
+++ b/app/assets/stylesheets/style.css.scss
@@ -15,10 +15,15 @@ $autolab-subtle-red: #C87B7E;
 $autolab-subtle-gray: #eee;
 $autolab-highlight-gray: #ccc;
 $autolab-black-text: #212121;
+$autolab-blue-text: #0882af;
 #F2EFEF
 
 html, body {
   height: 100%;
+}
+
+a {
+  color: $autolab-blue-text;
 }
 
 /* Error Classes - for elements that display error/status messages */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Changed all instances of blue text to the new Autolab blue standard color of #0882af

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
As per Perkins suggestions: Current blue text on assignment handin page color does not meet 4.5:1 contrast ratio between text and background. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally be viewing all pages that contain blue text.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR

## Other issues / help required
<!--- Do you have any other relevant issues / questions? --->
<!--- For example, if you require assistance for a certain part of your PR --->
<!--- or are facing specific issues while creating the pull request that you would like to highlight --->

If unsure, feel free to submit first and we'll help you along.
