### PR TITLE
Use Terser instead of Uglifier as JS compressor

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ gem 'bootstrap-sass', '>= 3.4.1'
 gem 'fomantic-ui-sass'
 
 # Use Uglifier as compressor for JavaScript assets
-gem 'uglifier', '>= 1.3.0'
+gem 'terser', '>= 1.1.7'
 
 # Use CoffeeScript for .js.coffee assets and views
 gem 'coffee-rails', '>= 4.0.0'

--- a/config/environments/production.rb.template
+++ b/config/environments/production.rb.template
@@ -15,7 +15,7 @@ Autolab3::Application.configure do
 
   config.assets.enabled = true
   # Compress JavaScripts and CSS
-  config.assets.js_compressor = Uglifier.new(harmony: true)
+  config.assets.js_compressor = :terser
   config.assets.css_compressor = :sass
 
   # Don't fallback to assets pipeline if a precompiled asset is missed


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Switches from Uglifier to [Terser](https://github.com/ahorek/terser-ruby) as JS compressor to support ES6 syntax.

## Motivation and Context
Fixes #1397.

## How Has This Been Tested?
Dockerfile built successfully with null chaining operator in watchlist.js

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR

## Other issues / help required
<!--- Do you have any other relevant issues / questions? --->
<!--- For example, if you require assistance for a certain part of your PR --->
<!--- or are facing specific issues while creating the pull request that you would like to highlight --->

If unsure, feel free to submit first and we'll help you along.
