### PR TITLE
Add reminder for Linting in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -20,6 +20,7 @@
 
 ## Checklist:
 <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
+- [ ] My PR involves changes to Ruby code and I have run `rubocop` from the Autolab directory
 - [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
 - [ ] I have updated the documentation accordingly, included in this PR
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add reminder for linting in PR template's checklist section.

## Motivation and Context
This is in an effort to enforce linting standard on future PR's.

## How Has This Been Tested?
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR

## Other issues / help required
<!--- Do you have any other relevant issues / questions? --->
<!--- For example, if you require assistance for a certain part of your PR --->
<!--- or are facing specific issues while creating the pull request that you would like to highlight --->

If unsure, feel free to submit first and we'll help you along.
