### PR TITLE
Specify Ruby-2.6.6 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@
 #     https://github.com/phusion/passenger-docker
 #
 #
-FROM phusion/passenger-ruby26
+FROM phusion/passenger-ruby26:1.0.13
 
 MAINTAINER Autolab Development Team "autolab-dev@andrew.cmu.edu"
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This change specifies Ruby version 2.6.6 in the Dockerfile.

## Motivation and Context
Addresses an error that occurs while building the Dockerfiles for docker-compose installation when it attempts to use a Ruby version other than 2.6.6 (as mentioned in [this issue](https://github.com/autolab/docker/issues/34).

## How Has This Been Tested?
Ran through the [docker-compose installation](https://docs.autolabproject.com/installation/docker-compose/) steps.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR

## Other issues / help required
<!--- Do you have any other relevant issues / questions? --->
<!--- For example, if you require assistance for a certain part of your PR --->
<!--- or are facing specific issues while creating the pull request that you would like to highlight --->

If unsure, feel free to submit first and we'll help you along.
