### PR TITLE
Pre-expanded Admin Course menu

### DIFF
--- a/app/views/courses/manage.html.erb
+++ b/app/views/courses/manage.html.erb
@@ -17,7 +17,7 @@
 <div class="row">
   <div class="col s12 m4">
     <ul class="collapsible" data-collapsible="accordion">
-      <li class="collapsible-menu-link">
+      <li class="collapsible-menu-link active">
         <div class="collapsible-header active"><h5>Admin Course</h5></div>
         <div class="collapsible-body">
           <ul class="options">


### PR DESCRIPTION
As per title, under "Manage Course", have the "Admin Course" dropdown menu pre-expanded.

## Description
Add active tag to the corresponding `li` element.

## Motivation and Context
For instructors, the "Admin Course" dropdown menu is the only menu on that page. It is convenient to have it pre-expanded.

## How Has This Been Tested?
Dropdown menu is pre-expanded as expected.
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR

## Other issues / help required
<!--- Do you have any other relevant issues / questions? --->
<!--- For example, if you require assistance for a certain part of your PR --->
<!--- or are facing specific issues while creating the pull request that you would like to highlight --->

If unsure, feel free to submit first and we'll help you along.
