### PR TITLE
Make Git Submission post request without Ajax

### DIFF
--- a/app/assets/javascripts/git_submission.js
+++ b/app/assets/javascripts/git_submission.js
@@ -38,6 +38,27 @@ $("#repo-dropdown").change(function() {
   update_branches(repo_name);
 });
 
+// https://stackoverflow.com/questions/5524045/jquery-non-ajax-post
+function submit(action, method, input) {
+  'use strict';
+  var form;
+  form = $('<form />', {
+      action: action,
+      method: method,
+      style: 'display: none;'
+  });
+  if (typeof input !== 'undefined' && input !== null) {
+      $.each(input, function (name, value) {
+          $('<input />', {
+              type: 'hidden',
+              name: name,
+              value: value
+          }).appendTo(form);
+      });
+  }
+  form.appendTo('body').submit();
+}
+
 $(document).on("click", "input[type='submit']", function (e) {
   var tab = $(".submission-panel .ui.tab.active").attr('id');
   if (tab === "github_tab" && !$(this).is(":disabled")) {
@@ -48,14 +69,7 @@ $(document).on("click", "input[type='submit']", function (e) {
     var assessment_nav = $(".sub-navigation").find(".item").last();
     var assessment_url = assessment_nav.find("a").attr("href");
     var url = assessment_url + "/handin"
-    $.ajax({
-      type: 'POST',
-      url: url,
-      data: params, 
-      success: function(data){
-        window.location.replace(assessment_url + "/history");
-      },
-    });
+    submit(url, 'post', params);
   }
 });
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Since Ajax can't handle rails redirecting or flash error messages, this makes the post request for handin via Git Submission without using Ajax. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR

## Other issues / help required
<!--- Do you have any other relevant issues / questions? --->
<!--- For example, if you require assistance for a certain part of your PR --->
<!--- or are facing specific issues while creating the pull request that you would like to highlight --->

If unsure, feel free to submit first and we'll help you along.
