### PR TITLE
Look for tasks with associated feedback in API

### DIFF
--- a/app/controllers/api/v1/submissions_controller.rb
+++ b/app/controllers/api/v1/submissions_controller.rb
@@ -43,8 +43,8 @@ class Api::V1::SubmissionsController < Api::V1::BaseApiController
     submission = @assessment.submissions.find_by(course_user_datum_id: @cud, version: vers)
     raise ApiError.new("Submission version #{vers} does not exist for #{@assessment.name}", :not_found) unless submission
 
-    # Looks weird, but currently feedbacks are the same for each problem
-    score = submission.scores.find_by(problem_id: problem.id)
+    # Looks weird, but currently feedbacks are the same for each problem, so we disregard the problem key and just return the first problem with feedback
+    score = submission.scores.where.not(feedback: nil).first
     raise ApiError.new("Score for #{params[:problem]} of submission version #{vers} of #{@assessment.name} does not exist", :not_found) unless score
 
     results = {:feedback => score.feedback}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Tweaks the API implementation to disregard the problem parameter, and just search for the first score with associated feedback.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
122 issue where tasks without associated feedback were being reported as an error in the CLI instead of looking for tasks with associated feedback. See autolab/Autolab-CLI#22

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested by requesting for multiple problems, including those without associated feedback

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

Does change existing functionality: please review

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR

## Other issues / help required
<!--- Do you have any other relevant issues / questions? --->
<!--- For example, if you require assistance for a certain part of your PR --->
<!--- or are facing specific issues while creating the pull request that you would like to highlight --->

If unsure, feel free to submit first and we'll help you along.
