### PR TITLE
Add Missing Config Copying for OS X instructions & Update Demo Creds

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # Welcome to the Autolab Docs
 
-##Rationale
+## Rationale
 
 Autolab is a course management platform that enables instructors to offer autograded programming assignments to their students. The two key ideas in Autolab are _autograding_–that is, programs evaluating other programs, and _scoreboards_ that display the latest autograded scores for each student.
 
@@ -14,7 +14,7 @@ For more of the rationale behind Autolab, please check out <a href="https://auto
 
 <!-- For information on how to use Autolab for your course see the [Guide for Instructors](/instructors). To learn how to write an autograded lab see the [Guide for Lab Authors](/lab). 
  -->
-##Components
+## Components
 
 Autolab consists of two services: (1) the Autolab frontend which is implemented using Ruby on Rails, and (2) Tango, the RESTful Python autograding server. <b>Either service can run independently without the other.</b> But in order to use all features of Autolab, we highly recommend installing both services.
 
@@ -26,18 +26,19 @@ As you can see on the left, the Autolab frontend receives handin files from the 
 
 Apart from client usage, both the Autolab frontend and Tango provide application programming interfaces (API) for developers. The specific guides are included in the [Reference](/reference) section.
 
-##Demonstration Website
-Installation instructions can be found in our comprehensive [installation guide](/installation/overview). However, if this is your first experience with Autolab, we encourage you to try out some key features on Autolab's <a href="https://nightly.autolabproject.com" target="_blank">Demo Site</a>. You can login through `Developer Login` with the email: `admin@foo.bar`. The demonstration website refreshes at 0,6,12,18 Hours (UTC) daily, and it is publicly accessible, so please only use it for your exploration. Do not use this site to store important information.
+## Demonstration Website
+Installation instructions can be found in our comprehensive [installation guide](/installation/overview). If this is your first experience with Autolab, we encourage you to try out some key features on Autolab's <a href="https://nightly.autolabproject.com" target="_blank">Demo Site</a>. Login with the following test credentials
 
+Email address: `admin@demo.bar`  
+Password: `adminfoobar`
 
-Try the following in order:
+The demonstration website refreshes daily and it is publicly accessible. Do not use the site to store important information.  
+After you have successfully logged in, try the user flow below 
 
-### Create a new course 
-Click on `Manage Autolab` (top-right navigation bar) > `Create New Course`. Fill in the name and semester, and then create to see your course on the homepage.
+### 1. Create a new course 
+Click on `Manage Autolab` (top-right navigation bar) > `Create New Course`. Fill in the name and semester, and then create to see your course on the homepage. (NOTE: the email doesn't need to be real here)
 
-(NOTE: the email doesn't need to be real here)
-
-### Create an Autograded Lab Assessment. 
+### 2. Create an Autograded Lab Assessment. 
 Go into the course you have just created, click on `Install Assessment`. You can install a simple autograded lab, called hello lab.
 [Download hello.tar](https://github.com/autolab/Autolab/raw/master/examples/hello.tar) and install it using the `Import from Tarball` option. 
 
@@ -60,7 +61,7 @@ In the `hello` lab, students are asked to write a file called `hello.c`. The aut
 
 For more information on `hello` lab, or how to create your own lab, go to [Guide for Lab Authors](/lab)! 
 
-### Create a PDF homework assessment
+### 3. Create a PDF homework assessment
 Autolab can also handle pdf submissions as well!
 
 Click on `Install Assessment`, then on `Assessment Builder`. Name your assessment, and give it a category and click `Create Assessment`!. 
@@ -72,5 +73,5 @@ Because it defaults to accepting `.c` files, we would like to change it to `*.pd
 1. Submit a `.pdf` file.
 2. Look at your submission using the magnifying glass icon
 
-### Grading submissions
+### 4. Grading submissions
 Click on `Grade Submissions`, and then the arrow button to open up student submissions. For details on the relevant features for an Instructor, go to [Guide for Instructors](/instructors).

--- a/docs/installation/osx.md
+++ b/docs/installation/osx.md
@@ -56,26 +56,22 @@ Follow the step-by-step instructions below:
     -   <a href="https://www.tutorialspoint.com/sqlite/sqlite_installation.htm" target="_blank">SQLite</a> should **only** be used in development
     -   <a href="https://dev.mysql.com/doc/refman/5.7/en/osx-installation-pkg.html" target="_blank">MySQL</a> can be used in development or production
 
-8.  Configure your database:
+8.  Initialize Autolab Configs
 
         :::bash
         cp config/database.yml.template config/database.yml
-
-    Edit `database.yml` with the correct credentials for your chosen database. Refer to [Troubleshooting](/installation/troubleshoot) for any issues.
-
-9.  Configure school/organization specific information (new feature):
-
-        :::bash
         cp config/school.yml.template config/school.yml
+        cp config/autogradeConfig.rb.template config/autogradeConfig.rb
 
     Edit `school.yml` with your school/organization specific names and emails
+    Edit `database.yml` with the correct credentials for your chosen database. Refer to [Troubleshooting](/installation/troubleshoot) for any issues and suggested development [configurations](/installation/troubleshoot/#suggested-development-configuration-for-configdatabaseyml).
 
-10. Initialize application secrets.
+9. Initialize application secrets.
 
         :::bash
         ./bin/initialize_secrets.sh
 
-11. Create and initialize the database tables:
+10. Create and initialize the database tables:
 
         :::bash
         bundle exec rails db:create
@@ -83,7 +79,7 @@ Follow the step-by-step instructions below:
 
     Do not forget to use `bundle exec` in front of every rake/rails command.
 
-12. Create initial root user, pass the `-d` flag for developmental deployments:
+11. Create initial root user, pass the `-d` flag for developmental deployments:
 
         :::bash
         # For production:
@@ -92,23 +88,23 @@ Follow the step-by-step instructions below:
         # For development:
         ./bin/initialize_user.sh -d
 
-13. Populate dummy data (for development only):
+12. Populate dummy data (for development only):
 
         :::bash
         bundle exec rails autolab:populate
 
-14. Start the rails server:
+13. Start the rails server:
 
         :::bash
         bundle exec rails s -p 3000
 
-15. Go to localhost:3000 and login with either the credentials of the root user you just created, or choose `Developer Login` with:
+14. Go to localhost:3000 and login with either the credentials of the root user you just created, or choose `Developer Login` with:
 
         :::bash
         Email: "admin@foo.bar".
 
-16. Install [Tango](/installation/tango), the backend autograding service.
+15. Install [Tango](/installation/tango), the backend autograding service.
 
-17. If you would like to configure Github integration to allow students to submit via Github, please follow the [Github integration setup instructions](/installation/github_integration).
+16. If you would like to configure Github integration to allow students to submit via Github, please follow the [Github integration setup instructions](/installation/github_integration).
 
-18. Now you are all set to start using Autolab! Visit the [Guide for Instructors](/instructors) and [Guide for Lab Authors](/lab) pages for more info.
+17. Now you are all set to start using Autolab! Visit the [Guide for Instructors](/instructors) and [Guide for Lab Authors](/lab) pages for more info.

--- a/docs/installation/troubleshoot.md
+++ b/docs/installation/troubleshoot.md
@@ -87,3 +87,47 @@ this may be an issue with using an incompatible version of MySQL. Try switching 
 
 #### Undefined method 'devise' for User
 You most likely missed the step of copying 'config/initializers/devise.rb.template' to 'config/initializers/devise.rb' and setting your secret key in the setup instructions.
+
+#### Suggested Development Configuration for config/database.yml
+
+**MySQL**  
+Change the <username> and <password> fields in config/database.yml to the username and password that has been set up for the mysql. For example if your username is `user1`, and your password is `123456`, then your yml would be
+
+    :::yml
+    development:
+        adapter: mysql2
+        database: autolab_development
+        pool: 5
+        username: user1
+        password: '123456'
+        socket: /var/run/mysqld/mysqld.sock
+        host: localhost
+        variables:
+            sql_mode: NO_ENGINE_SUBSTITUTION
+
+    test:
+        adapter: mysql2
+        database: autolab_test
+        pool: 5
+        username: user1
+        password: '123456'
+        socket: /var/run/mysqld/mysqld.sock
+        host: localhost
+        variables:
+            sql_mode: NO_ENGINE_SUBSTITUTION
+
+**SQLite**  
+Comment out the configurations meant for MySQL in config/database.yml, and insert the following
+
+    :::yml
+    development:
+        adapter: sqlite3
+        database: db/autolab_development
+        pool: 5
+        timeout: 5000
+
+    test:
+        adapter: sqlite3
+        database: db/autolab_test
+        pool: 5
+        timeout: 5000


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

- Adds the missing step of copying autogradeConfig.rb
- At the same time, added the suggested configuration of database.yml for testing to troubleshooting.
- Also updated the nightly demo-site testing credentials

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Went through OS X installation instructions, found missing step.
At the same time, email chain with one of our users let us realize that our current docs testing instruction of developer login is no longer valid.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [x] I have updated the documentation accordingly, included in this PR

## Other issues / help required
<!--- Do you have any other relevant issues / questions? --->
<!--- For example, if you require assistance for a certain part of your PR --->
<!--- or are facing specific issues while creating the pull request that you would like to highlight --->

If unsure, feel free to submit first and we'll help you along.
