### PR TITLE
Metrics notification badge

### DIFF
--- a/app/assets/javascripts/metrics.js
+++ b/app/assets/javascripts/metrics.js
@@ -13,7 +13,7 @@ Object.freeze(metrics_endpoints);
 $(document).ready(function(){
 
 	// Initializing Fomantic UI elements
-  $('.tabular.menu .item').tab();	
+	$('.tabular.menu .item').tab();	
 	$('.ui.dropdown').dropdown();
 	$('.ui.checkbox').checkbox();
 	$('.ui.calendar').calendar({type: 'date', initialDate: new Date()});

--- a/app/assets/javascripts/metrics.js
+++ b/app/assets/javascripts/metrics.js
@@ -13,7 +13,7 @@ Object.freeze(metrics_endpoints);
 $(document).ready(function(){
 
 	// Initializing Fomantic UI elements
-    $('.tabular.menu .item').tab();	
+  $('.tabular.menu .item').tab();	
 	$('.ui.dropdown').dropdown();
 	$('.ui.checkbox').checkbox();
 	$('.ui.calendar').calendar({type: 'date', initialDate: new Date()});

--- a/app/assets/stylesheets/style.css.scss
+++ b/app/assets/stylesheets/style.css.scss
@@ -710,6 +710,27 @@ table.navigatable tr:hover {
   padding: 2px 10px;
 }
 
+.badge.metrics-badge {
+  background-color: #008FCC !important;
+  border-radius: 10px !important;
+  padding: 0px 1px;
+  margin-left: -5px;
+  margin-right: -8px;
+  margin-top: 6px;
+  line-height: 16px;
+  height: 16px;
+  font-size: 0.65rem !important;
+}
+
+.row.metrics .col.metrics {
+  padding: 0px 0px;
+}
+
+h7.metrics {
+  margin-left: -15px;
+  margin-right: -10px;
+}
+
 /* collections */
 .collection
 a.collection-item {

--- a/app/views/assessments/index.html.erb
+++ b/app/views/assessments/index.html.erb
@@ -11,11 +11,17 @@
       $.getJSON('metrics/get_num_new_instances',function(data, status){
         if(status=='success' && data['num_new'] != 0){
           // when there is a non-zero number of new instances
-          var new_instances_str = `${data["num_new"]} new`;
-          $('.new.badge.metrics-badge').attr('data-badge-caption', new_instances_str);
-        } else {
-          // otherwise remove the notification badge
-          $('.row.metrics').empty().append("<i class='material-icons left'>assessment</i> Metrics");
+          var new_instances_str = 
+            `<div class='col s1 metrics'>
+              <i class='material-icons left metrics'>assessment</i>
+            </div>
+            <div class='col s4 metrics'>
+              <span class='new badge metrics-badge' data-badge-caption='${data["num_new"]} new'></span>
+            </div>
+            <h7 class='metrics'>
+              Metrics
+            </h7>`;
+          $('.row.metrics').empty().append(new_instances_str);
         }
       });
     });
@@ -55,18 +61,7 @@
           <% end %>
           <% if @cud.instructor? || !(@cud.course_assistant? && !@cud.section.blank?) %>
            <%= link_to "<i class='material-icons left'>grading</i> Gradebook".html_safe, [@course, @cud, :gradebook], title: "View your gradebook", :class => "btn btn-large red darken-3" %>
-           <%= link_to "
-            <div class='row metrics'>
-              <div class='col s1 metrics'>
-                <i class='material-icons left metrics'>assessment</i>
-              </div>
-              <div class='col s4 metrics'>
-                <span class='new badge metrics-badge'></span>
-              </div>
-              <h7 class='metrics'>
-                Metrics
-              </h7>
-            </div>".html_safe, course_metrics_path, title: "View student metrics", :class => "btn btn-large red darken-3" %>
+           <%= link_to "<div class='row metrics'><i class='material-icons left'>assessment</i> Metrics</div>".html_safe, course_metrics_path, title: "View student metrics", :class => "btn btn-large red darken-3" %>
           <% end %>
       </div>
       </div>

--- a/app/views/assessments/index.html.erb
+++ b/app/views/assessments/index.html.erb
@@ -8,6 +8,16 @@
           return false;  // prevent click propagation
         });
       });
+      $.getJSON('metrics/get_num_new_instances',function(data, status){
+        if(status=='success' && data['num_new'] != 0){
+          // when there is a non-zero number of new instances
+          var new_instances_str = `${data["num_new"]} new`;
+          $('.new.badge.metrics-badge').attr('data-badge-caption', new_instances_str);
+        } else {
+          // otherwise remove the notification badge
+          $('.row.metrics').empty().append("<i class='material-icons left'>assessment</i> Metrics");
+        }
+      });
     });
   </script>
 <% end %>
@@ -45,7 +55,18 @@
           <% end %>
           <% if @cud.instructor? || !(@cud.course_assistant? && !@cud.section.blank?) %>
            <%= link_to "<i class='material-icons left'>grading</i> Gradebook".html_safe, [@course, @cud, :gradebook], title: "View your gradebook", :class => "btn btn-large red darken-3" %>
-           <%= link_to "<i class='material-icons left'>assessment</i> Metrics".html_safe, course_metrics_path, title: "View student metrics", :class => "btn btn-large red darken-3" %>
+           <%= link_to "
+            <div class='row metrics'>
+              <div class='col s1 metrics'>
+                <i class='material-icons left metrics'>assessment</i>
+              </div>
+              <div class='col s4 metrics'>
+                <span class='new badge metrics-badge'></span>
+              </div>
+              <h7 class='metrics'>
+                Metrics
+              </h7>
+            </div>".html_safe, course_metrics_path, title: "View student metrics", :class => "btn btn-large red darken-3" %>
           <% end %>
       </div>
       </div>


### PR DESCRIPTION
## Description
Adds a notification badge on the icon in the metrics button on the main course page. The badge shows the number of new watchlist instances by calling the get_num_new_instances endpoint.
![image](https://user-images.githubusercontent.com/13857201/100965953-d29df380-34f9-11eb-9030-eb1c164b61e7.png)

## Motivation and Context
This alerts instructors that there are a number of students that their risk metrics have flagged in the watchlist without relying on the instructors to constantly check the watchlist.

## How Has This Been Tested?
Tested locally without setting any risk metrics so that number of new instances is 0, did not show notification badge. Set risk metrics of "students with 1 submitted assignment below 100%" so that number of new instances is 100, notification badge displayed as in image above.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR
