### PR TITLE
Fixes Bulk Resolve and Resolving Quickly Throwing Errors

### DIFF
--- a/app/assets/javascripts/watchlist.js
+++ b/app/assets/javascripts/watchlist.js
@@ -298,20 +298,40 @@ function get_watchlist_function(){
       $('.ui.circular.label.condition').popup();
 
       $('.ui.button.contact_single').click(function() {
-        $(this).prop('disabled', true);
+
+        // disable all action buttons
+        var button_group = $(this).parent().find('button');
+        button_group.prop('disabled', true);
+
         method = "contact";
         var user_id = $(this).parent().parent().attr('id');
         window.open(`mailto: ${new_instances[user_id]["email"]}`, "_blank");
         console.log(new_instances[user_id]["instance_ids"]);
-        update_watchlist(method, new_instances[user_id]["instance_ids"],this);
+        
+        // re-enabling buttons on failure
+        function enable_buttons () {
+          button_group.removeAttr("disabled");
+        } 
+
+        update_watchlist(method, new_instances[user_id]["instance_ids"], enable_buttons);
       })
 
       $('.ui.button.resolve_single').click(function() {
-        $(this).prop('disabled', true);
+
+        // disable all action buttons
+        var button_group = $(this).parent().find('button');
+        button_group.prop('disabled', true);
+        
         method = "resolve";
         var user_id = $(this).parent().parent().attr('id');
         var instances = get_active_instances(new_instances, contacted_instances);
-        update_watchlist(method, instances[user_id]["instance_ids"],this);
+        
+        // re-enabling buttons on failure
+        function enable_buttons () {
+          button_group.removeAttr("disabled");
+        } 
+
+        update_watchlist(method, instances[user_id]["instance_ids"], enable_buttons);
       })
   });
 
@@ -397,7 +417,7 @@ function get_active_instances(new_instances, contacted_instances) {
   }
 }
 
-function update_watchlist(method, ids, update_button = null){
+function update_watchlist(method, ids, on_error = null){
 	let students_selected = {};
 	students_selected['method'] = method;
 	students_selected['ids'] = ids;
@@ -419,9 +439,9 @@ function update_watchlist(method, ids, update_button = null){
 				timeout: -1
 			});
 
-      // enable single button on failure
-      if(update_button!=null){
-        $(update_button).removeAttr("disabled");
+      // call on_error if exists
+      if(on_error!=null){ 
+        on_error();
       }
 		},
 	});

--- a/app/assets/javascripts/watchlist.js
+++ b/app/assets/javascripts/watchlist.js
@@ -161,6 +161,7 @@ function addInstanceToDict(instancesDict, id, user_id, course_id, user_name, use
 }
 
 function get_watchlist_function(){
+
   var new_instances = {}
   var contacted_instances = {}
   var resolved_instances = {}
@@ -297,22 +298,25 @@ function get_watchlist_function(){
       $('.ui.circular.label.condition').popup();
 
       $('.ui.button.contact_single').click(function() {
+        $(this).prop('disabled', true);
         method = "contact";
         var user_id = $(this).parent().parent().attr('id');
-
         window.open(`mailto: ${new_instances[user_id]["email"]}`, "_blank");
         console.log(new_instances[user_id]["instance_ids"]);
-        update_watchlist(method, new_instances[user_id]["instance_ids"]);
+        update_watchlist(method, new_instances[user_id]["instance_ids"],this);
       })
 
       $('.ui.button.resolve_single').click(function() {
+        $(this).prop('disabled', true);
         method = "resolve";
         var user_id = $(this).parent().parent().attr('id');
         var instances = get_active_instances(new_instances, contacted_instances);
-        update_watchlist(method, instances[user_id]["instance_ids"]);
+        update_watchlist(method, instances[user_id]["instance_ids"],this);
       })
   });
 
+  // Removes previous click function binded to contact button
+  $('#contact_button').off('click');
   $('#contact_button').click(function(){
     method = "contact";
 
@@ -332,6 +336,8 @@ function get_watchlist_function(){
     }
   });
 
+  // Removes previous click function binded to resolve button
+  $('#resolve_button').off('click');
   $('#resolve_button').click(function(){
     method = "resolve";
     var instances = get_active_instances(new_instances, contacted_instances);
@@ -391,7 +397,7 @@ function get_active_instances(new_instances, contacted_instances) {
   }
 }
 
-function update_watchlist(method, ids){
+function update_watchlist(method, ids, update_button = null){
 	let students_selected = {};
 	students_selected['method'] = method;
 	students_selected['ids'] = ids;
@@ -412,7 +418,12 @@ function update_watchlist(method, ids){
 				message: "Do try again later",
 				timeout: -1
 			});
-		}
+
+      // enable single button on failure
+      if(update_button!=null){
+        $(update_button).removeAttr("disabled");
+      }
+		},
 	});
 }
 

--- a/app/controllers/metrics_controller.rb
+++ b/app/controllers/metrics_controller.rb
@@ -165,7 +165,7 @@ class MetricsController < ApplicationController
 		# On success, the watchlist instance will be updated appropriately
 		# params required would be the course name
 		# example json body {"method":"resolve","ids":[1,2,3]}
-		# method: update, resolve
+		# method: contact, resolve
 		# ids: [1,2,3...] list of ids to be updated
 	
 		begin

--- a/app/models/watchlist_instance.rb
+++ b/app/models/watchlist_instance.rb
@@ -270,6 +270,7 @@ class WatchlistInstance < ApplicationRecord
       found_instance_ids = instances.map{|instance| instance.id}
       raise "Instance ids #{instance_ids - found_instance_ids} cannot be found"
     end
+    
     ActiveRecord::Base.transaction do
       instances.each do |instance|
         instance.resolve_watchlist_instance
@@ -301,6 +302,7 @@ class WatchlistInstance < ApplicationRecord
   end
 
   def resolve_watchlist_instance
+    
     if (self.new_watchlist? || self.contacted_watchlist?)
       self.resolved_watchlist!
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Currently, when you 
1.  Bulk resolve many instances (~> 5) after doing a refresh it is sure to have an error
2.  Resolve using the individual buttons too quickly, it will also throw an error

## Description
<!--- Describe your changes in detail -->
![image](https://user-images.githubusercontent.com/5773562/111234753-a2b8be80-85c5-11eb-97e4-d1eddbe4d2f7.png)

The two issues mentioned above are actually two unrelated issues

The first issue is because the function `get_watchlist_function` is called whenever changes are made (update_watchlist, refresh_watchlist). Each time it is called, it uses jquery's `click` helper to add a new function to the resolve and contact buttons. However, the click function does not override the existing function, but appends the new behavior. As such the previously binded function is called alongside the newly binded ones. This causes multiple calls to `update_watchlist_function`.

The second issue is because the single resolve buttons are not disabled after pressing, so pressing quickly will just register twice. This is fixed simply by disabling it, and re-enabling it if there's an error.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

For bulk resolve
1. Have instances in the watchlist
2. Refresh watchlist instance (this is to get `get_watchlist_function` to be called again
3. Select all instances and click resolve
4. Repeat the same for contact as well

For quick resolve
1. Double click / triple click on the individual resolve buttons
2. Repeat the same for individual  contact button as well

No errors should be thrown for both

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR
