### PR TITLE
Consider Duplications When Refreshing

### DIFF
--- a/app/models/watchlist_instance.rb
+++ b/app/models/watchlist_instance.rb
@@ -32,19 +32,22 @@ class WatchlistInstance < ApplicationRecord
     end
 
     # update!
-    # archive previous watchlist instances first
-    for instance in current_instances
-      instance.archive_watchlist_instance
-    end
+    new_instances = []
     # now check current conditions
     if current_conditions.length == 0
       # case 1: no current risk conditions exist
-      return []
+      # no-op
     else
       # case 2: current risk conditions exist
-      new_instances = self.add_new_instances_for_conditions(current_conditions, course)
-      return new_instances
+      new_instances, deprecated_instances = self.add_new_instances_for_conditions(current_conditions, course, current_instances)
     end
+
+    # archive previous watchlist instances
+    for instance in deprecated_instances
+      instance.archive_watchlist_instance
+    end
+
+    return new_instances
   end
   
   # Update the grace day usage condition watchlist instances for each course user datum of a particular course
@@ -314,50 +317,80 @@ class WatchlistInstance < ApplicationRecord
 
 private
   
-  def self.add_new_instances_for_conditions(conditions, course)
+  def self.add_new_instances_for_conditions(conditions, course, current_instances)
     new_instances = []
     course_user_data = CourseUserDatum.where(course_id: course.id, instructor: false, course_assistant: false)
+
+    # new
+    criteria2 = current_instances.where(status: :new)
+    # contacted or resolved
+    criteria1 = current_instances - criteria2
+    deprecated_instances = current_instances
     
-    conditions.each do |condition|
-      case condition.condition_type
-      
-      when "grace_day_usage"
-        grace_day_threshold = condition.parameters[:grace_day_threshold].to_i
-        date = condition.parameters[:date]
-        asmts_before_date = course.asmts_before_date(date)
-        next if asmts_before_date.count == 0 # go to the next condition loop if there is no latest assessment
-        for cud in course_user_data
-          new_instance = self.add_new_instance_for_cud_grace_day_usage(course, condition.id, cud, asmts_before_date, grace_day_threshold)
-          new_instances << new_instance unless new_instance.nil?
-        end
-
-      when "grade_drop"
-        percentage_drop = (condition.parameters[:percentage_drop]).to_f
-        consecutive_counts = condition.parameters[:consecutive_counts].to_i
+    for cud in course_user_data
+      cur_instances = []
+      conditions.each do |condition|
+        case condition.condition_type
         
-        categories = course.assessment_categories
-        asmt_arrs = categories.map { |category| course.assessments_with_category(category).ordered }
-        asmt_arrs.select! { |asmts| asmts.count >= consecutive_counts}
-        for cud in course_user_data
+        when "grace_day_usage"
+          grace_day_threshold = condition.parameters[:grace_day_threshold].to_i
+          date = condition.parameters[:date]
+          asmts_before_date = course.asmts_before_date(date)
+          next if asmts_before_date.count == 0 # go to the next condition loop if there is no latest assessment
+          new_instance = self.add_new_instance_for_cud_grace_day_usage(course, condition.id, cud, asmts_before_date, grace_day_threshold)
+          cur_instances << new_instance unless new_instance.nil?
+        
+        when "grade_drop"
+          percentage_drop = (condition.parameters[:percentage_drop]).to_f
+          consecutive_counts = condition.parameters[:consecutive_counts].to_i
+          
+          categories = course.assessment_categories
+          asmt_arrs = categories.map { |category| course.assessments_with_category(category).ordered }
+          asmt_arrs.select! { |asmts| asmts.count >= consecutive_counts}
           new_instance = self.add_new_instance_for_cud_grade_drop(course, condition.id, cud, asmt_arrs, consecutive_counts, percentage_drop)
-          new_instances << new_instance unless new_instance.nil?
-        end
+          cur_instances << new_instance unless new_instance.nil?
 
-      when "no_submissions"
-        no_submissions_threshold = condition.parameters[:no_submissions_threshold].to_i
+        when "no_submissions"
+          no_submissions_threshold = condition.parameters[:no_submissions_threshold].to_i
 
-        for cud in course_user_data
           new_instance = self.add_new_instance_for_cud_no_submissions(course, condition.id, cud, no_submissions_threshold)
-          new_instances << new_instance unless new_instance.nil?
-        end
+          cur_instances << new_instance unless new_instance.nil?
 
-      when "low_grades"
-        grade_threshold = condition.parameters[:grade_threshold].to_f
-        count_threshold = condition.parameters[:count_threshold].to_i
+        when "low_grades"
+          grade_threshold = condition.parameters[:grade_threshold].to_f
+          count_threshold = condition.parameters[:count_threshold].to_i
 
-        for cud in course_user_data
           new_instance = self.add_new_instance_for_cud_low_grades(course, condition.id, cud, grade_threshold, count_threshold)
-          new_instances << new_instance unless new_instance.nil?
+          cur_instances << new_instance unless new_instance.nil?
+        end
+      end
+      # check for duplication
+      all_dup = true
+      cur_instances.each do |inst|
+        # contact or resolved
+        cr_dup = criteria1.select { |inst1|
+          inst1.course_user_datum_id == inst.course_user_datum_id and
+          inst1.risk_condition_id == inst.risk_condition_id and
+          inst1.violation_info == inst.violation_info
+        }
+        if cr_dup.count == 0
+          all_dup = false
+        end
+      end
+
+      if not all_dup
+        cur_instances.each do |inst|
+          # new
+          new_dup = criteria2.where(
+            course_user_datum_id: inst.course_user_datum_id,
+            risk_condition_id: inst.risk_condition_id,
+            violation_info: inst.violation_info
+          )
+          if new_dup.count == 0
+            new_instances << inst;
+          else
+            deprecated_instances = deprecated_instances - new_dup
+          end
         end
       end
     end
@@ -370,7 +403,7 @@ private
       end
     end
 
-    return new_instances
+    return new_instances, deprecated_instances
   end
 
   # The following 4 methods that create a watchlist instance for a course user datum does not


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR considers duplications of watchlist instances when refreshing a watchlist.

## Motivation and Context
Currently, if an instructor resolves/contacts some students on the watchlist and hits refresh button just for fun, those who have been resolved/contacted reappear on the watchlist. If the resolved/contacted student does not add any fresh information to the watchlist, we don't want to add them back.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Set up metrics for a course and check that watchlist instances are initialized (through refreshing the watchlist).
2. Randomly resolve or contact some students. Hit refresh again. The watchlist should remain the same, without the resolved/contacted students coming back.
3. Change your metrics and come back and check the watchlist has been correctly refreshed.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR

## Other issues / help required
<!--- Do you have any other relevant issues / questions? --->
<!--- For example, if you require assistance for a certain part of your PR --->
<!--- or are facing specific issues while creating the pull request that you would like to highlight --->
As of now, the callbacks set up for refreshing individual students' watchlist status only consider conditions relevant to that callback, e.g. when there is a score change for the student, the callback only considers low grades and downward trend conditions. Suppose previously, an instructor has resolved/contacted this student on the grace day condition, then the score callback is not responsible for bringing the grace day condition instance back. Since we bring back all of a single student's instances when refreshing, I was wondering whether this would be considered an inconsistency.

If unsure, feel free to submit first and we'll help you along.
