### PR TITLE
Properly display fractional grades in annotations

### DIFF
--- a/app/assets/javascripts/annotations.js
+++ b/app/assets/javascripts/annotations.js
@@ -122,7 +122,7 @@ function scrollToLine(n) {
 }
 
 function plusFix(n) {
-  n = parseInt(n)
+  n = parseFloat(n)
   if (isNaN(n)) n = 0;
 
   if (n > 0) {
@@ -207,7 +207,6 @@ function fillAnnotationBox() {
       } else {
         pointBadge.addClass('neutral');
       }
-
       pointBadge.text(plusFix(annotation.value));
       link.append(pointBadge);
       link.append(annotation.comment);

--- a/app/assets/javascripts/annotations.js
+++ b/app/assets/javascripts/annotations.js
@@ -589,6 +589,8 @@ function newAnnotationBox(annotation) {
 
   if (annotation.value < 0) {
     box.find('.value').parent().removeClass('positive').addClass('negative');
+  } else if (!annotation.value > 0) { // I am a little hesitant about using == 1 here -> what if it's negative 0?
+    box.find('.value').parent().removeClass('positive').addClass('neutral');
   }
 
   box.find('.submitted_by').text(annotation.submitted_by);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Always a good idea to reason about whether a value is actually an integer before using `parseInt`!

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #1314 

Also fixes another UI/UX I found where annotations with no changes to scores are not properly reflected using the `neutral` class

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested by creating an annotation with -1.6, 0, 0.5, and 1.6 points

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR
