### PR TITLE
Hotfix for ill-accessed non-archive file

### DIFF
--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -297,7 +297,7 @@ class SubmissionsController < ApplicationController
       }]
     end
 
-    if params[:header_position]
+    if Archive.archive? @filename && params[:header_position]
       file, pathname = Archive.get_nth_file(@submission.handin_file_path, params[:header_position].to_i)
 
       if(file.nil?)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR fixes the issue where when a student wants to access feedback of a non-archive file submission, they encounter an "Unrecognized Archive Type" error.

## Motivation and Context
To fix #1282 

## How Has This Been Tested?
1. Act as instructor. Set an ongoing assessment.
2. Act as student. Submit a non-archive file. .c, .py, .jpeg, or anything.
3. Act as instructor. Grade the file and add annotations accordingly. Release grades.
4. Act as student. Check handin history. Click on the clickable section scores. It should redirect to a feedback page, at the bottom of which, there is a Remarks section. Click on the link in the Remarks section. Previously, this would cause the error stated above. Now, it should display the desired annotation in the non-archive file.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR

## Other issues / help required
<!--- Do you have any other relevant issues / questions? --->
<!--- For example, if you require assistance for a certain part of your PR --->
<!--- or are facing specific issues while creating the pull request that you would like to highlight --->

If unsure, feel free to submit first and we'll help you along.
