### PR TITLE
Fix autograder Git settings UI

### DIFF
--- a/app/views/autograders/_form.html.erb
+++ b/app/views/autograders/_form.html.erb
@@ -1,5 +1,14 @@
 <% content_for :javascripts do %>
 	<script>
+		function toggleGitAssignmentName(checkbox) {
+			var $checkbox = $(checkbox);
+			if($checkbox.is(':checked')) {
+				$('#git_assignment_name').css("display", "block");
+			} else {
+				$('#git_assignment_name').css("display", "none");
+			}
+		}
+
 		$(function() {
 		  $(document).on('change', ':file', function() {
 		    var input = $(this),
@@ -16,13 +25,10 @@
 						$('#tar_name').val(label);
 		    });
 				$("input[type='checkbox']#autograder_git_enabled").on('change', function(){
-  				if(this.checked) {
-						$('#git_assignment_name').css("display", "block");
-					} else {
-						$('#git_assignment_name').css("display", "none");
-					}
+  				toggleGitAssignmentName(this);
 				});
 		  });
+			toggleGitAssignmentName($("input[type='checkbox']#autograder_git_enabled"))
 		});
 	</script>
 <% end %>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
There's currently an issue with the fields for Git submissions in the autograder settings where if Git is enabled upon loading the settings, the assignment name field does not appear below unless the user interacts with the checkbox. This PR checks if the Git enabled checkbox is checked on page load so that it shows the Git assignment name if Git is enabled.

<img width="861" alt="Screen Shot 2021-04-12 at 9 04 17 PM" src="https://user-images.githubusercontent.com/13857201/114481493-a7778f00-9bd2-11eb-957b-be270264f568.png">


## Motivation and Context
Fixes an issue from https://github.com/autolab/Autolab/pull/1317.

## How Has This Been Tested?
Go to an assessment's autograder settings, check the `enable git submissions` checkbox, and fill in the git assignment name. Save settings and reload the page - the assignment name should still appear below the checkbox. 
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR

## Other issues / help required
<!--- Do you have any other relevant issues / questions? --->
<!--- For example, if you require assistance for a certain part of your PR --->
<!--- or are facing specific issues while creating the pull request that you would like to highlight --->

If unsure, feel free to submit first and we'll help you along.
