### PR TITLE
Show hidden file in speedgrader

### DIFF
--- a/lib/archive.rb
+++ b/lib/archive.rb
@@ -25,8 +25,7 @@ module Archive
         header_position: i,
         mac_bs_file: pathname.include?("__MACOSX") ||
           pathname.include?(".DS_Store") ||
-          pathname.include?(".metadata") ||
-          File.basename(pathname).start_with?('.'),
+          pathname.include?(".metadata"),
         directory: looks_like_directory?(pathname)
       }
     end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR addresses #1166.

## Motivation and Context
The current master does not support showing hidden files whose file name starts with a period, which could be problematic for some instructors. This is now enabled.
(To whoever reviews this PR: But can I know why hidden files are also considered mac_bs_file in the archive library? What does the term mean in the first place? 😂 )

## How Has This Been Tested?
Submit an archive file with a hidden file in it. It should now appear alright in the speedgrader.
![hidden file](https://user-images.githubusercontent.com/54905587/115250834-8841aa00-a15c-11eb-8de8-a0059e61eb33.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR

## Other issues / help required
<!--- Do you have any other relevant issues / questions? --->
<!--- For example, if you require assistance for a certain part of your PR --->
<!--- or are facing specific issues while creating the pull request that you would like to highlight --->

If unsure, feel free to submit first and we'll help you along.
