### PR TITLE
Set git_enabled to false by default in migration

### DIFF
--- a/db/migrate/20210328201958_add_git_submission_to_autograder.rb
+++ b/db/migrate/20210328201958_add_git_submission_to_autograder.rb
@@ -1,6 +1,6 @@
 class AddGitSubmissionToAutograder < ActiveRecord::Migration[5.2]
   def change
-    add_column :autograders, :git_enabled, :boolean
+    add_column :autograders, :git_enabled, :boolean, :default => false
     add_column :autograders, :git_assignment_name, :string
   end
 end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Setting default value to false so it makes more sense (instead of nil)
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR

## Other issues / help required
<!--- Do you have any other relevant issues / questions? --->
<!--- For example, if you require assistance for a certain part of your PR --->
<!--- or are facing specific issues while creating the pull request that you would like to highlight --->

If unsure, feel free to submit first and we'll help you along.
