### PR TITLE
[BUGFIX] Fixed sql syntax error

### DIFF
--- a/app/controllers/announcements_controller.rb
+++ b/app/controllers/announcements_controller.rb
@@ -10,7 +10,7 @@ class AnnouncementsController < ApplicationController
   action_auth_level :index, :instructor
   def index
     @announcements = if @cud.user.administrator?
-                       Announcement.where("course_id=? or system", @course.id)
+                       Announcement.where("course_id=? or `system`", @course.id)
                      else
                        @course.announcements
                      end


### PR DESCRIPTION
There is a SQL error when querying all announcements.

## Description
"system" is a keyword an needs to be escaped.

## How Has This Been Tested?
Now you can see all announcements.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR