### PR TITLE
initialize_user.sh to take in flag for dev

### DIFF
--- a/bin/initialize_user.sh
+++ b/bin/initialize_user.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+env='production'
+
 add_a_user()
 {
   echo "############## Initialize a new root user ##############"
@@ -19,7 +21,14 @@ done
   read -p 'First Name: ' first_name
   read -p 'Last Name: ' last_name
 
-  RAILS_ENV=production bundle exec rails admin:create_root_user[$email,"$password","$first_name","$last_name"]
+  echo $1
+  RAILS_ENV=$1 bundle exec rails admin:create_root_user[$email,"$password","$first_name","$last_name"]
 }
 
-add_a_user
+while getopts 'd' flag; do
+    case "${flag}" in
+    d) env="development" ;;
+  esac
+done
+
+add_a_user $env

--- a/bin/initialize_user.sh
+++ b/bin/initialize_user.sh
@@ -21,7 +21,6 @@ done
   read -p 'First Name: ' first_name
   read -p 'Last Name: ' last_name
 
-  echo $1
   RAILS_ENV=$1 bundle exec rails admin:create_root_user[$email,"$password","$first_name","$last_name"]
 }
 

--- a/docs/installation/osx.md
+++ b/docs/installation/osx.md
@@ -86,7 +86,7 @@ Follow the step-by-step instructions below:
 
     Do not forget to use `bundle exec` in front of every rake/rails command.
 
-12. Create initial root user. (Flag is required for differentiating the environment because this affects the database (prod or dev) in which the user is created.)
+12. Create initial root user, pass the `-d` flag for developmental deployments:
 
         :::bash
         # For production:

--- a/docs/installation/osx.md
+++ b/docs/installation/osx.md
@@ -86,10 +86,14 @@ Follow the step-by-step instructions below:
 
     Do not forget to use `bundle exec` in front of every rake/rails command.
 
-12. Create initial root user
+12. Create initial root user. (Flag is required for differentiating the environment because this affects the database (prod or dev) in which the user is created.)
 
         :::bash
+        # For production:
         ./bin/initialize_user.sh
+
+        # For development:
+        ./bin/initialize_user.sh -d
 
 13. Populate dummy data (for development only):
 

--- a/docs/installation/ubuntu.md
+++ b/docs/installation/ubuntu.md
@@ -137,10 +137,14 @@ Comment out the configurations meant for MySQL in config/database.yml, and inser
         bundle exec rails db:reset
         bundle exec rails db:migrate
 
-13. Create initial root user
+13. Create initial root user. (Flag is required for differentiating the environment because this affects the database (prod or dev) in which the user is created.)
 
         :::bash
+        # For production:
         ./bin/initialize_user.sh
+
+        # For development:
+        ./bin/initialize_user.sh -d
 
 14. If you are just testing Autolab, you can populate the database with sample course & students
 

--- a/docs/installation/ubuntu.md
+++ b/docs/installation/ubuntu.md
@@ -137,7 +137,7 @@ Comment out the configurations meant for MySQL in config/database.yml, and inser
         bundle exec rails db:reset
         bundle exec rails db:migrate
 
-13. Create initial root user. (Flag is required for differentiating the environment because this affects the database (prod or dev) in which the user is created.)
+13. Create initial root user, pass the `-d` flag for developmental deployments:
 
         :::bash
         # For production:

--- a/lib/tasks/admin.rake
+++ b/lib/tasks/admin.rake
@@ -30,7 +30,7 @@ namespace :admin do
   task :create_root_user, [:email, :password, :first_name, :last_name] => [:environment] do |t, args|
     u = User.create(email: args.email, first_name: args.first_name, last_name: args.last_name, password: args.password, administrator: true, school: "My School", major: "CS", year: "4")
     u.skip_confirmation!
-    u.save
+    u.save!
     puts "Successfully created root user with email #{args.email}"
   end
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Let ./initialize_user.sh to take in a flag for dev (-d), so that people running dev installations can also get a user created (by default it uses prod env vars)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
./bin/initialize_user.sh -d works for creating a dev user
./bin/initialize_user.sh will also work once https://github.com/autolab/Autolab/pull/1363 is merged

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [x] I have updated the documentation accordingly, included in this PR

## Other issues / help required
<!--- Do you have any other relevant issues / questions? --->
<!--- For example, if you require assistance for a certain part of your PR --->
<!--- or are facing specific issues while creating the pull request that you would like to highlight --->

If unsure, feel free to submit first and we'll help you along.
