### PR TITLE
API endpoint for refreshing watchlist instances

### DIFF
--- a/app/controllers/metrics_controller.rb
+++ b/app/controllers/metrics_controller.rb
@@ -48,7 +48,10 @@ class MetricsController < ApplicationController
 			new_instances = WatchlistInstance.refresh_instances_for_course(course_name)
 			render json: new_instances
 		rescue => error
-			flash[:error] = error.message
+			render json: { error: error.message }, status: :bad_request
+			return
+		end
+	end
 
 	action_auth_level :update_current_metrics, :instructor
 	def update_current_metrics
@@ -91,5 +94,5 @@ private
 											  :no_submissions => [:no_submissions_threshold],
 											  :low_grades => [:grade_threshold, :count_threshold]) if params[:metric].present?
 	end
->>>>>>> metrics-feature
+
 end

--- a/app/controllers/metrics_controller.rb
+++ b/app/controllers/metrics_controller.rb
@@ -41,4 +41,16 @@ class MetricsController < ApplicationController
 		end
 	end
 
+	action_auth_level :refresh_watchlist_instances, :instructor
+	def refresh_watchlist_instances
+		begin
+			course_name = params[:course_name]
+			new_instances = WatchlistInstance.refresh_instances_for_course(course_name)
+			render json: new_instances
+		rescue => error
+			flash[:error] = error.message
+			return
+		end
+	end
+
 end

--- a/app/controllers/metrics_controller.rb
+++ b/app/controllers/metrics_controller.rb
@@ -58,6 +58,7 @@ class MetricsController < ApplicationController
 
 	action_auth_level :refresh_watchlist_instances, :instructor
 	def refresh_watchlist_instances
+
 		# This API endpoint refreshes the watchlist instances for a particular course from scratch
 		# Any previously added watchlist instances will be archived
 		# Any current watchlist instances whose risk conditions match the latest conditions will be destroyed
@@ -65,12 +66,16 @@ class MetricsController < ApplicationController
 		# params required would be the course name
 		# each watchlist instance will contain course_user_datum, course_id, risk_condition_id
 		# status (new, resolved, contacted), archived or not, and violation info 
-		# (a json containing more info pertaining to violation)
-		# On error, a 404 error is returned
+		# Specifically, violation info for each condition category takes on the following form (examples):
+		# grace_day_usage: { "Homework 1" => 2, "Homework 3" => 2 }
+		# grade_drop: { "Homework" => [{ "Homework 1" => "100/100", "Homework 3" => "80/100"}, ...], "Lab" => [{"Lab 1" => "10/10", "Lab 3" => "8/10" }] }
+		# no_submissions: { "no_submissions_asmt_names" => [ "Homework 1", "Quiz 2", ... ] }
+		# low_grades: { "Homework 1" => "70/100", ... }
+		# On error, an error json is rendered and status is set to :bad_request
 		begin
 			course_name = params[:course_name]
 			new_instances = WatchlistInstance.refresh_instances_for_course(course_name)
-			render json: new_instances
+			render json: new_instances, status: :ok
 		rescue => error
 			render json: { error: error.message }, status: :bad_request
 			return
@@ -90,7 +95,7 @@ class MetricsController < ApplicationController
 		# "grade_drop" with parameters "percentage_drop", "consecutive_counts"
 		# "no_submissions" with parameter "no_submissions_threshold"
 		# "low_grades" with parameters "grade_threshold", "count_threshold"
-		# On error, a flash error message will be rendered and nil gets returned
+		# On error, an error json will be rendered
 		begin
 			course_name = params[:course_name]
 			params_filtered = new_metrics_params
@@ -103,7 +108,7 @@ class MetricsController < ApplicationController
 				raise "Invalid update parameters for risk conditions! Make sure your request body fits the criteria!"
 			end
 			conditions = RiskCondition.update_current_for_course(course_name, params_filtered)
-			render json: conditions
+			render json: conditions, status: :ok
 		rescue => error
 			render json: { error: error.message }, status: :bad_request
 			return
@@ -123,6 +128,7 @@ class MetricsController < ApplicationController
 			course_name = params[:course_name]
 			if course_name.blank?
 				raise "Course name cannot be blank"
+			end
 		rescue => error
 			render json:  {error:error.message}, :status => :not_found
 			return
@@ -151,6 +157,7 @@ class MetricsController < ApplicationController
 		end
 
 		render json: {message:"Successfully updated instances"}, :status => :ok
+	end
 
 private
 	

--- a/app/controllers/metrics_controller.rb
+++ b/app/controllers/metrics_controller.rb
@@ -43,6 +43,15 @@ class MetricsController < ApplicationController
 
 	action_auth_level :refresh_watchlist_instances, :instructor
 	def refresh_watchlist_instances
+		# This API endpoint refreshes the watchlist instances for a particular course from scratch
+		# Any previously added watchlist instances will be archived
+		# Any current watchlist instances whose risk conditions match the latest conditions will be destroyed
+		# On success, a JSON list of watchlist instances will be returned
+		# params required would be the course name
+		# each watchlist instance will contain course_user_datum, course_id, risk_condition_id
+		# status (new, resolved, contacted), archived or not, and violation info 
+		# (a json containing more info pertaining to violation)
+		# On error, a 404 error is returned
 		begin
 			course_name = params[:course_name]
 			new_instances = WatchlistInstance.refresh_instances_for_course(course_name)

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -334,6 +334,10 @@ class Assessment < ApplicationRecord
     end
   end
 
+  # to be able to calculate total score for an assessment from another model
+  def default_total_score
+    problems.sum :max_score
+  end
 
 private
 

--- a/app/models/risk_condition.rb
+++ b/app/models/risk_condition.rb
@@ -60,7 +60,9 @@ class RiskCondition < ApplicationRecord
     if params.length == 0
       if previous_types.length > 0 and not previous_types.any? { |t| t == "no_condition_selected" }
         # puts "case 2: previous conditions set to something and instructor doesn't want any this time"
-        create_condition_for_course_with_type(course_id, 0, {}, max_version + 1)
+        ActiveRecord::Base.transaction do
+          create_condition_for_course_with_type(course_id, 0, {}, max_version + 1)
+        end
       # else
       #   puts "case 3: previous conditions set to nothing selected and instructor doesn't want any this time either"
       end
@@ -82,9 +84,11 @@ class RiskCondition < ApplicationRecord
 
       unless no_change
         # puts "case 4: instructor changed conditions this time; previous conditions were either unset, or different from current parameters"
-        params.map do |k, v|
-          new_condition = create_condition_for_course_with_type(course_id, self.condition_types[k], v, max_version + 1)
-          conditions << new_condition
+        ActiveRecord::Base.transaction do
+          params.map do |k, v|
+            new_condition = create_condition_for_course_with_type(course_id, self.condition_types[k], v, max_version + 1)
+            conditions << new_condition
+          end
         end
       # else
       #   puts "case 5: previous conditions and current conditions match and no update is needed"

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -278,6 +278,10 @@ class Submission < ApplicationRecord
     final_score_opts o
   end
 
+  def all_scores_released?
+    return self.scores.inject(true) { |result, score| result and score.released? }
+  end
+
   # NOTE: threshold  is no longer calculated using submission version,
   # but now using the number of submissions. This way, deleted submissions will
   # not be accounted for in the version penalty.

--- a/app/models/watchlist_instance.rb
+++ b/app/models/watchlist_instance.rb
@@ -15,9 +15,9 @@ class WatchlistInstance < ApplicationRecord
 
   def self.refresh_instances_for_course(course_name)
     begin
-      course_id = Coures.find_by(name: coures_name).id
-      current_conditions = RiskCondition.get_current_for_course(coures_name)
-      current_instances = WatchlistInstance.where(course_id: course_id)
+      course = Course.find_by(name: course_name)
+      current_conditions = RiskCondition.get_current_for_course(course_name)
+      current_instances = WatchlistInstance.where(course_id: course.id)
     rescue NoMethodError
       raise "Course #{course_name} cannot be found"
     end
@@ -25,7 +25,7 @@ class WatchlistInstance < ApplicationRecord
     # check whether the watchlist instances are up-to-date
     current_instances_condition_ids = (current_instances.map { |inst| inst.risk_condition_id }).uniq.to_set
     current_condition_ids = (current_conditions.map { |c| c.id }).uniq.to_set # should be unique by design but add the suffix to ensure
-    if current_instances_conditions_ids == current_instances_conditions_ids
+    if current_instances_condition_ids == current_condition_ids
       return current_instances
     else
       # update!
@@ -39,9 +39,11 @@ class WatchlistInstance < ApplicationRecord
         return []
       else
         # case 2: current risk conditions exist
-        new_instances = self.add_new_instances_for_conditions(current_conditions, course_id)
+        new_instances = self.add_new_instances_for_conditions(current_conditions, course)
+        return new_instances
       end
     end
+  end
 
   def archive_watchlist_instance
     if self.new_watchlist?
@@ -80,62 +82,91 @@ class WatchlistInstance < ApplicationRecord
 
 private
   
-  def self.add_new_instances_for_conditions(conditions, course_id)
+  def self.add_new_instances_for_conditions(conditions, course)
     # grace_day_usage: grace_day_threshold x and date y
     # grade_drop => percentage_drop x, consecutive_counts y
     # no_submissions => no_submissions_threshold x
     # low_grades => grade_threshold x, count_threshold y
     new_instances = []
-    course_user_data = CourseUserDatum.where(course_id: course_id, instructor: false, course_assistant: false)
+    course_user_data = CourseUserDatum.where(course_id: course.id, instructor: false, course_assistant: false)
     for condition in conditions
+      puts "#{condition.condition_type} with params #{condition.parameters}"
       case condition.condition_type
       
       when "grace_day_usage"
-        
         grace_day_threshold = condition.parameters[:grace_day_threshold]
         date = condition.parameters[:date]
-        
-        # assume for now date takes on the form "yyyy-mm-dd"
+        asmts = course.assessments.ordered
         for cud in course_user_data
-          aud_before_date = AssessmentUserDatum.where(course_user_datum_id: cud.id).where("updated_at < ?", date)
-          latest_aud_before_date = aud_before_date.order("updated_at DESC").first
-          next if latest_aud_before_date.nil?
+          asmts_before_date = asmts.where("updated_at < ?", date)
+          latest_asmt = asmts_before_date.last
+          next if latest_asmt.nil?
+          auds_before_date = asmts_before_date.map { |asmt| AssessmentUserDatum.find_by(course_user_datum_id: cud.id, assessment_id: asmt.id) }
+          # select as an assertion
+          auds_before_date.select! { |aud| not aud.nil? }
+          latest_aud_before_date = auds_before_date.last
           if latest_aud_before_date.global_cumulative_grace_days_used >= grace_day_threshold
-            # add new instance
             violation_info = {}
-            aud_before_date.map { |aud| violation_info[aud.assessment_id] = aud.grace_days_used }
-            violation_info.select! { |k, v| v > 0 }
-            new_instance = WatchlistInstance.new(course_user_datum_id: cud.id, course_id: course_id,
+            auds_before_date.map do |aud|
+              violation_info[aud.assessment.display_name] = aud.grace_days_used if aud.grace_days_used > 0
+            end
+            puts "Course user datum #{cud.id} with violation info #{violation_info}"
+            new_instance = WatchlistInstance.new(course_user_datum_id: cud.id, course_id: course.id,
                                                  risk_condition_id: condition.id,
                                                  violation_info: violation_info)
+            if not new_instance.save
+              raise "Fail to create new watchlist instance for CUD #{cud.id} in course #{course.name} with violation info #{violation_info}"
+            end
             new_instances << new_instance;
           end
         end
 
       when "grade_drop"
-        # TODO: confirm with the team about different categories
         percentage_drop = (condition.parameters[:percentage_drop]).to_f
         consecutive_counts = condition.parameters[:consecutive_counts]
         
+        categories = course.assessment_categories
+        asmt_arrs = categories.map { |category| course.assessments_with_category(category).ordered }
+        asmt_arrs.select! { |asmts| asmts.length >= consecutive_counts}
         for cud in course_user_data
-          auds = AssessmentUserDatum.where(course_user_datum_id: cud.id)
-          next if auds.length < consecutive_counts
-          i = 0
-          while i+consecutive_counts-1 < auds.length
-            begin_aud = auds[i]
-            end_aud = auds[i+consecutive_counts-1]
-            begin_grade = begin_aud.final_score(cud)
-            end_grade = end_aud.final_score(cud)
-            next if end_grade >= begin_grade
-            diff = (begin_grade - end_grade) * 100.0 / begin_grade
-            if diff >= percentage_drop
-              violation_info = {}
-              violation_info[begin_aud.assessment_id] = begin_grade
-              violation_info[end_aud.assesssment_id] = end_grade
-              new_instance = WatchlistInstance.new(course_user_datum_id: cud.id, course_id: course_id,
-                                                   risk_condition_id: condition.id,
-                                                   violation_info: violation_info)
+          violation_info = {}
+          for asmts in asmt_arrs
+            auds = asmts.map { |asmt| AssessmentUserDatum.find_by(course_user_datum_id: cud.id, assessment_id: asmt.id) }
+            puts "category #{asmts[0].display_name}"
+            # select as an assertion
+            auds.select! { |aud| not aud.nil? }
+            violating_pairs = []
+            i = 0
+            while i+consecutive_counts-1 < auds.length
+              puts i
+              begin_aud = auds[i]
+              end_aud = auds[i+consecutive_counts-1]
+              begin_grade = begin_aud.final_score(cud)
+              end_grade = end_aud.final_score(cud)
+              if end_grade >= begin_grade
+                i = i + 1
+                next
+              end
+              diff = (begin_grade - end_grade) * 100.0 / begin_grade
+              if diff >= percentage_drop
+                pair = {}
+                pair[begin_aud.assessment.display_name] = begin_grade
+                pair[end_aud.assessment.display_name] = end_grade
+                violating_pairs << pair
+              end
+              i = i + 1
             end
+            violation_info[asmts[0].category_name] = violating_pairs if violating_pairs.length > 0
+          end
+          if violation_info.length > 0
+            puts "Course user datum #{cud.id} with violation info #{violation_info}"
+            new_instance = WatchlistInstance.new(course_user_datum_id: cud.id, course_id: course.id,
+                                                 risk_condition_id: condition.id,
+                                                 violation_info: violation_info)
+            if not new_instance.save
+              raise "Fail to create new watchlist instance for CUD #{cud.id} in course #{course.name} with violation info #{violation_info}"
+            end
+            new_instances << new_instance
           end
         end
 
@@ -144,35 +175,51 @@ private
 
         for cud in course_user_data
           auds = AssessmentUserDatum.where(course_user_datum_id: cud.id)
-          no_submissions_asmt_ids = []
-          auds.map { |aud| no_submissions_asmt_ids << aud.assessment_id if aud.latest_submission.nil? }
-          if no_submissions_asmt_ids.length >= no_submissions_threshold
-            new_instance = WatchlistInstance.new(course_user_datum_id: cud.id, course_id: course_id,
+          no_submissions_asmt_names = []
+          auds.map { |aud| no_submissions_asmt_names << aud.assessment.display_name if aud.latest_submission.nil? }
+          if no_submissions_asmt_names.length >= no_submissions_threshold
+            puts "Course user datum #{cud.id} with violation info #{violation_info}"
+            new_instance = WatchlistInstance.new(course_user_datum_id: cud.id, course_id: course.id,
                                                  risk_condition_id: condition.id,
-                                                 violation_info: { :no_submissions_asmt_ids => no_submissions_asmt_ids })
+                                                 violation_info: { :no_submissions_asmt_names => no_submissions_asmt_names })
+            if not new_instance.save
+              raise "Fail to create new watchlist instance for CUD #{cud.id} in course #{course.name} with violation info #{violation_info}"
+            end
+            new_instances << new_instance
           end
         end
+
       when "low_grades"
-        grade_threshold = condition.parameters[:grade_threshold]
+        grade_threshold = condition.parameters[:grade_threshold].to_f
         count_threshold = condition.parameters[:count_threshold]
 
         for cud in course_user_data
           auds = AssessmentUserDatum.where(course_user_datum_id: cud.id)
           violation_info = {}
           auds.map do |aud|
-            score_percent = aud.final_score(cud) * 100.0 / aud.assessment.default_total_score
+            aud_score = aud.final_score(cud)
+            total = aud.assessment.default_total_score
+            score_percent = aud_score * 100.0 / total
             if score_percent < grade_threshold
-              violation_info[aud.assessment_id] = score_percent
+              violation_info[aud.assessment.display_name] = "#{aud_score}/#{total}"
             end
           end
           if violation_info.length >= count_threshold
+            puts "Course user datum #{cud.id} with violation info #{violation_info}"
             new_instance = WatchlistInstance.new(course_user_datum_id: cud.id, course_id: course_id,
                                                  risk_condition_id: condition.id,
-                                                 violation_info: { violation_info })
+                                                 violation_info: violation_info)
+            if not new_instance.save
+              raise "Fail to create new watchlist instance for CUD #{cud.id} in course #{course.name} with violation info #{violation_info}"
+            end
+            new_instances << new_instance
           end
         end
       end
+      puts ""
     end
+
+    return new_instances
   end
 
 end

--- a/app/models/watchlist_instance.rb
+++ b/app/models/watchlist_instance.rb
@@ -13,6 +13,36 @@ class WatchlistInstance < ApplicationRecord
     return WatchlistInstance.where(course_id:course_id)
   end 
 
+  def self.refresh_instances_for_course(course_name)
+    begin
+      course_id = Coures.find_by(name: coures_name).id
+      current_conditions = RiskCondition.get_current_for_course(coures_name)
+      current_instances = WatchlistInstance.where(course_id: course_id)
+    rescue NoMethodError
+      raise "Course #{course_name} cannot be found"
+    end
+
+    # check whether the watchlist instances are up-to-date
+    current_instances_condition_ids = (current_instances.map { |inst| inst.risk_condition_id }).uniq.to_set
+    current_condition_ids = (current_conditions.map { |c| c.id }).uniq.to_set # should be unique by design but add the suffix to ensure
+    if current_instances_conditions_ids == current_instances_conditions_ids
+      return current_instances
+    else
+      # update!
+      # archive previous watchlist instances first
+      for instance in current_instances
+        instance.archive_watchlist_instance
+      end
+      # now check current conditions
+      if current_conditions.length == 0
+        # case 1: no current risk conditions exist
+        return []
+      else
+        # case 2: current risk conditions exist
+        new_instances = self.add_new_instances_for_conditions(current_conditions, course_id)
+      end
+    end
+
   def archive_watchlist_instance
     if self.new_watchlist?
       self.destroy
@@ -45,6 +75,47 @@ class WatchlistInstance < ApplicationRecord
       end
     else
       raise "Unable to resolve a watchlist instance that is not new or contacted #{self.id}"
+    end
+  end
+
+private
+  
+  def self.add_new_instances_for_conditions(conditions)
+    # grace_day_usage: grace_day_threshold x and date y
+    # grade_drop => percentage_drop x, consecutive_counts y
+    # no_submissions => no_submissions_threshold x
+    # low_grades => grade_threshold x, count_threshold y
+    new_instances = []
+    for condition in conditions
+      case condition.condition_type
+      when "grace_day_usage"
+        grace_day_threshold = condition.parameters[:grace_day_threshold]
+        date = condition.parameters[:date]
+        # assume for now date takes on the form "yyyy-mm-dd"
+        course_user_data = CourseUserDatum.where(course_id: course_id, instructor: false, course_assistant: false)
+        for cud in course_user_data
+          latest_aud_before_date = AssessmentUserDatum.where(course_user_datum_id: cud.id).
+                                                       where("updated_at < ?", date).
+                                                       order("updated_at DESC").first
+          next if latest_aud_before_date.nil?
+          if latest_aud_before_date.global_cumulative_grace_days_used >= grace_day_threshold
+            # add new instance
+            new_instance = WatchlistInstance.new(course_user_datum_id: cud.id, course_id: condition.course_id,
+                                                 risk_condition_id: condition.id,
+                                                 violation_info: {}, # TODO
+                                                 )
+            new_instances << new_instance;
+          end
+        end
+      when "grade_drop"
+        percentage_drop = condition.parameters[:percentage_drop]
+        consecutive_counts = condition.parameters[:consecutive_counts]
+      when "no_submissions"
+        no_submissions_threshold = condition.parameters[:no_submissions_threshold]
+      when "low_grades"
+        grade_threshold = condition.parameters[:grade_threshold]
+        count_threshold = condition.parameters[:count_threshold]
+      end
     end
   end
 

--- a/app/models/watchlist_instance.rb
+++ b/app/models/watchlist_instance.rb
@@ -261,11 +261,12 @@ private
     violation_info = {}
     auds.each do |aud|
       aud_score = aud.final_score(cud)
-      # DDL not passed yet
-      next if aud_score.nil?
-      # Score has not been released yet
-      if aud.latest_submission and not aud.latest_submission.all_scores_released?
-        puts "Score has not been released yet."
+      # - DDL not passed yet
+      # - Score has not been released yet
+      # - Student did not make any submissions at all
+      if aud_score.nil? or
+         aud.latest_submission.nil? or
+         (aud.latest_submission and not aud.latest_submission.all_scores_released?)
         next
       end
       total = aud.assessment.default_total_score

--- a/app/models/watchlist_instance.rb
+++ b/app/models/watchlist_instance.rb
@@ -122,7 +122,7 @@ private
     course_user_data = CourseUserDatum.where(course_id: course.id, instructor: false, course_assistant: false)
     # HUGE TRANSACTION AHEAD
     ActiveRecord::Base.transaction do
-      for condition in conditions
+      conditions.each do |condition|
         case condition.condition_type
         
         when "grace_day_usage"
@@ -133,25 +133,8 @@ private
             asmts_before_date = asmts.where("updated_at < ?", date)
             latest_asmt = asmts_before_date.last
             next if latest_asmt.nil?
-            auds_before_date = asmts_before_date.map { |asmt| AssessmentUserDatum.find_by(course_user_datum_id: cud.id, assessment_id: asmt.id) }
-            auds_before_date_filtered = auds_before_date.select { |aud| not aud.nil? }
-            if auds_before_date_filtered.count < auds_before_date.count
-              raise "Assessment user datum does not exist for some assessments for course user datum #{cud.id}"
-            end
-            latest_aud_before_date = auds_before_date.last
-            if latest_aud_before_date.global_cumulative_grace_days_used >= grace_day_threshold
-              violation_info = {}
-              auds_before_date.each do |aud|
-                violation_info[aud.assessment.display_name] = aud.grace_days_used if aud.grace_days_used > 0
-              end
-              new_instance = WatchlistInstance.new(course_user_datum_id: cud.id, course_id: course.id,
-                                                   risk_condition_id: condition.id,
-                                                   violation_info: violation_info)
-              if not new_instance.save
-                raise "Fail to create new watchlist instance for CUD #{cud.id} in course #{course.name} with violation info #{violation_info}"
-              end
-              new_instances << new_instance;
-            end
+            new_instance = self.add_new_instance_for_cud_grace_day_usage(course, condition.id, cud, asmts_before_date, grace_day_threshold)
+            new_instances << new_instance unless new_instance.nil?
           end
 
         when "grade_drop"
@@ -162,74 +145,16 @@ private
           asmt_arrs = categories.map { |category| course.assessments_with_category(category).ordered }
           asmt_arrs.select! { |asmts| asmts.count >= consecutive_counts}
           for cud in course_user_data
-            violation_info = {}
-            for asmts in asmt_arrs
-              auds = asmts.map { |asmt| AssessmentUserDatum.find_by(course_user_datum_id: cud.id, assessment_id: asmt.id) }
-              auds_filtered = auds.select { |aud| not aud.nil? }
-              if auds_filtered.count < auds.count
-                raise "Assessment user datum does not exist for some assessments for course user datum #{cud.id}"
-              end
-              violating_pairs = []
-              i = 0
-              while i+consecutive_counts-1 < auds.count
-                begin_aud = auds[i]
-                end_aud = auds[i+consecutive_counts-1]
-                begin_grade = begin_aud.final_score(cud)
-                end_grade = end_aud.final_score(cud)
-                # - Grading deadline has not passed yet
-                # - Score is not finalized and released to student yet
-                if end_grade.nil? or begin_grade.nil?
-                  i = i + 1
-                  next
-                end
-                begin_total = begin_aud.assessment.default_total_score
-                end_total = end_aud.assessment.default_total_score
-                begin_grade_percent = begin_grade * 100.0 / begin_total
-                end_grade_percent = end_grade * 100.0 / end_total
-                if end_grade_percent >= begin_grade_percent
-                  i = i + 1
-                  next
-                end
-                diff = (begin_grade_percent - end_grade_percent) * 100.0 / begin_grade_percent
-                if diff >= percentage_drop
-                  pair = {}
-                  pair[begin_aud.assessment.display_name] = "#{begin_grade}/#{begin_total}"
-                  pair[end_aud.assessment.display_name] = "#{end_grade}/#{end_total}"
-                  violating_pairs << pair
-                end
-                i = i + 1
-              end
-              violation_info[asmts[0].category_name] = violating_pairs if violating_pairs.length > 0
-            end
-            if violation_info.length > 0
-              new_instance = WatchlistInstance.new(course_user_datum_id: cud.id, course_id: course.id,
-                                                   risk_condition_id: condition.id,
-                                                   violation_info: violation_info)
-              if not new_instance.save
-                raise "Fail to create new watchlist instance for CUD #{cud.id} in course #{course.name} with violation info #{violation_info}"
-              end
-              new_instances << new_instance
-            end
+            new_instance = self.add_new_instance_for_cud_grade_drop(course, condition.id, cud, asmt_arrs, consecutive_counts, percentage_drop)
+            new_instances << new_instance unless new_instance.nil?
           end
 
         when "no_submissions"
           no_submissions_threshold = condition.parameters[:no_submissions_threshold]
 
           for cud in course_user_data
-            auds = AssessmentUserDatum.where(course_user_datum_id: cud.id)
-            no_submissions_asmt_names = []
-            auds.each do |aud|
-              no_submissions_asmt_names << aud.assessment.display_name if aud.latest_submission.nil?
-            end
-            if no_submissions_asmt_names.length >= no_submissions_threshold
-              new_instance = WatchlistInstance.new(course_user_datum_id: cud.id, course_id: course.id,
-                                                   risk_condition_id: condition.id,
-                                                   violation_info: { :no_submissions_asmt_names => no_submissions_asmt_names })
-              if not new_instance.save
-                raise "Fail to create new watchlist instance for CUD #{cud.id} in course #{course.name} with violation info #{violation_info}"
-              end
-              new_instances << new_instance
-            end
+            new_instance = self.add_new_instance_for_cud_no_submissions(course, condition.id, cud, no_submissions_threshold)
+            new_instances << new_instance unless new_instance.nil?
           end
 
         when "low_grades"
@@ -237,33 +162,129 @@ private
           count_threshold = condition.parameters[:count_threshold]
 
           for cud in course_user_data
-            auds = AssessmentUserDatum.where(course_user_datum_id: cud.id)
-            violation_info = {}
-            auds.each do |aud|
-              aud_score = aud.final_score(cud)
-              # score not out yet
-              next if aud_score.nil?
-              total = aud.assessment.default_total_score
-              score_percent = aud_score * 100.0 / total
-              if score_percent < grade_threshold
-                violation_info[aud.assessment.display_name] = "#{aud_score}/#{total}"
-              end
-            end
-            if violation_info.length >= count_threshold
-              new_instance = WatchlistInstance.new(course_user_datum_id: cud.id, course_id: course.id,
-                                                   risk_condition_id: condition.id,
-                                                   violation_info: violation_info)
-              if not new_instance.save
-                raise "Fail to create new watchlist instance for CUD #{cud.id} in course #{course.name} with violation info #{violation_info}"
-              end
-              new_instances << new_instance
-            end
+            new_instance = self.add_new_instance_for_cud_low_grades(course, condition.id, cud, grade_threshold, count_threshold)
+            new_instances << new_instance unless new_instance.nil?
           end
         end
       end
     end
 
     return new_instances
+  end
+
+  def self.add_new_instance_for_cud_grace_day_usage(course, condition_id, cud, asmts_before_date, grace_day_threshold)
+    auds_before_date = asmts_before_date.map { |asmt| AssessmentUserDatum.find_by(course_user_datum_id: cud.id, assessment_id: asmt.id) }
+    auds_before_date_filtered = auds_before_date.select { |aud| not aud.nil? }
+    if auds_before_date_filtered.count < auds_before_date.count
+      raise "Assessment user datum does not exist for some assessments for course user datum #{cud.id}"
+    end
+    latest_aud_before_date = auds_before_date.last
+    if latest_aud_before_date.global_cumulative_grace_days_used >= grace_day_threshold
+      violation_info = {}
+      auds_before_date.each do |aud|
+        violation_info[aud.assessment.display_name] = aud.grace_days_used if aud.grace_days_used > 0
+      end
+      new_instance = WatchlistInstance.new(course_user_datum_id: cud.id, course_id: course.id,
+                                           risk_condition_id: condition_id,
+                                           violation_info: violation_info)
+      if not new_instance.save
+        raise "Fail to create new watchlist instance for CUD #{cud.id} in course #{course.name} with violation info #{violation_info}"
+      end
+      return new_instance
+    end
+  end
+
+  def self.add_new_instance_for_cud_grade_drop(course, condition_id, cud, asmt_arrs, consecutive_counts, percentage_drop)
+    violation_info = {}
+    for asmts in asmt_arrs
+      auds = asmts.map { |asmt| AssessmentUserDatum.find_by(course_user_datum_id: cud.id, assessment_id: asmt.id) }
+      auds_filtered = auds.select { |aud| not aud.nil? }
+      if auds_filtered.count < auds.count
+        raise "Assessment user datum does not exist for some assessments for course user datum #{cud.id}"
+      end
+      violating_pairs = []
+      i = 0
+      while i+consecutive_counts-1 < auds.count
+        begin_aud = auds[i]
+        end_aud = auds[i+consecutive_counts-1]
+        begin_grade = begin_aud.final_score(cud)
+        end_grade = end_aud.final_score(cud)
+        # - Grading deadline has not passed yet
+        # - Score is not finalized and released to student yet
+        if end_grade.nil? or begin_grade.nil?
+          i = i + 1
+          next
+        end
+        begin_total = begin_aud.assessment.default_total_score
+        end_total = end_aud.assessment.default_total_score
+        begin_grade_percent = begin_grade * 100.0 / begin_total
+        end_grade_percent = end_grade * 100.0 / end_total
+        if end_grade_percent >= begin_grade_percent
+          i = i + 1
+          next
+        end
+        diff = (begin_grade_percent - end_grade_percent) * 100.0 / begin_grade_percent
+        if diff >= percentage_drop
+          pair = {}
+          pair[begin_aud.assessment.display_name] = "#{begin_grade}/#{begin_total}"
+          pair[end_aud.assessment.display_name] = "#{end_grade}/#{end_total}"
+          violating_pairs << pair
+        end
+        i = i + 1
+      end
+      violation_info[asmts[0].category_name] = violating_pairs if violating_pairs.length > 0
+    end
+
+    if violation_info.length > 0
+      new_instance = WatchlistInstance.new(course_user_datum_id: cud.id, course_id: course.id,
+                                           risk_condition_id: condition_id,
+                                           violation_info: violation_info)
+      if not new_instance.save
+        raise "Fail to create new watchlist instance for CUD #{cud.id} in course #{course.name} with violation info #{violation_info}"
+      end
+      return new_instance
+    end
+  end
+
+  def self.add_new_instance_for_cud_no_submissions(course, condition_id, cud, no_submissions_threshold)
+    auds = AssessmentUserDatum.where(course_user_datum_id: cud.id)
+    no_submissions_asmt_names = []
+    auds.each do |aud|
+      no_submissions_asmt_names << aud.assessment.display_name if aud.latest_submission.nil?
+    end
+    if no_submissions_asmt_names.length >= no_submissions_threshold
+      new_instance = WatchlistInstance.new(course_user_datum_id: cud.id, course_id: course.id,
+                                           risk_condition_id: condition_id,
+                                           violation_info: { :no_submissions_asmt_names => no_submissions_asmt_names })
+      if not new_instance.save
+        raise "Fail to create new watchlist instance for CUD #{cud.id} in course #{course.name} with violation info #{violation_info}"
+      end
+      return new_instance
+    end
+  end
+
+  def self.add_new_instance_for_cud_low_grades(course, condition_id, cud, grade_threshold, count_threshold)
+    auds = AssessmentUserDatum.where(course_user_datum_id: cud.id)
+    violation_info = {}
+    auds.each do |aud|
+      aud_score = aud.final_score(cud)
+      # score not out yet
+      next if aud_score.nil?
+      total = aud.assessment.default_total_score
+      score_percent = aud_score * 100.0 / total
+      if score_percent < grade_threshold
+        violation_info[aud.assessment.display_name] = "#{aud_score}/#{total}"
+      end
+    end
+    if violation_info.length >= count_threshold
+      new_instance = WatchlistInstance.new(course_user_datum_id: cud.id, course_id: course.id,
+                                           risk_condition_id: condition_id,
+                                           violation_info: violation_info)
+      if not new_instance.save
+        raise "Fail to create new watchlist instance for CUD #{cud.id} in course #{course.name} with violation info #{violation_info}"
+      end
+      return new_instance
+    end
   end
 
 end

--- a/app/models/watchlist_instance.rb
+++ b/app/models/watchlist_instance.rb
@@ -80,41 +80,97 @@ class WatchlistInstance < ApplicationRecord
 
 private
   
-  def self.add_new_instances_for_conditions(conditions)
+  def self.add_new_instances_for_conditions(conditions, course_id)
     # grace_day_usage: grace_day_threshold x and date y
     # grade_drop => percentage_drop x, consecutive_counts y
     # no_submissions => no_submissions_threshold x
     # low_grades => grade_threshold x, count_threshold y
     new_instances = []
+    course_user_data = CourseUserDatum.where(course_id: course_id, instructor: false, course_assistant: false)
     for condition in conditions
       case condition.condition_type
+      
       when "grace_day_usage"
+        
         grace_day_threshold = condition.parameters[:grace_day_threshold]
         date = condition.parameters[:date]
+        
         # assume for now date takes on the form "yyyy-mm-dd"
-        course_user_data = CourseUserDatum.where(course_id: course_id, instructor: false, course_assistant: false)
         for cud in course_user_data
-          latest_aud_before_date = AssessmentUserDatum.where(course_user_datum_id: cud.id).
-                                                       where("updated_at < ?", date).
-                                                       order("updated_at DESC").first
+          aud_before_date = AssessmentUserDatum.where(course_user_datum_id: cud.id).where("updated_at < ?", date)
+          latest_aud_before_date = aud_before_date.order("updated_at DESC").first
           next if latest_aud_before_date.nil?
           if latest_aud_before_date.global_cumulative_grace_days_used >= grace_day_threshold
             # add new instance
-            new_instance = WatchlistInstance.new(course_user_datum_id: cud.id, course_id: condition.course_id,
+            violation_info = {}
+            aud_before_date.map { |aud| violation_info[aud.assessment_id] = aud.grace_days_used }
+            violation_info.select! { |k, v| v > 0 }
+            new_instance = WatchlistInstance.new(course_user_datum_id: cud.id, course_id: course_id,
                                                  risk_condition_id: condition.id,
-                                                 violation_info: {}, # TODO
-                                                 )
+                                                 violation_info: violation_info)
             new_instances << new_instance;
           end
         end
+
       when "grade_drop"
-        percentage_drop = condition.parameters[:percentage_drop]
+        # TODO: confirm with the team about different categories
+        percentage_drop = (condition.parameters[:percentage_drop]).to_f
         consecutive_counts = condition.parameters[:consecutive_counts]
+        
+        for cud in course_user_data
+          auds = AssessmentUserDatum.where(course_user_datum_id: cud.id)
+          next if auds.length < consecutive_counts
+          i = 0
+          while i+consecutive_counts-1 < auds.length
+            begin_aud = auds[i]
+            end_aud = auds[i+consecutive_counts-1]
+            begin_grade = begin_aud.final_score(cud)
+            end_grade = end_aud.final_score(cud)
+            next if end_grade >= begin_grade
+            diff = (begin_grade - end_grade) * 100.0 / begin_grade
+            if diff >= percentage_drop
+              violation_info = {}
+              violation_info[begin_aud.assessment_id] = begin_grade
+              violation_info[end_aud.assesssment_id] = end_grade
+              new_instance = WatchlistInstance.new(course_user_datum_id: cud.id, course_id: course_id,
+                                                   risk_condition_id: condition.id,
+                                                   violation_info: violation_info)
+            end
+          end
+        end
+
       when "no_submissions"
         no_submissions_threshold = condition.parameters[:no_submissions_threshold]
+
+        for cud in course_user_data
+          auds = AssessmentUserDatum.where(course_user_datum_id: cud.id)
+          no_submissions_asmt_ids = []
+          auds.map { |aud| no_submissions_asmt_ids << aud.assessment_id if aud.latest_submission.nil? }
+          if no_submissions_asmt_ids.length >= no_submissions_threshold
+            new_instance = WatchlistInstance.new(course_user_datum_id: cud.id, course_id: course_id,
+                                                 risk_condition_id: condition.id,
+                                                 violation_info: { :no_submissions_asmt_ids => no_submissions_asmt_ids })
+          end
+        end
       when "low_grades"
         grade_threshold = condition.parameters[:grade_threshold]
         count_threshold = condition.parameters[:count_threshold]
+
+        for cud in course_user_data
+          auds = AssessmentUserDatum.where(course_user_datum_id: cud.id)
+          violation_info = {}
+          auds.map do |aud|
+            score_percent = aud.final_score(cud) * 100.0 / aud.assessment.default_total_score
+            if score_percent < grade_threshold
+              violation_info[aud.assessment_id] = score_percent
+            end
+          end
+          if violation_info.length >= count_threshold
+            new_instance = WatchlistInstance.new(course_user_datum_id: cud.id, course_id: course_id,
+                                                 risk_condition_id: condition.id,
+                                                 violation_info: { violation_info })
+          end
+        end
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -75,6 +75,7 @@ Rails.application.routes.draw do
       get 'get_watchlist_instances'
       get 'get_num_new_instances'
       get 'refresh_watchlist_instances'
+      post 'update_current_metrics'
       post 'update_watchlist_instances'
     end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -74,6 +74,7 @@ Rails.application.routes.draw do
       get 'get_current_metrics'
       get 'get_watchlist_instances'
       get 'get_num_new_instances'
+      get 'refresh_watchlist_instances'
       post 'update_watchlist_instances'
     end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -72,6 +72,7 @@ Rails.application.routes.draw do
     get "metrics", to: 'metrics#index'
     get 'metrics/get_current_metrics', to: 'metrics#get_current_metrics'
     post 'metrics/update_current_metrics', to: 'metrics#update_current_metrics'
+    get 'metrics/refresh_watchlist_instances', to: 'metrics#refresh_watchlist_instances'
     get 'metrics/get_watchlist_instances', to: 'metrics#get_watchlist_instances'
 
     resources :jobs, only: :index do


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR adds the API endpoint for bulk refreshing watchlist instances for a course. In addition, it also patched app/models/risk_conditions.rb such that the method update_current_for_course now utilizes transaction.

## Motivation and Context
This is part of the metrics feature functionality.

## How Has This Been Tested?
1. Add a new course with a reasonable number of grace days.
2. Add at least 3 users to that course.
3. Add a reasonable number of assignments, each consuming preferably different number of grace days (by tweaking due date and end date). For ease of later testing, set only one problem to each assignment with weight 100. Act as each user added in step 2. Submit as these users such that the number of no-submissions for each is varied. Act as instructor again and grade their submissions. Make sure the grades are spread over a reasonable range and pay attention to the ups and downs of one particular user. Take note of each user's trend so that comparison is easier for later purposes. After all of this is done, make sure to change the end date of each assignment to a past date. Unreleased grades are not considered for the grade-related conditions.
**Testing is first done case by case.**
4. Add a grace day usage condition to the course. Visit AutoPopulated/metrics/refresh_watch_list_instances. See if the returned instances match expectation. Tweak the condition to see if refreshed instances reflect the modification.
5. Add a grade drop condition. Visit AutoPopulated/metrics/refresh_watch_list_instances. See if the returned instances match expectation. Tweak the condition to see if refreshed instances reflect the modification.
6. Add a no submissions condition. Visit AutoPopulated/metrics/refresh_watch_list_instances. See if the returned instances match expectation. Tweak the condition to see if refreshed instances reflect the modification.
7. Add a low grades condition. Visit AutoPopulated/metrics/refresh_watch_list_instances. See if the returned instances match expectation. Tweak the condition to see if refreshed instances reflect the modification.
**Testing is then done in a hybrid manner.**
8. Update current conditions such that they are a hybrid of some of the four types. See if the refreshed instances match expectation.
**Lastly**
9. Refresh twice in a row. There shouldn't be any change in the records returned by the endpoint.
10. It should also be the case that none of the returned instances should include instructors' information.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR

## Other issues / help required
<!--- Do you have any other relevant issues / questions? --->
<!--- For example, if you require assistance for a certain part of your PR --->
<!--- or are facing specific issues while creating the pull request that you would like to highlight --->

If unsure, feel free to submit first and we'll help you along.
