### PR TITLE
Consistent annotation among group submissions

### DIFF
--- a/app/controllers/annotations_controller.rb
+++ b/app/controllers/annotations_controller.rb
@@ -29,12 +29,18 @@ class AnnotationsController < ApplicationController
       respond_with(@course, @assessment, @submission, primary_annotation)
     end
 
-    # All submissions of the iteration in the group, excluding the current one
-    group_submissions = @submission.group_associated_submissions
-
     # Set shared comment to false to avoid duplicates in shared comment pool
     tweaked_params = annotation_params
     tweaked_params[:shared_comment] = false
+
+    # All submissions of the iteration in the group, excluding the current one
+    group_submissions = @submission.group_associated_submissions
+
+    # Set up annotation group key
+    submission_group_key = @submission.group_key
+    annotation_group_key = "#{submission_group_key} + #{tweaked_params[:problem_id]}"
+    annotation_group_key += Time.current.utc.to_s(:number)
+    tweaked_params[:group_key] = annotation_group_key
 
     annotations = [primary_annotation]
 

--- a/app/controllers/annotations_controller.rb
+++ b/app/controllers/annotations_controller.rb
@@ -46,7 +46,7 @@ class AnnotationsController < ApplicationController
       annotations = [primary_annotation]
 
       group_submissions.each do |group_submission|
-        group_annotations.append(group_submission.annotations.new(tweaked_params))
+        annotations.append(group_submission.annotations.new(tweaked_params))
       end
 
       ActiveRecord::Base.transaction do
@@ -63,7 +63,7 @@ class AnnotationsController < ApplicationController
   # PUT /:course/annotations/1.json
   action_auth_level :update, :course_assistant
   def update
-    if annotation.group_key.empty?
+    if @annotation.group_key.empty?
       ActiveRecord::Base.transaction do
         @annotation.update(annotation_params)
         @annotation.update_non_autograded_score
@@ -72,8 +72,12 @@ class AnnotationsController < ApplicationController
       annotations = @annotation.group_associated_annotations
 
       # Set shared comment to false to avoid duplicate shared comments
+      # Delete submission_id and filename to avoid association with the
+      # wrong submission
       tweaked_params = annotation_params
       tweaked_params[:shared_comment] = false
+      tweaked_params.delete(:submission_id)
+      tweaked_params.delete(:filename)
 
       ActiveRecord::Base.transaction do
         # Update "primary" annotation with native parameters

--- a/app/controllers/annotations_controller.rb
+++ b/app/controllers/annotations_controller.rb
@@ -26,44 +26,66 @@ class AnnotationsController < ApplicationController
         primary_annotation.save
         primary_annotation.update_non_autograded_score
       end
-      respond_with(@course, @assessment, @submission, primary_annotation)
-    end
+    else
+      # Set up annotation group key = submission group key + problem id + timestamp
+      tweaked_params = annotation_params
+      submission_group_key = @submission.group_key
+      annotation_group_key = "#{submission_group_key}_#{tweaked_params[:problem_id]}_"
+      annotation_group_key += Time.current.utc.to_s(:number)
 
-    # Set shared comment to false to avoid duplicates in shared comment pool
-    tweaked_params = annotation_params
-    tweaked_params[:shared_comment] = false
+      # Set "primary" annotation's group key
+      primary_annotation.group_key = annotation_group_key
 
-    # All submissions of the iteration in the group, excluding the current one
-    group_submissions = @submission.group_associated_submissions
+      # Set shared comment to false to avoid duplicates in shared comment pool
+      tweaked_params[:shared_comment] = false
+      tweaked_params[:group_key] = annotation_group_key
 
-    # Set up annotation group key
-    submission_group_key = @submission.group_key
-    annotation_group_key = "#{submission_group_key} + #{tweaked_params[:problem_id]}"
-    annotation_group_key += Time.current.utc.to_s(:number)
-    tweaked_params[:group_key] = annotation_group_key
+      # All submissions of the iteration in the group, excluding the current one
+      group_submissions = @submission.group_associated_submissions
 
-    annotations = [primary_annotation]
+      annotations = [primary_annotation]
 
-    group_submissions.each do |group_submission|
-      group_annotations.append(group_submission.annotations.new(tweaked_params))
-    end
+      group_submissions.each do |group_submission|
+        group_annotations.append(group_submission.annotations.new(tweaked_params))
+      end
 
-    ActiveRecord::Base.transaction do
-      annotations.each do |annotation|
-        annotation.save
-        annotation.update_non_autograded_score
+      ActiveRecord::Base.transaction do
+        annotations.each do |annotation|
+          annotation.save
+          annotation.update_non_autograded_score
+        end
       end
     end
 
-    respond_with(@course, @assessment, @submission, annotations)
+    respond_with(@course, @assessment, @submission, primary_annotation)
   end
 
   # PUT /:course/annotations/1.json
   action_auth_level :update, :course_assistant
   def update
-    ActiveRecord::Base.transaction do
-      @annotation.update(annotation_params)
-      @annotation.update_non_autograded_score
+    if annotation.group_key.empty?
+      ActiveRecord::Base.transaction do
+        @annotation.update(annotation_params)
+        @annotation.update_non_autograded_score
+      end
+    else
+      annotations = @annotation.group_associated_annotations
+
+      # Set shared comment to false to avoid duplicate shared comments
+      tweaked_params = annotation_params
+      tweaked_params[:shared_comment] = false
+
+      ActiveRecord::Base.transaction do
+        # Update "primary" annotation with native parameters
+        @annotation.update(annotation_params)
+        @annotation.update_non_autograded_score
+
+        # Update group annotations with tweaked parameters
+        annotations.each do |annotation|
+          annotation.update(tweaked_params)
+          annotation.update_non_autograded_score
+        end
+      end
     end
 
     respond_with(@course, @assessment, @submission, @annotation) do |format|
@@ -74,9 +96,22 @@ class AnnotationsController < ApplicationController
   # DELETE /:course/annotations/1.json
   action_auth_level :destroy, :course_assistant
   def destroy
-    ActiveRecord::Base.transaction do
-      @annotation.destroy
-      @annotation.update_non_autograded_score
+    if @annotation.group_key.empty?
+      ActiveRecord::Base.transaction do
+        @annotation.destroy
+        @annotation.update_non_autograded_score
+      end
+    else
+      annotations = @annotation.group_associated_annotations
+      ActiveRecord::Base.transaction do
+        @annotation.destroy
+        @annotation.update_non_autograded_score
+
+        annotations.each do |annotation|
+          annotation.destroy
+          annotation.update_non_autograded_score
+        end
+      end
     end
 
     head :no_content

--- a/app/helpers/assessment_handin_core.rb
+++ b/app/helpers/assessment_handin_core.rb
@@ -90,11 +90,17 @@ module AssessmentHandinCore
     end
 
     submissions = []
+
+    # group_key = group_name_submitter_email_handin_filename_timestamp
+    group_key = "#{group.name}_#{@cud.user.email}_#{@assessment.handin_filename}_"
+    group_key += Time.current.utc.to_s(:number)
+
     ActiveRecord::Base.transaction do
       group.course_user_data.each do |cud|
         submission = @assessment.submissions.create(course_user_datum_id: cud.id,
                                                     submitter_ip: request.remote_ip,
-                                                    submitted_by_app_id: app_id)
+                                                    submitted_by_app_id: app_id,
+                                                    group_key: group_key)
         submission.save_file(sub)
         submissions << submission
       end

--- a/app/models/annotation.rb
+++ b/app/models/annotation.rb
@@ -55,4 +55,12 @@ class Annotation < ApplicationRecord
     # Update score
     score.update!(score: new_score)
   end
+
+  # This only applies when an annotation is for a group submission
+  # Returns all annotations shared across one iteration of group submissions
+  def group_associated_annotations
+    raise "Annotation is not for a group submission!" if group_key.empty?
+
+    Annotation.where(group_key: group_key).where.not(id: id)
+  end
 end

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -389,6 +389,12 @@ class Submission < ApplicationRecord
     assessment.aud_for course_user_datum_id
   end
 
+  def group_associated_submissions
+    raise "Submission is not associated with a group" if group_key.empty?
+
+    Submission.where(group_key: group_key)
+  end
+
 private
 
   # NOTE: remember to update cache_key if additional options are added

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -392,7 +392,7 @@ class Submission < ApplicationRecord
   def group_associated_submissions
     raise "Submission is not associated with a group" if group_key.empty?
 
-    Submission.where(group_key: group_key)
+    Submission.where(group_key: group_key).where.not(id: id)
   end
 
 private

--- a/db/migrate/20220424202745_add_group_key_to_submissions.rb
+++ b/db/migrate/20220424202745_add_group_key_to_submissions.rb
@@ -1,0 +1,11 @@
+class AddGroupKeyToSubmissions < ActiveRecord::Migration[6.0]
+  def up
+    add_column :submissions, :group_key, :string, default: ""
+    add_column :annotations, :group_key, :string, default: ""
+  end
+
+  def down
+    remove_column :submissions, :group_key
+    remove_column :annotations, :group_key
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_04_17_023837) do
+ActiveRecord::Schema.define(version: 2022_04_24_202745) do
 
   create_table "annotations", force: :cascade do |t|
     t.integer "submission_id"
@@ -25,6 +25,7 @@ ActiveRecord::Schema.define(version: 2022_04_17_023837) do
     t.integer "problem_id"
     t.string "coordinate"
     t.boolean "shared_comment", default: false
+    t.string "group_key", default: ""
   end
 
   create_table "announcements", force: :cascade do |t|
@@ -320,6 +321,7 @@ ActiveRecord::Schema.define(version: 2022_04_17_023837) do
     t.text "settings"
     t.text "embedded_quiz_form_answer"
     t.integer "submitted_by_app_id"
+    t.string "group_key", default: ""
     t.index ["assessment_id"], name: "index_submissions_on_assessment_id"
     t.index ["course_user_datum_id"], name: "index_submissions_on_course_user_datum_id"
   end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR ensures annotations are consistent among group members' submissions of the same iteration.

## Motivation and Context
This is in the interest of polishing the group feature of Autolab.

## How Has This Been Tested?
1. Create a group of >= 2.
2. Act as one of the members and hand in a file.
3. Reset user and annotate one of the members' submission. Toggle among the members' submissions and see that the same annotation shows up. (You might want to refresh again if there doesn't appear to be a change due to the latency of database.)
4. Edit this annotation, and see that the change is reflected across members.
5. Delete this annotation and see that it's been deleted for all members.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR

## Other issues / help required
<!--- Do you have any other relevant issues / questions? --->
<!--- For example, if you require assistance for a certain part of your PR --->
<!--- or are facing specific issues while creating the pull request that you would like to highlight --->

If unsure, feel free to submit first and we'll help you along.
