### PR TITLE
Rework Gradebook button logic to allow for both instructor and CA roles

### DIFF
--- a/app/views/assessments/index.html.erb
+++ b/app/views/assessments/index.html.erb
@@ -61,7 +61,7 @@
             <%= link_to "<i class='material-icons left'>web</i> Course Website".html_safe, @course.website, target: "_blank", title: "Go to course website", :class => "btn btn-large red darken-3" %>
           <% end %>
 
-          <% if !(@cud.course_assistant? && @cud.section.blank?) %>
+          <% if !(!@cud.instructor? && @cud.course_assistant? && @cud.section.blank?) %>
             <%= link_to "<i class='material-icons left'>grading</i> Gradebook".html_safe, [@course, @cud, :gradebook], title: "View your gradebook", :class => "btn btn-large red darken-3" %>
           <% end %>
 

--- a/app/views/courses/index.html.erb
+++ b/app/views/courses/index.html.erb
@@ -36,10 +36,10 @@
               <%= link_to 'Course Page', course_path(course), class: "red-text text-darken-3", title: "Go to course page" %>
 
               <% if course_cud %>
-                <% if not_student && !course_cud.section.blank? %>
+                <% if !course_cud.instructor? && course_cud.course_assistant? && !course_cud.section.blank? %>
                   <hr>
                   <%= link_to "Grade Section", [:view, course, course_cud, :gradebook, section: course_cud.section], title: "Grade your section", class: "red-text text-darken-3", style: "white-space: nowrap" %>
-                <% elsif !not_student %>
+                <% elsif course_cud.instructor? || course_cud.student? %>
                   <%= link_to "Gradebook", [course, course_cud, :gradebook], title: "View your gradebook", class: "red-text text-darken-3" %>
                 <% end %>
               <% end %>

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -53,9 +53,7 @@
         <% if @cud %>
           <% if !@cud.instructor? && @cud.course_assistant? && !@cud.section.blank? %>
             <li><%= link_to "<i class='material-icons left'>grading</i> Section #{@cud.section} Gradebook".html_safe, [:view, @course, @cud, :gradebook, section: @cud.section], title: "View your gradebook" %></li>
-          <% end %>
-
-          <% if @cud.instructor? || @cud.student? %>
+          <% elsif @cud.instructor? || @cud.student? %>
             <li><%= link_to "<i class='material-icons left'>grading</i> Gradebook".html_safe, [@course, @cud, :gradebook], title: "View your gradebook" %></li>
           <% end %>
 
@@ -112,9 +110,7 @@
         <% if @cud %>
           <% if !@cud.instructor? && @cud.course_assistant? && !@cud.section.blank? %>
             <li><%= link_to "<i class='material-icons left'>grading</i> Section #{@cud.section} Gradebook".html_safe, [:view, @course, @cud, :gradebook, section: @cud.section], title: "View your gradebook" %></li>
-          <% end %>
-
-          <% if @cud.instructor? || @cud.student? %>
+          <% elsif @cud.instructor? || @cud.student? %>
             <li><%= link_to "<i class='material-icons left'>grading</i> Gradebook".html_safe, [@course, @cud, :gradebook], title: "View your gradebook" %></li>
           <% end %>
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Rework Gradebook button logic to allow for both instructor and CA roles

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Turns out users can be both an instructor and CA. Rework the logic a little bit to show Gradebook button to such users (highest available privilege)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally with student, instructor, instructor & CA with no section, instructor & CA with section, CA with no section, and CA with section

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR

## Other issues / help required
<!--- Do you have any other relevant issues / questions? --->
<!--- For example, if you require assistance for a certain part of your PR --->
<!--- or are facing specific issues while creating the pull request that you would like to highlight --->

If unsure, feel free to submit first and we'll help you along.
