### PR TITLE
Add safe navigator to lines chomp

### DIFF
--- a/app/controllers/assessments_controller.rb
+++ b/app/controllers/assessments_controller.rb
@@ -555,7 +555,7 @@ class AssessmentsController < ApplicationController
 
   def parseFeedback(feedback)
     lines = feedback.lines
-    feedback = lines[lines.length - 2].chomp
+    feedback = lines[lines.length - 2]&.chomp
     if valid_json?(feedback)
       jsonFeedbackHash = JSON.parse(feedback)
       if jsonFeedbackHash.key?("_presentation") == false


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This change uses safe navigation operator to check for nil before calling chomp
https://mitrev.net/ruby/2015/11/13/the-operator-in-ruby/

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Addresses issue as found in https://github.com/autolab/Autolab/issues/1360,
where chomp can be called on a nil object.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested by running the segment of code and testing when an nil object is the result of `lines[lines.length - 2]`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR

## Other issues / help required
<!--- Do you have any other relevant issues / questions? --->
<!--- For example, if you require assistance for a certain part of your PR --->
<!--- or are facing specific issues while creating the pull request that you would like to highlight --->

If unsure, feel free to submit first and we'll help you along.
