### PR TITLE
Change null coalescing and null chaining operators to lodash alternatives

### DIFF
--- a/app/assets/javascripts/metrics.js
+++ b/app/assets/javascripts/metrics.js
@@ -76,35 +76,35 @@ $.getJSON(metrics_endpoints['get'],function(data, status){
 
 		// switch case to check each checkbox field
 		data.forEach(condition => {
-			switch(condition?.condition_type){
+			switch(_.get(condition,'condition_type')){
 				case "no_submissions":
 					$('#no_submit_checkbox').checkbox('check');
 					$("#no_submit_value")
-					.dropdown("set selected", condition?.parameters?.no_submissions_threshold ?? 1);
+					.dropdown("set selected", _.get(condition,'parameters.no_submissions_threshold',1));
 					break;
 				case "grace_day_usage":
 					$('#grace_days_checkbox').checkbox('check');
 					$('#grace_days_value')
-					.dropdown('set selected',condition?.parameters?.grace_day_threshold ?? 1);
+					.dropdown('set selected',_.get(condition,'parameters.grace_day_threshold',1));
 					$('#grace_days_by_date')
-					.calendar('set date', new Date(condition?.parameters?.date));
+					.calendar('set date', new Date(_.get(condition,'parameters.date',null)));
 					break;
 				case "grade_drop":
 					$('#grade_drop_checkbox').checkbox('check');
 					$('#grade_drop_percentage')
-					.val(condition?.parameters?.percentage_drop);
+					.val(_.get(condition,'parameters.percentage_drop',null));
 					$('#grade_drop_consecutive_counts')
-					.dropdown('set selected',condition?.parameters?.consecutive_counts ?? 1);
+					.dropdown('set selected',_.get(condition,'parameters.consecutive_counts',1));
 					break;
 				case "low_grades":
 					$('#low_grades_checkbox').checkbox('check');
 					$('#low_grades_count')
-					.dropdown('set selected',condition?.parameters?.count_threshold ?? 1);
+					.dropdown('set selected',_.get(condition,'parameters.count_threshold',1));
 					$('#low_grades_percentage')
-					.val(condition?.parameters?.grade_threshold);
+					.val(_.get(condition,'parameters.grade_threshold',1));
 					break;
 				default:
-					console.error(condition?.condition_type +" is not valid");
+					console.error(_.get(condition,'condition_type') +" is not valid");
 					return;
 			}
 		})
@@ -245,7 +245,7 @@ const render_banner = (params) => {
 				$(`#message_${message_id} .close`).closest('.message');
 			if(!message_box.hasClass('hidden'))
 				message_box.transition('fade');
-		},params['timeout']?? 5000);
+		},params['timeout'] || 5000 );
 	}
 
 	message_count++;

--- a/app/assets/javascripts/watchlist.js
+++ b/app/assets/javascripts/watchlist.js
@@ -46,17 +46,19 @@ function get_condition_html(condition_types) {
         var violation_list = [];
         $.each(violations, function( assessmentType, vals ) {
           var inner_list = []
-          vals?.forEach(dict => {
-            $.each(dict, function( lab, val ) {
-              inner_list.push(`${lab}: ${val}`);
+          if(vals){
+            vals.forEach(dict => {
+              $.each(dict, function( lab, val ) {
+                inner_list.push(`${lab}: ${val}`);
+              });
             });
-          });
+          }
           violation_list.push(`${assessmentType} - ${inner_list.join(" | ")}`);
         });
         violation_string = violation_list.join(" <br /><br /> ");
         break;
       case "low_grades":
-        condition_string = `${Object.keys(violations ?? {})?.length} low score`;
+        condition_string = `${Object.keys(violations || {}).length} low score`;
         var violation_list = [];
         $.each(violations, function( lab, val ) {
           violation_list.push(`${lab}: ${val}`);
@@ -64,15 +66,15 @@ function get_condition_html(condition_types) {
         violation_string = violation_list.join(" | ");
         break;
       case "no_submissions":
-        condition_string = `${Object.keys(violations?.no_submissions_asmt_names ?? {})?.length} no submission`;
+        condition_string = `${Object.keys(_.get(violations,'no_submissions_asmt_names',{})).length} no submission`;
         var violation_list = [];
-        violations?.no_submissions_asmt_names?.forEach(val => {
+        _.get(violations,'no_submissions_asmt_names',[]).forEach(val => {
           violation_list.push(val);
         });
         violation_string = violation_list.join(" | ");
         break;
       case "grace_day_usage":
-        condition_string = `${Object.keys(violations ?? {})?.length} grace days used`;
+        condition_string = `${Object.keys(violations || {}).length} grace days used`;
         var violation_list = [];
         $.each(violations, function( lab, val ) {
           violation_list.push(`${lab}: ${val}`);
@@ -184,22 +186,23 @@ function get_watchlist_function(){
         $('#archived_tab').empty();
 
         data["instances"].forEach(watchlist_instance => {
-          var id = watchlist_instance?.id;
-          var course_id = watchlist_instance?.course_id;
-          var user_id = watchlist_instance?.course_user_datum_id;
-		    	var user_name = data["users"][user_id]?.first_name + " " + data["users"][user_id]?.last_name; 
-          var user_email = data["users"][user_id]?.email;
-          var condition_type = data["risk_conditions"][watchlist_instance?.risk_condition_id]?.condition_type;
-          var violation_info = watchlist_instance?.violation_info;
-          
+          var id = _.get(watchlist_instance,'id');
+          var course_id = _.get(watchlist_instance,'course_id');
+          var user_id = _.get(watchlist_instance,'course_user_datum_id');
+          var user_name = _.get(data,`["users"][${user_id}].first_name`) + " " + _.get(data,`["users"][${user_id}].last_name`); 
+          var user_email = _.get(data,`["users"][${user_id}].email`);
+          var risk_condition_id = _.get(watchlist_instance,'risk_condition_id');
+          var condition_type = _.get(data,`["risk_conditions"][${risk_condition_id}].condition_type`);
+          var violation_info = _.get(watchlist_instance,'violation_info');
+
           if(watchlist_instance.updated_at > last_updated_date)
             last_updated_date = watchlist_instance.updated_at;
 
-          if (watchlist_instance?.archived) {
+          if (_.get(watchlist_instance,'archived')) {
             archived_empty = 0;
             addInstanceToDict(archived_instances, id, user_id, course_id, user_name, user_email, condition_type, violation_info);
           }
-          switch(watchlist_instance?.status){
+          switch(_.get(watchlist_instance,'status')){
             case "new":
               new_empty = 0;
               addInstanceToDict(new_instances, id, user_id, course_id, user_name, user_email, condition_type, violation_info);
@@ -213,11 +216,11 @@ function get_watchlist_function(){
               addInstanceToDict(resolved_instances, id, user_id, course_id, user_name, user_email, condition_type, violation_info);
               break;
             default:
-              console.error(watchlist_instance?.status + " is not valid");
+              console.error(_.get(watchlist_instance,'status') + " is not valid");
               return;
           }
         });
-
+        
         new_html = "";
         contacted_html = "";
         resolved_html = "";

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -176,8 +176,6 @@ module ApplicationHelper
       javascript_include_tag "#{cloudflare}/handlebars.js/#{version}/handlebars.min.js"
     when "bootstrap"
       javascript_include_tag "#{cloudflare}/twitter-bootstrap/#{version}/js/bootstrap.js"
-    when "lodash"
-      javascript_include_tag "#{cloudflare}/lodash.js/#{version}/lodash.min.js"
     end
   end
 

--- a/app/views/metrics/index.html.erb
+++ b/app/views/metrics/index.html.erb
@@ -4,8 +4,9 @@
 <% end %>
 
 <% content_for :javascripts do %>
+  <%= external_javascript_include_tag "lodash", "3.10.1" %>
   <%= javascript_include_tag "watchlist" %>
-  <%= javascript_include_tag "metrics" %>
+  <%= javascript_include_tag "metrics"%>
 <% end %>
 
 <div id="message_area">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Changes Null Coalescing and Null Chaining Operators into lodash alternative (https://lodash.com/docs/4.17.15#get)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This is a required as Uglifier, the javascript precompiling library we are using, do not currently have support for the two operators as mentioned.

This change utilizes the lodash equivalent, which is correct but slower.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Ensured that it is functionally similar when using the metrics page (everything renders as per usual)
- Ran `RAILS_ENV=production bundle exec rails assets:precompile` to ensure that it precompiles


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
