### PR TITLE
Duplicated confirm button at top roster upload confirmation screen

### DIFF
--- a/app/assets/stylesheets/style.css.scss
+++ b/app/assets/stylesheets/style.css.scss
@@ -651,6 +651,10 @@ div.field_with_errors {
   display: none;
 }
 
+#sorted_cuds, #unsorted_cuds {
+  margin-top: 10px;
+}
+
 /* TABLE STYLES.  Styles for the multiple tables that we have for some reason */
 /* Pretty Border Tables. I vote we make this the generic table style. */
 table.prettyBorder,

--- a/app/views/courses/upload_roster.html.erb
+++ b/app/views/courses/upload_roster.html.erb
@@ -14,10 +14,12 @@
     </div>
   </div>
   <%= form_for :doIt, :url=>{:action=>"upload_roster",:doIt=>"true"} do |f| %>
+    <%= f.submit "Confirm", {:class => "btn primary"} %>
+    <br>
     <%= render partial: 'uploadTable', locals: {cud_view:@cuds, sort_status:"unsorted_cuds"} %>
     <%= render partial: 'uploadTable', locals: {cud_view:@sorted_cuds, sort_status:"sorted_cuds"} %>
-  <br>
-  <%= f.submit "Confirm", {:class => "btn primary"} %>
+    <br>
+    <%= f.submit "Confirm", {:class => "btn primary"} %>
 	<% end %>
 <% else %>
 <p>


### PR DESCRIPTION
## Description
Added a second "Confirm" button at the top of the student table on the roster upload confirmation screen.
![Screen Shot 2022-02-22 at 11 46 26 PM](https://user-images.githubusercontent.com/50491000/155263234-6087c906-5ce2-4832-ab5c-e760d46b8004.jpg)

## Motivation and Context
Suggested by Iliano so that professors don't need to scroll all the way to the bottom of the screen for large classes.

## How Has This Been Tested?
Clicked the new button to check that 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR

