### PR TITLE
Make last updated at not show when there are no items

### DIFF
--- a/app/assets/javascripts/watchlist.js
+++ b/app/assets/javascripts/watchlist.js
@@ -271,8 +271,10 @@ function get_watchlist_function(){
         
         updateButtonVisibility($('.ui.vertical.fluid.tabular.menu .item.active'));
         
-        // displays last refreshed time in local time zone
-        $('#last-updated-time').text(`Last Updated ${(new Date(last_updated_date)).toLocaleString()}`);
+        // displays latest updated time based on item with latest time
+        if(last_updated_date != "")
+          $('#last-updated-time')
+          .text(`Last Updated ${(new Date(last_updated_date)).toLocaleString()}`);
 
       } else {
         render_banner({
@@ -485,6 +487,10 @@ function refresh_watchlist(){
       header:"Successfully refreshed watchlist instances",
       message: "The latest instances should be showing now",
     });
+    // set last updated time to now on success
+    $('#last-updated-time')
+    .text(`Last Updated ${(new Date()).toLocaleString()}`);
+    
   }).fail(function(){
     render_banner({
       type:"negative",

--- a/app/assets/javascripts/watchlist.js
+++ b/app/assets/javascripts/watchlist.js
@@ -481,15 +481,17 @@ function refresh_watchlist(){
   // uses formantic ui loading class 
   $("#refresh_btn").addClass('loading');
   $.getJSON(watchlist_endpoints['refresh'],function(){
+    
+    // set last updated time to now on success
+    $('#last-updated-time')
+    .text(`Last Updated ${(new Date()).toLocaleString()}`);
+
     get_watchlist_function();
     render_banner({
       type:"positive",
       header:"Successfully refreshed watchlist instances",
       message: "The latest instances should be showing now",
     });
-    // set last updated time to now on success
-    $('#last-updated-time')
-    .text(`Last Updated ${(new Date()).toLocaleString()}`);
     
   }).fail(function(){
     render_banner({

--- a/app/views/metrics/index.html.erb
+++ b/app/views/metrics/index.html.erb
@@ -81,7 +81,7 @@
             </div>
           </div>
         </span>
-        grace days by
+        grace day(s) by
         <span>
           <div class="ui calendar" id="grace_days_by_date">
             <div class="ui input left icon">
@@ -139,7 +139,7 @@
             </div>
           </div>
         </span>
-        assignments
+        assignment(s)
       </div>
     </div>
     <br>
@@ -162,7 +162,7 @@
             </div>
           </div>
         </span>
-        submitted assignments below a percentage of
+        submitted assignment(s) below a percentage of
         <span>
           <input type="text" placeholder="0" id='low_grades_percentage'>
         </span>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Currently, when there are no items being identified in the watchlist, it will show "Last Updated Invalid Date"
![image](https://user-images.githubusercontent.com/5773562/112197355-61866700-8be2-11eb-81a1-22b744ea830f.png)

This PR addresses that issue by 
1. Removing last updated time when there are no items in the watchlist
2. Using the last updated time with current time upon successful refresh

At the same time, this PR adds brackets to plural words 
![image](https://user-images.githubusercontent.com/5773562/112199069-28e78d00-8be4-11eb-87e4-a5aa228fdb02.png)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This is part of an ongoing series of bugfix to rollout the new metrics feature.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Testing this scenario is best done by resetting and creating a new course (because it requires the course to not have any watchlist instances). I used autolab:populate to regenerate a course with fake data.

1. `bundle exec rails db:reset`
2. `bundle exec rails db:migrate`
3. `bundle exec rails autolab:populate`

I then tested a scenario that no one would be identified. This is done by setting 
Students who have used 3 grace days by March 1 2021. (This works because autopopulate won't create submissions in the past.. i think)

![image](https://user-images.githubusercontent.com/5773562/112197974-09039980-8be3-11eb-8bad-2a9ff9583c2a.png)
We see that the Last updated date does not show

I then proceed to click the refresh button

![image](https://user-images.githubusercontent.com/5773562/112198033-16b91f00-8be3-11eb-903c-754d3a351d8f.png)
We see that the time updates to the current time upon successful refresh. (this is a front-end trick... when u refresh the page it disappears)

I then added risk conditions that would identify students.

1. Students who have used 3 grace days by March 31 2021
2. Students who did not submit 1 assignments
3. Students with 1 submitted assignments below a percentage of 50

![image](https://user-images.githubusercontent.com/5773562/112198274-541dac80-8be3-11eb-985e-dd1626bed62c.png)
We see that the date is shown properly


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR

## Other issues / help required
<!--- Do you have any other relevant issues / questions? --->
<!--- For example, if you require assistance for a certain part of your PR --->
<!--- or are facing specific issues while creating the pull request that you would like to highlight --->

If unsure, feel free to submit first and we'll help you along.
