### PR TITLE
Dockerfile create logs directory and file as root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,14 +42,14 @@ WORKDIR /home/app/webapp
 # Add the rails app
 ADD . /home/app/webapp
 
+USER root
+
 # Create the log files
 RUN mkdir -p /home/app/webapp/log && \
   touch /home/app/webapp/log/production.log && \
-  chown -R app:app /home/app/webapp/log && \
-  chmod 0664 /home/app/webapp/log/production.log
+  chmod 0664 /home/app/webapp/log/production.log && \
+  chown -R app:app .
 
-USER root
-RUN chown -R app:app .
 USER app
 
 # precompile the Rails assets


### PR DESCRIPTION
Previously, if the log file already exists (from a docker-compose installation), building the image will fail as the files are not owned by the current user but rather app:app, i.e `touch: cannot touch '/home/app/webapp/log/production.log': Permission denied
`. 

This PR fixes that by creating the log files as root, and then changing the owner afterwards.
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`docker-compose build` succeeds on updated installation

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR

## Other issues / help required
<!--- Do you have any other relevant issues / questions? --->
<!--- For example, if you require assistance for a certain part of your PR --->
<!--- or are facing specific issues while creating the pull request that you would like to highlight --->

If unsure, feel free to submit first and we'll help you along.
