### PR TITLE
Better output for non-ascii autograder feedback

### DIFF
--- a/app/helpers/assessment_autograde_core.rb
+++ b/app/helpers/assessment_autograde_core.rb
@@ -316,9 +316,21 @@ module AssessmentAutogradeCore
 
       feedback_file = File.join(ass_dir, @assessment.handin_directory, filename)
       COURSE_LOGGER.log("Looking for Feedbackfile:" + feedback_file)
-      File.open(feedback_file, "wb") do |f|
-        f.write(feedback.force_encoding("utf-8"))
+      feedback.force_encoding("UTF-8")
+
+      if not feedback.valid_encoding?
+        feedback.force_encoding("Windows-1252")
+        hexify = Proc.new {|c| "\\x" + c.bytes[0].to_s(16) }
+        feedback = feedback.encode("UTF-8", invalid: :replace, fallback: hexify)
       end
+
+      File.open(feedback_file, "w") do |f|
+        f.write(feedback)
+      end
+
+      # File.open(feedback_file, "wb") do |f|
+      #   f.write(feedback.force_encoding("utf-8"))
+      # end
     end
 
     saveAutograde(submissions, feedback)

--- a/app/helpers/assessment_autograde_core.rb
+++ b/app/helpers/assessment_autograde_core.rb
@@ -316,10 +316,10 @@ module AssessmentAutogradeCore
 
       feedback_file = File.join(ass_dir, @assessment.handin_directory, filename)
       COURSE_LOGGER.log("Looking for Feedbackfile:" + feedback_file)
-      feedback.force_encoding("UTF-8")
 
+      feedback.force_encoding("UTF-8")
       if not feedback.valid_encoding?
-        feedback.force_encoding("Windows-1252")
+        feedback.force_encoding("ASCII-8BIT")
         hexify = Proc.new {|c| "\\x" + c.bytes[0].to_s(16) }
         feedback = feedback.encode("UTF-8", invalid: :replace, fallback: hexify)
       end
@@ -327,10 +327,6 @@ module AssessmentAutogradeCore
       File.open(feedback_file, "w") do |f|
         f.write(feedback)
       end
-
-      # File.open(feedback_file, "wb") do |f|
-      #   f.write(feedback.force_encoding("utf-8"))
-      # end
     end
 
     saveAutograde(submissions, feedback)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Improves on the feedback returned when non-ASCII output appears from the autograder (see https://github.com/autolab/Autolab/pull/1384). Many thanks to @cg2v for the enhancements.

## Motivation and Context
See https://github.com/autolab/Autolab/pull/1384
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Upload something like a binary file on hellolab, you should be able to see the feedback even though it contains non-ASCII characters.

To test the encoding workflow, upload a file containing just \xc2 (see https://apidock.com/ruby/v2_5_5/String/valid_encoding%3F), and verify that we get \xc2 instead of the actual representation in the feedback 


<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR

## Other issues / help required
<!--- Do you have any other relevant issues / questions? --->
<!--- For example, if you require assistance for a certain part of your PR --->
<!--- or are facing specific issues while creating the pull request that you would like to highlight --->

If unsure, feel free to submit first and we'll help you along.
