### PR TITLE
Fast Version Switching (Beta)

### DIFF
--- a/app/assets/stylesheets/annotations.css
+++ b/app/assets/stylesheets/annotations.css
@@ -11,6 +11,18 @@
   max-height: calc(100vh - 173px);
 }
 
+.submission-controls select {
+  height: 2rem;
+  display: inline-block;
+  width: 50px;
+}
+
+.submission-controls .btn {
+  height: 2rem;
+  display: inline-flex;
+  align-items: center;
+}
+
 #code-loader {
   height: 50vh;
   display: flex;

--- a/app/assets/stylesheets/style.css.scss
+++ b/app/assets/stylesheets/style.css.scss
@@ -49,6 +49,10 @@ a {
 
 /* Helper Styles */
 
+.clickable {
+  cursor: pointer;
+}
+
 .full-width {
   width: 100%;
 }

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -472,10 +472,25 @@ class SubmissionsController < ApplicationController
     @curSubmissionIndex = @latestSubmissions.index do |submission|
       submission.course_user_datum.user.email == @submission.course_user_datum.user.email
     end
-    @prevSubmission = @curSubmissionIndex > 0 ? @latestSubmissions[@curSubmissionIndex - 1] : nil
+    @prevSubmission = if @curSubmissionIndex > 0
+                        @latestSubmissions[@curSubmissionIndex - 1]
+                      end
     @nextSubmission = if @curSubmissionIndex < (@latestSubmissions.size - 1)
                         @latestSubmissions[@curSubmissionIndex + 1]
                       end
+
+    @userVersions = @assessment.submissions
+                               .where(course_user_datum_id: @submission.course_user_datum_id)
+                               .order("version DESC")
+    @curVersionIndex = @userVersions.index do |submission|
+      submission.version == @submission.version
+    end
+    @prevVersion = if @curVersionIndex < (@userVersions.size - 1)
+                     @userVersions[@curVersionIndex + 1]
+                   end
+    @nextVersion = if @curVersionIndex > 0
+                     @userVersions[@curVersionIndex - 1]
+                   end
 
     # Adding allowing scores to be assessed by the view
     @scores = Score.where(submission_id: @submission.id)

--- a/app/views/assessments/history.html.erb
+++ b/app/views/assessments/history.html.erb
@@ -1,6 +1,6 @@
 <% @title = "Handin History" %>
 <% if @partial then %>
-  <a onclick="hideStudent()">Exit</a>
+  <a class="clickable" onclick="hideStudent()">Exit</a>
 <% end %>
 <% download_access = (@cud.instructor?) %>
 
@@ -45,7 +45,7 @@
 <%= render partial: "submission_history_table", locals: {download_access: download_access} %>
 
 <% if @partial then %>
-  <a onclick="hideStudent()">Exit</a>
+  <a class="clickable" onclick="hideStudent()">Exit</a>
 <% end %>
 <p>
 <%= "Page loaded in " + (Time.now() - @startTime).to_s + " seconds" %>

--- a/app/views/submissions/view.html.erb
+++ b/app/views/submissions/view.html.erb
@@ -70,9 +70,18 @@
          <link rel="prerender" href= <%= url_for([:view, @course, @assessment, @prevSubmission])%> />
       <% end %>
     </div>
-    <div class="col s8 center-align valign-wrapper">
+    <div class="col s8 center-align valign-wrapper submission-controls">
       <div style="display: inline-block">
-      <%= @submission.course_user_datum.email %> (v<%= @submission.version %>) [<%= @curSubmissionIndex+1 %>/<%= @latestSubmissions.length %>]</div>
+      <%= @submission.course_user_datum.email %> [<%= @curSubmissionIndex+1 %>/<%= @latestSubmissions.length %>]</div>
+      <strong>version:</strong>
+      <select class="browser-default" onchange="location = this.value">
+        <% for submission in @userVersions do %>
+          <option <% if @submission.version == submission.version %> selected <% end %> value=<%= url_for([:view, @course, @assessment, submission]) %>>
+            <%= submission.version %>
+          </option>
+        <% end %>
+      </select>
+      <strong>/<%= @userVersions.length %></strong>
       <a href="<%= download_file_url(@submission) %>" class="btn small" title="Download" >Download</a>
       <button class="btn small" onclick="resetLayout()">Reset Layout</button>
     </div>


### PR DESCRIPTION
When viewing a student's submission, a user can now easily switch between different versions of the submission via the use of a dropdown menu.

(Lite version of #1503)

## Description
- On submission view page, include a dropdown that lists the versions of a student's submission
- Added styling to make existing buttons shorter
- Nit: Added new `clickable` class, used for "Exit" button of handin history

## Motivation and Context
When investigating academic integrity violations, instructors often need to track changes over the various submission versions. Currently, there is no easy way to switch between these different versions.

## How Has This Been Tested?
Clicking a particular version on the dropdown switches to the correct version as expected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR

## Other issues / help required
<!--- Do you have any other relevant issues / questions? --->
<!--- For example, if you require assistance for a certain part of your PR --->
<!--- or are facing specific issues while creating the pull request that you would like to highlight --->

If unsure, feel free to submit first and we'll help you along.
