### PR TITLE
Handin disabled bugfix

### DIFF
--- a/app/controllers/assessment/handin.rb
+++ b/app/controllers/assessment/handin.rb
@@ -20,25 +20,20 @@ module AssessmentHandin
   #
   # Any errors should be added to flash[:error] and return false or nil.
   def handin
+    if @assessment.disable_handins?
+      flash[:error] = "Sorry, handins are disabled for this assessment."
+      redirect_to(action: :show)
+      return false
+    end
 
     if @assessment.embedded_quiz
-
       contents = params[:submission]["embedded_quiz_form_answer"].to_s
 
       out_file = File.new("out.txt", "w+")
       out_file.puts(contents)
 
       params[:submission]["file"] = out_file
-
     end
-
-    if @assessment.embedded_quiz
-      if @assessment.disable_handins?
-        flash[:error] = "Sorry, handins are disabled for this assessment."
-        redirect_to(action: :show)
-        return false
-      end
-    else
 
       # validate the handin
       redirect_to(action: :show) && return unless validateHandin_forHTML


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The handin UI is disabled when the Disable Handin checkbox is checked under the Assessment Settings. However, the logic here seems fishy since there's no reason for it to only be disabled on the backend only if embedded forms are set. This seems to be a bug that just hasn't manifested because the UI is already disabled. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR

## Other issues / help required
<!--- Do you have any other relevant issues / questions? --->
<!--- For example, if you require assistance for a certain part of your PR --->
<!--- or are facing specific issues while creating the pull request that you would like to highlight --->

If unsure, feel free to submit first and we'll help you along.
