### PR TITLE
Add exception handler for invalid tar files

### DIFF
--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -284,8 +284,13 @@ class SubmissionsController < ApplicationController
 
     # Pull the files with their hierarchy info for the file tree
     if Archive.archive? @filename
-      @files = Archive.get_file_hierarchy(@filename).sort! { |a, b| a[:pathname] <=> b[:pathname] }
-      @header_position = params[:header_position].to_i
+      begin
+        @files = Archive.get_file_hierarchy(@filename).sort! { |a, b| a[:pathname] <=> b[:pathname] }
+        @header_position = params[:header_position].to_i
+      rescue
+        flash[:error] = "Could not read archive."
+        redirect_to [@course, @assessment] and return false
+      end
     else
       @files = [{
         pathname: @filename,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Wrap `Archive.get_file_hierarchy` in an exception handler, and return "Could not read archive" if an exception is thrown

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Due to changes in `lib/archive.rb`, some invalid tar files will result in an ArgumentError being thrown, which causes a 500 error since the exception is not handled

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested with [this submission](https://autolab-dev.andrew.cmu.edu/courses/15213-f27/assessments/testassignmentforinc0580430/history?cud_id=1239)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR