### PR TITLE
[BUGFIX] fixed race condition bug for embedded quiz handin

### DIFF
--- a/app/controllers/assessment/handin.rb
+++ b/app/controllers/assessment/handin.rb
@@ -27,8 +27,7 @@ module AssessmentHandin
 
     if @assessment.embedded_quiz
       contents = params[:submission]["embedded_quiz_form_answer"].to_s
-      require 'tempfile'
-      out_file = Tempfile.new('out.txt')
+      out_file = Tempfile.new('out.txt-')
       out_file.puts(contents)
       params[:submission]["file"] = out_file
     elsif @assessment.github_submission_enabled && params["repo"].present? && params["branch"].present?

--- a/app/controllers/assessment/handin.rb
+++ b/app/controllers/assessment/handin.rb
@@ -27,10 +27,11 @@ module AssessmentHandin
 
     if @assessment.embedded_quiz
       contents = params[:submission]["embedded_quiz_form_answer"].to_s
-      out_file = File.new("out.txt", "w+")
+      require 'tempfile'
+      out_file = Tempfile.new('out.txt')
       out_file.puts(contents)
       params[:submission]["file"] = out_file
-    elsif @assessment.github_submission_enabled && params["repo"].present? && params["branch"].present? 
+    elsif @assessment.github_submission_enabled && params["repo"].present? && params["branch"].present?
       # get code from Github
       github_integration = current_user.github_integration
 
@@ -68,6 +69,11 @@ module AssessmentHandin
 
       COURSE_LOGGER.log("could not save handin: #{exception.class} (#{exception.message})")
       submissions = nil
+    end
+
+    if @assessment.embedded_quiz
+      out_file.close
+      out_file.unlink
     end
 
     # make sure submission was correctly constructed and saved


### PR DESCRIPTION
If two students submit at the same time it may happen that the out.txt gets written by two requests at the same time resulting in invalid submissions. This fixes that by creating a tempfile so very submission gets its own file.

## How Has This Been Tested?
I submitted an embedded form.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR