### PR TITLE
Handle empty course rosters

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -650,7 +650,7 @@ private
       flash[:error] = "Error parsing CSV file: #{e}"
       redirect_to(action: "upload_roster") && return
     rescue StandardError => e
-      flash[:error] = "Error uploading the CSV file!: #{e}#{e.backtrace.join('<br>')}"
+      flash[:error] = "Error uploading the CSV file: #{e}"
       redirect_to(action: "upload_roster") && return
       raise e
     end
@@ -709,6 +709,7 @@ private
   # map[10]: section
   # rubocop:disable Lint/UselessAssignment
   def detect_and_convert_roster(roster)
+    raise "Roster is empty" if roster.empty?
     parsedRoster = CSV.parse(roster, skip_blanks: true)
     raise "Roster cannot be recognized" if parsedRoster[0][0].nil?
 

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -710,6 +710,7 @@ private
   # rubocop:disable Lint/UselessAssignment
   def detect_and_convert_roster(roster)
     raise "Roster is empty" if roster.empty?
+
     parsedRoster = CSV.parse(roster, skip_blanks: true)
     raise "Roster cannot be recognized" if parsedRoster[0][0].nil?
 


### PR DESCRIPTION
## Description
Removed backtrace for error flash in `parse_roster_csv`.

Additionally check that CSV contents are nonempty before attempting to parse. If empty, return the error message `Roster is empty`.

## Motivation and Context
Previously, uploading a blank roster would lead to a `CookieOverflow` error. This was because the original error handling code would flash the entire backtrace, exceeding the cookie size limit.

In addition, it was not checked that roster was nonempty before attempting to parse it. In that scenario, `CSV.parse` returns a `[]`, leading to a bad array access when accessing `parsedRoster[0][0]` on the next line.

Fixes #1479 

## How Has This Been Tested?
Uploading a blank roster now results in the error message `Error uploading the CSV file! Roster is empty` as desired.

Uploading a well-formed roster still works as intended.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR

## Other issues / help required
<!--- Do you have any other relevant issues / questions? --->
<!--- For example, if you require assistance for a certain part of your PR --->
<!--- or are facing specific issues while creating the pull request that you would like to highlight --->

If unsure, feel free to submit first and we'll help you along.
