### PR TITLE
[BUGFIX] Disabled the submit button of a disabled assessment

### DIFF
--- a/app/views/assessments/show.html.erb
+++ b/app/views/assessments/show.html.erb
@@ -3,7 +3,7 @@
   <%= javascript_include_tag 'validateIntegrity.js' %>
   <script>
     function toggleAria(id) {
-      var expanded = document.getElementById(id).getAttribute("aria-expanded"); 
+      var expanded = document.getElementById(id).getAttribute("aria-expanded");
       if (expanded == "true") {
         expanded = "false"
       } else {
@@ -262,18 +262,21 @@
                 <% end %>
               </p>
 
-              <!-- Academic integrity checkbox -->
-              
-              <%= label_tag(:integrity_checkbox) do %>
-                <%= check_box_tag(:integrity_checkbox) %>
-                <%= content_tag("span", "I affirm that I have complied with this course's academic integrity policy as defined in the syllabus.") %>
+
+              <% if @can_submit %>
+
+                <!-- Academic integrity checkbox -->
+
+                <%= label_tag(:integrity_checkbox) do %>
+                  <%= check_box_tag(:integrity_checkbox) %>
+                  <%= content_tag("span", "I affirm that I have complied with this course's academic integrity policy as defined in the syllabus.") %>
+                <% end %>
+
+                <div class = "row" style = "margin-top: 10px !important">
+                  <input type="submit" class = "btn primary handin-btn" onclick = "setSubmitClicked()">
+                  <span id="submission_error" style = "margin-left: 10px !important; color: red"></span>
+                </div>
               <% end %>
-
-              <div class = "row" style = "margin-top: 10px !important">
-                <input type="submit" class = "btn primary handin-btn" onclick = "setSubmitClicked()">
-                <span id="submission_error" style = "margin-left: 10px !important; color: red"></span>
-              </div>
-
           <% end %>
           <hr>
         </div>


### PR DESCRIPTION
You can see the submit button of an embedded quiz even past the deadline.

## Motivation and Context
Submitting a embedded form after the deadline results in an error message.

## How Has This Been Tested?
The submit button is only visible if the assessment is open.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR
