### PR TITLE
Fix selected month not shown in date time picker

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'rails', '=5.2.0'
 gem 'sass-rails', '>= 4.0.3'
 
 # Use Materialize for the base css
-gem 'materialize-sass'
+gem 'materialize-sass', "=1.0.0"
 
 # Use for some of the glypicons on the site
 gem 'bootstrap-sass', '>= 3.4.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -176,7 +176,7 @@ GEM
       mini_mime (>= 0.1.1)
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
-    materialize-sass (1.0.0.1)
+    materialize-sass (1.0.0)
       autoprefixer-rails (>= 6.0.3)
     matrix (0.4.2)
     method_source (1.0.0)
@@ -397,7 +397,7 @@ DEPENDENCIES
   jquery-rails
   js_cookie_rails
   jstz-rails3-plus (>= 1.0)
-  materialize-sass
+  materialize-sass (= 1.0.0)
   mimemagic (>= 0.3.7)
   mini_racer (<= 0.4.0)
   moment_timezone-rails


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Downgrade [`materialize-sass`](https://rubygems.org/gems/materialize-sass/) from `1.0.0.1` to `1.0.0`. In `1.0.0.1`, it added a CSS line `opacity: 0;` to all `<select>` elements, which made the month selector in the datetimepicker transparent

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://app.asana.com/0/1201396080493675/1201396957239603

Closes #1417 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally, month selector visible again

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR

## Other issues / help required
<!--- Do you have any other relevant issues / questions? --->
<!--- For example, if you require assistance for a certain part of your PR --->
<!--- or are facing specific issues while creating the pull request that you would like to highlight --->

If unsure, feel free to submit first and we'll help you along.
