### PR TITLE
[BUGFIX] fixed visibility of autograder output

### DIFF
--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -303,14 +303,14 @@ class SubmissionsController < ApplicationController
 
     # Adds autograded file as first option if it exist
     # We are mapping Autograder to header_position -1
-    unless @submission.autograde_file.nil?
-      @files.prepend({ pathname: "Autograder Output",
-                       header_position: -1,
-                       mac_bs_file: false,
-                       directory: false })
-    end
-
-    if params.include?(:header_position) && (params[:header_position].to_i == -1) && !@submission.autograde_file.nil?
+    if(!@submission.autograde_file.nil? && (!@assessment.before_grading_deadline? || @cud.instructor || @cud.course_assistant))
+      @files.prepend({pathname:"Autograder Output",
+                      header_position: -1,
+                      mac_bs_file: false,
+                      directory: false})
+      end
+    
+    if (params.include?(:header_position) && (params[:header_position].to_i == -1) && !@submission.autograde_file.nil? && (!@assessment.before_grading_deadline? || @cud.instructor || @cud.course_assistant))
       file = @submission.autograde_file.read || "Empty Autograder Output"
       @displayFilename = "Autograder Output"
     elsif params.include?(:header_position) && Archive.archive?(@submission.handin_file_path)


### PR DESCRIPTION
Student can see their autograding output also in the case that the score is not directly release. This Commit fixes that

## How Has This Been Tested?
I viewed the submission and now you can not see the Autograder Output until the scores are released.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR
