### PR TITLE
Switch some `after_save` hooks to `after_commit`

### DIFF
--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -38,8 +38,8 @@ class Assessment < ApplicationRecord
 
   # Callbacks
   trim_field :name, :display_name, :handin_filename, :handin_directory, :handout, :writeup
-  after_save :dump_yaml
-  after_save :dump_embedded_quiz, if: :saved_change_to_embedded_quiz_form_data?
+  after_commit :dump_yaml
+  after_commit :dump_embedded_quiz, if: :saved_change_to_embedded_quiz_form_data?
   after_save :invalidate_course_cgdubs, if: :saved_change_to_due_at_or_max_grace_days?
   after_save :update_course_grade_watchlist_instances_if_past_end_at,
              if: :saved_change_to_grade_related_fields?

--- a/app/models/autograder.rb
+++ b/app/models/autograder.rb
@@ -12,7 +12,7 @@ class Autograder < ApplicationRecord
   validates :autograde_image, :autograde_timeout, presence: true
   validates :autograde_image, length: { maximum: 64 }
 
-  after_save -> { assessment.dump_yaml }
+  after_commit -> { assessment.dump_yaml }
 
   SERIALIZABLE = Set.new %w[autograde_image autograde_timeout release_score]
   def serialize

--- a/app/models/problem.rb
+++ b/app/models/problem.rb
@@ -13,7 +13,7 @@ class Problem < ApplicationRecord
   validates :name, presence: true
   validates_associated :assessment
 
-  after_save -> { assessment.dump_yaml }
+  after_commit -> { assessment.dump_yaml }
   after_save :update_course_grade_watchlist_instances_if_past_end_at,
              if: :saved_change_to_max_score?
   after_create :update_course_grade_watchlist_instances_if_past_end_at

--- a/app/models/score.rb
+++ b/app/models/score.rb
@@ -24,7 +24,7 @@ class Score < ApplicationRecord
   validates(:problem_id, uniqueness: { scope: :submission_id })
   validates :grader_id, presence: true
 
-  after_save :log_entry
+  after_commit :log_entry
 
   def self.find_with_feedback(*args)
     with_exclusive_scope { find(*args) }

--- a/app/models/scoreboard.rb
+++ b/app/models/scoreboard.rb
@@ -8,7 +8,7 @@ class Scoreboard < ApplicationRecord
 
   validate :colspec_is_well_formed
 
-  after_save -> { assessment.dump_yaml }
+  after_commit -> { assessment.dump_yaml }
 
   SERIALIZABLE = Set.new %w[banner colspec]
   def serialize

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -33,7 +33,7 @@ class Submission < ApplicationRecord
   after_save :update_latest_submission, if: :version_changed?
   after_save :update_latest_submission, if: :ignored_changed?
   after_save :update_individual_grade_watchlist_instances_if_latest, if: :saved_change_to_tweak_id?
-  after_save do |sub|
+  after_commit do |sub|
     COURSE_LOGGER.log("Submission #{sub.id} SAVED for " \
       "#{sub.course_user_datum.user.email} on" \
       " #{sub.assessment.name}, file #{sub.filename} (#{sub.mime_type}),"\


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Switched some `after_save` hooks that do not require strict data dependency from the DB (e.g. methods that do not write to the database, only filesystem) to `after_commit`, as recommended by Chaskiel

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Chaskiel's email dated Oct 21, 2021, 11:58 AM: MySQL deadlocks

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR

## Other issues / help required
<!--- Do you have any other relevant issues / questions? --->
<!--- For example, if you require assistance for a certain part of your PR --->
<!--- or are facing specific issues while creating the pull request that you would like to highlight --->

If unsure, feel free to submit first and we'll help you along.
