### PR TITLE
fixed checkboxes not build with FormBuilderWithDateTimeInput

### DIFF
--- a/app/views/courses/uploadRoster.html.erb
+++ b/app/views/courses/uploadRoster.html.erb
@@ -75,11 +75,14 @@ The file should be in the following formats: <br><br>
 <p>
 The CMU Roster file should include a header.  Editing accounts will occur as a <a href="http://en.wikipedia.org/wiki/Database_transaction#Transactional_databases">transaction</a>, if there is an error we will cancel all changes and allow you to correct the error and re-submit. </p>
 <%= form_for :upload, :url=>{:action=>"uploadRoster"}, :html=>{:multipart=>true} do |f| %>
-<%= f.file_field :file %><br>
-<%= f.check_box :dropMissing, class: "filled-in-box" %> 
-<label for="upload_dropMissing">Mark students not included in this roster as 'Dropped'?</label></br>
-<font class="smallText">Dropped students can view grades but cannot submit
-assignments or download new assignments</font>
+<%= f.file_field :file %>
+<p></p>
+<label for="upload_dropMissing">
+    <%= f.check_box :dropMissing, class: "filled-in-box" %>
+    <span>Mark students not included in this roster as 'Dropped'?</span> <br />
+    <font class="smallText">Dropped students can view grades but cannot submit
+      assignments or download new assignments</font>
+</label>
 <p></p>
 <%= f.submit 'Upload!' , {:class=>"btn primary"} %>
 <% end %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -10,9 +10,12 @@
   <div><%= f.password_field :password, :placeholder=> "Password"%></div>
 
   <% if devise_mapping.rememberable? -%>
-    <%= f.check_box :remember_me %><%= f.label :remember_me %>
+  <label>
+      <%= f.check_box :remember_me %>
+      <span> <%= f.label :remember_me %> </span> <br />
+  </label>
+  <p></p>
   <% end -%>
-
   <div><%= f.submit "Sign in", :class=>"btn primary" %></div>
 <% end %>
 <br>

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -30,7 +30,7 @@
     <div class="field">
         <label>
               <%= f.check_box :administrator %>
-            <span> <%= f.label :administrator %> <span> <br>
+            <span> <%= f.label :administrator %> </span> <br>
         </label>
 
     </div>


### PR DESCRIPTION
Fixed checkboxes that were not visible due to material design update.

## Description
I added a `<span>`-element after the checkbox and put everything in a `<label>`-element.

## Motivation and Context
Remember me at the sign in page was not usable.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR

## Other issues / help required
The code seems inconsistent in using `<br>` and `<br />`  and should be unified.
