### PR TITLE
[BUGFIX+IMPROVEMENT] Fixed and added autocomplete for inputing students

### DIFF
--- a/app/controllers/course_user_data_controller.rb
+++ b/app/controllers/course_user_data_controller.rb
@@ -191,6 +191,11 @@ class CourseUserDataController < ApplicationController
       redirect_to([@cud.course]) && return
     end
 
+    @users = {}
+    @course.course_user_data.each do |cud|
+      @users[cud.full_name_with_email] = cud.email
+    end
+
     return unless request.post?
 
     sudo_user = User.where(email: params[:sudo_email]).first

--- a/app/controllers/extensions_controller.rb
+++ b/app/controllers/extensions_controller.rb
@@ -15,10 +15,8 @@ class ExtensionsController < ApplicationController
   def index
     @extensions = @assessment.extensions.includes(:course_user_datum)
     @users = {}
-    @usersEncoded = {}
     @course.course_user_data.each do |cud|
       @users[cud.full_name_with_email] = cud.id
-      @usersEncoded[Base64.encode64(cud.full_name_with_email.strip).strip] = cud.id
     end
     @new_extension = @assessment.extensions.new
   end

--- a/app/views/course_user_data/sudo.html.erb
+++ b/app/views/course_user_data/sudo.html.erb
@@ -1,10 +1,43 @@
+<% content_for :javascripts do %>
+  <script type="application/javascript">
+    jQuery(function() {
+      userData = {
+        <% @users.each do |k,v| %>
+          "<%= k %>": "<%= v %>",
+        <% end %>
+      };
+
+      /* user autocomplete */
+      $studentAutocompleteField = $('#student_autocomplete');
+      $hiddenCUDField = $('#sudo_email');
+      $studentAutocompleteField.autocomplete({
+        data: {
+          <% @users.each do |k,v| %>
+            "<%= k %>": null,
+          <% end %>
+        }
+      });
+
+      /* track changes in student autocomplete field */
+      $studentAutocompleteField.on('change', function() {
+        $hiddenCUDField.val(userData[$studentAutocompleteField.val()]);
+      })
+    });
+  </script>
+<% end %>
+
 <h2>Act as User</h2>
 
 <p>You can use sudo to examine how Autolab appears to other users. You can also change your permission levels to see what your course assistants or students generically see.</p>
 
-<p>
+<div>
 <%= form_tag do %>
-  Act as user (email): <%= email_field_tag :sudo_email %>
+  Act as user (email):
+  <div class="input-field">
+    <input type="text" size="3" id="student_autocomplete" class="autocomplete" autocomplete="off"/>
+    <label for="student_autocomplete">Start typing student name or email</label>
+  </div><br>
+  <%= hidden_field_tag(:sudo_email)%>
   <%= submit_tag "Sudo", {:value=>"Sudo", :class=> "btn primary"} %>
 <% end %>
-</p>
+</div>

--- a/app/views/extensions/index.html.erb
+++ b/app/views/extensions/index.html.erb
@@ -6,7 +6,7 @@
     jQuery(function() {
       /* match user name/email with cud_id */
       userData = {
-        <% @usersEncoded.each do |k,v| %>
+        <% @users.each do |k,v| %>
           "<%= k %>": "<%= v %>",
         <% end %>
       };
@@ -24,7 +24,7 @@
 
       /* track changes in student autocomplete field */
       $studentAutocompleteField.on('change', function() {
-        $hiddenCUDField.val(userData[window.btoa($studentAutocompleteField.val())]);
+        $hiddenCUDField.val(userData[$studentAutocompleteField.val()]);
       })
 
       /* set up dates */

--- a/app/views/submissions/new.html.erb
+++ b/app/views/submissions/new.html.erb
@@ -9,7 +9,7 @@
 
       /* user autocomplete */
       $studentAutocompleteField = $('#student_autocomplete');
-      $hiddenCUDField = $('#extension_course_user_datum_id');
+      $hiddenCUDField = $('#submission_course_user_datum_id');
       $studentAutocompleteField.autocomplete({
         data: {
           <% @cuds.each do |k,v| %>


### PR DESCRIPTION
There are mutiple bugs regarding the autocompletion for students in the new submission site and the assessment extension site. This PR fixes them and adds autocompletion to the sudo site as well.

## Motivation and Context
There are multiple bugs due to code redundancies and base64 that breaks the encoded string after 60 characters which results in invalid javascript. I removed the base64 conversion entirely because its not necessary.

## How Has This Been Tested?
Autocompletion and submitting the form on the new submission, assessment extension and sudo site.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR

## Other issues / help required
This is not an optimal solution as we still have code redundancies. We should only write one autocompletion javascript file and import it wherever we need it.

