### PR TITLE
Datetime picker result display fix

### DIFF
--- a/app/assets/javascripts/initialize_datetimepickers.js
+++ b/app/assets/javascripts/initialize_datetimepickers.js
@@ -13,8 +13,13 @@
       $(datetimeElts[i]).flatpickr({
         enableTime: true,
         altInput: true,
-        altFormat: "Y-m-d H:i",
         defaultDate: defaultDate,
+        formatDate: (date, format) => {
+          return moment(date).format(format);
+        },
+        parseDate: (datestr, format) => {
+          return moment(datestr, format, true).toDate();
+        },
       })
     }
 
@@ -28,8 +33,13 @@
 
       $(dateElts[i]).flatpickr({
         altInput: true,
-        altFormat: "Y-m-d H:i",
         defaultDate: defaultDate,
+        formatDate: (date, format) => {
+          return moment(date).format(format);
+        },
+        parseDate: (datestr, format) => {
+          return moment(datestr, format, true).toDate();
+        },
       })
     }
   });

--- a/app/assets/javascripts/initialize_datetimepickers.js
+++ b/app/assets/javascripts/initialize_datetimepickers.js
@@ -13,7 +13,8 @@
       $(datetimeElts[i]).flatpickr({
         enableTime: true,
         altInput: true,
-        defaultDate: defaultDate
+        altFormat: "Y-m-d H:i",
+        defaultDate: defaultDate,
       })
     }
 
@@ -27,7 +28,8 @@
 
       $(dateElts[i]).flatpickr({
         altInput: true,
-        defaultDate: defaultDate
+        altFormat: "Y-m-d H:i",
+        defaultDate: defaultDate,
       })
     }
   });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Addresses #1357

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The bug comes from the fact that altInput is specified, but the formatting is not specified. Usually one would do it with altFormat, but in this case we already have a template from @oliverli that also shows the time zone as well, so I decided to go with that to be more descriptive and consistent. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Announcement start/end times now render properly, now with the time zone being specified as well

![Screenshot_select-area_20210530012825](https://user-images.githubusercontent.com/9707110/120093163-f8275500-c14a-11eb-82ed-0b584a4a2921.png)

I have also checked that handin start/end times datepicker values, and extension times still render properly. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR

## Other issues / help required
<!--- Do you have any other relevant issues / questions? --->
<!--- For example, if you require assistance for a certain part of your PR --->
<!--- or are facing specific issues while creating the pull request that you would like to highlight --->

If unsure, feel free to submit first and we'll help you along.
