### PR TITLE
Make Tango callback URL aware of docker no-SSL option

### DIFF
--- a/app/helpers/assessment_autograde_core.rb
+++ b/app/helpers/assessment_autograde_core.rb
@@ -97,15 +97,21 @@ module AssessmentAutogradeCore
   # Returns the callback_url for the given submission/dave key
   #
   def get_callback_url(course, assessment, submission, dave)
+    # Use https, unless explicitly specified not to
+    prefix = "https://"
+    if ENV["DOCKER_SSL"] == "false"
+      prefix = "http://"
+    end
+
     begin
       if Rails.env.development?
         hostname = request.base_url
       else
-        hostname = "https://" + request.host
+        hostname = prefix + request.host
       end
     rescue
       hostname = `hostname`
-      hostname = "https://" + hostname.strip
+      hostname = prefix + hostname.strip
     end
 
     callback_url = (RESTFUL_USE_POLLING) ? "" :


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->


## Description
<!--- Describe your changes in detail -->
When a user installs Autolab via the docker-compose method, the no-SSL option results in Tango not working properly because Autolab only gives https callback URLs right now. This PR fixes this by making Autolab aware of whether it should give https or http callback URLs.

Thanks abx for reporting this and giving a fix on our community Slack! 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested by using a no-SSL docker compose installation config, creating Hello lab, and sending a job. The output from Tango is as follows, where we see that the callback does indeed use http now:
```
==> tango_job_manager_log.log <==
DEBUG|2021-02-18 00:43:02,712|LocalDocker|runJob returning 0
INFO|2021-02-18 00:43:02,712|Worker|Job TestCourse_hello_4_fzeng@andrew.cmu.edu:7 executed [status=0]
DEBUG|2021-02-18 00:43:02,713|LocalDocker|Copied feedback file to courselabs/REPLACE_ME_SECRET_TANGO_KEY-TestCourse-hello/output/fzeng@andrew.cmu.edu_4_hello_autograde.txt
DEBUG|2021-02-18 00:43:03,718|LocalDocker|Deleted volume prod-1010-autograding_image
INFO|2021-02-18 00:43:03,719|Worker|Output copied for job TestCourse_hello_4_fzeng@andrew.cmu.edu:7 [status=0]
INFO|2021-02-18 00:43:03,719|Worker|Success: job TestCourse_hello_4_fzeng@andrew.cmu.edu:7 finished
INFO|2021-02-18 00:43:03,719|JobQueue|makeDead| Making dead job ID: 7
DEBUG|2021-02-18 00:43:03,719|JobQueue|makeDead| Acquired lock to job queue.
INFO|2021-02-18 00:43:03,720|JobQueue|makeDead| Found job ID: 7 in the live queue
INFO|2021-02-18 00:43:03,722|JobQueue|Terminated job TestCourse_hello_4_fzeng@andrew.cmu.edu:7: Success: Autodriver returned normally
DEBUG|2021-02-18 00:43:03,725|JobQueue|makeDead| Released lock to job queue.
DEBUG|2021-02-18 00:43:04,732|Worker|Sending request to http://localhost/courses/TestCourse/assessments/hello/autograde_done?dave=LBNEXBPLPNUTHVQDDVVEIMKKNYKGJCSRAIIIFOXJVLLCFLLJJNOPKQNRPEYA&submission_id=14
DEBUG|2021-02-18 00:43:04,737|urllib3.connectionpool|Starting new HTTP connection (1): localhost:80
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR

## Other issues / help required
<!--- Do you have any other relevant issues / questions? --->
<!--- For example, if you require assistance for a certain part of your PR --->
<!--- or are facing specific issues while creating the pull request that you would like to highlight --->

If unsure, feel free to submit first and we'll help you along.
