### PR TITLE
Update Carnegie Mellon LDAP integration

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -183,10 +183,9 @@ class User < ApplicationRecord
     require "rubygems"
     require "net/ldap"
 
-    host = "ldap.andrew.cmu.edu"
+    host = "ldap.cmu.edu"
     ldap = Net::LDAP.new(host: host, port: 389)
-    user = ldap.search(base: "ou=Person,dc=cmu,dc=edu",
-                       filter: "cmuAndrewId=" + andrewID)[0]
+    user = ldap.search(base: "uid=" + andrewID + ",ou=AndrewPerson,dc=andrew,dc=cmu,dc=edu")[0]
 
     return unless user
 
@@ -226,6 +225,8 @@ class User < ApplicationRecord
 
     result[:year] = case user[:cmustudentclass][0]
                     when "Freshman" then "1"
+                    when "First-Year student" then "1"
+                    when "First-Year Student" then "1"
                     when "Sophomore" then "2"
                     when "Junior" then "3"
                     when "Senior" then "4"


### PR DESCRIPTION
## Description

- Stop using the legacy LDAP server
- Check for the currently used value denoting first year students

## Motivation and Context
Carnegie Mellon computing services is retiring the LDAP pool at ldap.andrew.cmu.edu and requiring all services to switch to the newer service at ldap.cmu.edu, which only provides a subset of the schema, but continues to provide all the data Autolab consumes. This change uses the new server and schema.

Several semesters ago, the Carnegie Mellon registrar started labeling first year students as "First-Year student" and not "Freshman". This change maps both "First-Year student" (and First-Year Student in case they ever fix the case) to the year value 1 in addition to "Freshman"

## How Has This Been Tested?
I manually invoked User.ldap_lookup on a variety of accounts and verified that the results looked ok

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR

