### PR TITLE
Remove null chaining operators from watchlist.js

### DIFF
--- a/app/assets/javascripts/watchlist.js
+++ b/app/assets/javascripts/watchlist.js
@@ -299,8 +299,10 @@ function search_enter_action(query, tab_name, instances, archived_instances, emp
     );
   }
   var filtered_instances = Object.keys(instances).reduce(function (filtered, key) {
-    if (instances[key]["name"]?.toLowerCase()?.includes(search_input)
-      || instances[key]["email"]?.toLowerCase()?.includes(search_input)
+    var instance_name = instances[key]["name"] || "";
+    var instance_email = instances[key]["email"] || "";
+    if (instance_name.toLowerCase().includes(search_input)
+      || instance_email.toLowerCase().includes(search_input)
       || instance_passes_condition_search(instances[key], search_input)) {
       filtered[key] = instances[key];
     } 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Removes null chaining operator since Uglifier does not support it (same as in https://github.com/autolab/Autolab/pull/1276).

## Motivation and Context
Fixes https://github.com/autolab/Autolab/issues/1397. 

## How Has This Been Tested?
Pulled recent watchlist changes and Dockerfile builds successfully (used to error out on rails precompile step - refer to issue above for more context)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR

## Other issues / help required
<!--- Do you have any other relevant issues / questions? --->
<!--- For example, if you require assistance for a certain part of your PR --->
<!--- or are facing specific issues while creating the pull request that you would like to highlight --->

If unsure, feel free to submit first and we'll help you along.
