### PR TITLE
Change Max Submissions to Unpenalized Submissions in Autolab API

### DIFF
--- a/app/controllers/api/v1/assessments_controller.rb
+++ b/app/controllers/api/v1/assessments_controller.rb
@@ -22,7 +22,7 @@ class Api::V1::AssessmentsController < Api::V1::BaseApiController
 
   def show
     allowed = [:name, :display_name, :description, :start_at, :due_at, :end_at, :updated_at, :max_grace_days, :max_submissions,
-      :disable_handins, :category_name, :group_size, :writeup_format, :handout_format, :has_scoreboard, :has_autograder]
+      :disable_handins, :category_name, :group_size, :writeup_format, :handout_format, :has_scoreboard, :has_autograder, :max_unpenalized_submissions]
     if not @cud.student?
       allowed += [:grading_deadline]
     end
@@ -30,6 +30,7 @@ class Api::V1::AssessmentsController < Api::V1::BaseApiController
     result = @assessment.attributes.symbolize_keys
     result.merge!(:has_scoreboard => @assessment.has_scoreboard?)
     result.merge!(:has_autograder => @assessment.has_autograder?)
+    result.merge!(:max_unpenalized_submissions => @assessment.effective_version_threshold)
     if @assessment.writeup_is_file?
       result.merge!(:writeup_format => "file")
     elsif @assessment.writeup_is_url?

--- a/docs/api-interface.md
+++ b/docs/api-interface.md
@@ -130,6 +130,7 @@ Show detailed information of an assessment.
 | updated_at       | datetime | The last time an update was made to the assessment.                                                       |
 | max_grace_days   | integer  | Maximum number of grace days that a student can spend on this assessment.                                 |
 | max_submissions  | integer  | The maximum number of times a student can submit the assessment.<br>-1 means unlimited submissions.       |
+| max_unpenalized_submissions  | integer  | The maximum number of times the assessment can be submitted without incurring a penalty.<br>-1 means unlimited submissions.|
 | disable_handins  | boolean  | Are handins disallowed by students?                                                                       |
 | category_name    | string   | Name of the category this assessment belongs to.                                                          |
 | group_size       | integer  | The maximum size of groups for this assessment.                                                           |


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add `max_unpenalized_submissions` field to API's `/courses/{course_name}/assessments/{assessment_name}` endpoint

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We want to show clients (especially in the CLI) the number of submissions they can make before they start incurring version penalties. Closes #1184

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally using Postman, with no version penalties, and with version penalties after 3 submissions

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [X] I have updated the documentation accordingly, included in this PR

## Other issues / help required
<!--- Do you have any other relevant issues / questions? --->
<!--- For example, if you require assistance for a certain part of your PR --->
<!--- or are facing specific issues while creating the pull request that you would like to highlight --->

If unsure, feel free to submit first and we'll help you along.
