### PR TITLE
Address undefined method `feedback' for nil:NilClass

### DIFF
--- a/app/controllers/assessments_controller.rb
+++ b/app/controllers/assessments_controller.rb
@@ -508,11 +508,11 @@ class AssessmentsController < ApplicationController
   def viewFeedback
     # User requested to view feedback on a score
     @score = @submission.scores.find_by(problem_id: params[:feedback])
-    @jsonFeedback = parseFeedback(@score.feedback)
     if !@score
       flash[:error] = "No feedback for requested score"
       redirect_to(action: "index") && return
     end
+    @jsonFeedback = parseFeedback(@score.feedback)
     if @jsonFeedback != nil
       @scoreHash = parseScore(@score.feedback)
     end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Reordered code to only run `parseFeedback` after making sure `@score` is not nil

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixed [CMU-Autolab-Prod Error] assessments viewFeedback (NoMethodError) "undefined method `feedback' for nil:NilClass"

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested by going to non-existent feedback page for some submission (e.g. `/courses/AutoPopulated/assessments/hello/viewFeedback?feedback=171&submission_id=1884`, change the `feedback` value to something else). It should correctly flash an error

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR

## Other issues / help required
<!--- Do you have any other relevant issues / questions? --->
<!--- For example, if you require assistance for a certain part of your PR --->
<!--- or are facing specific issues while creating the pull request that you would like to highlight --->

If unsure, feel free to submit first and we'll help you along.
