### PR TITLE
Generate github callback url with https

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -206,9 +206,25 @@ class UsersController < ApplicationController
     else
       github_integration.update!(oauth_state: state)
     end
+    # Use https, unless explicitly specified not to
+    prefix = "https://"
+    if ENV["DOCKER_SSL"] == "false"
+      prefix = "http://"
+    end
+
+    begin
+      if Rails.env.development?
+        hostname = request.base_url
+      else
+        hostname = prefix + request.host
+      end
+    rescue
+      hostname = `hostname`
+      hostname = prefix + hostname.strip
+    end
 
     authorize_url_params = {
-      redirect_uri: "http://#{request.host}:#{request.port}/users/github_oauth_callback",
+      redirect_uri: "#{hostname}/users/github_oauth_callback",
       scope: "repo",
       state: state
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Copy the logic from AssessmentAutogradeCore:get_callback_url to generate 
the redirect uri for github. That will cause https vs http to be used appropriately.
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
At present, the github callback url is always generated with the 'http' protocol. This can cause 
1. a redirect_uri mismatch (if the github oauth app is configured with https in the redirect_uri)
2. failure to complete authorization (if the autolab host doesn't accept http)
3. disclosure of the oauth state and code tokens 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR