### PR TITLE
Fix initialize_user resulting in email confirmation when this was unwanted

### DIFF
--- a/lib/tasks/admin.rake
+++ b/lib/tasks/admin.rake
@@ -28,9 +28,9 @@ namespace :admin do
 
   desc "Create a new root user"
   task :create_root_user, [:email, :password, :first_name, :last_name] => [:environment] do |t, args|
-    u = User.create(email: args.email, first_name: args.first_name, last_name: args.last_name, password: args.password, administrator: true, school: "My School", major: "CS", year: "4")
+    u = User.new(email: args.email, first_name: args.first_name, last_name: args.last_name, password: args.password, administrator: true, school: "My School", major: "CS", year: "4")
     u.skip_confirmation!
-    u.save
+    u.save!
     puts "Successfully created root user with email #{args.email}"
   end
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Previously we were using .create in the rake task, which actually creates and stores the user in the db. .new only creates the object but does not actually store it yet, causing the devise mailing callbacks to not fire, which is what we want

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/autolab/docker/issues/34

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Newly created user is persisted, and no more error is shown

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR

## Other issues / help required
<!--- Do you have any other relevant issues / questions? --->
<!--- For example, if you require assistance for a certain part of your PR --->
<!--- or are facing specific issues while creating the pull request that you would like to highlight --->

If unsure, feel free to submit first and we'll help you along.
