### PR TITLE
Make releaseAllGrades, withdrawAllGrades, etc. POST to prevent CSRF attacks

### DIFF
--- a/app/assets/stylesheets/style.css.scss
+++ b/app/assets/stylesheets/style.css.scss
@@ -1078,6 +1078,20 @@ form p:last-child {
   padding-left: 14px;
 }
 
+.danger-side input {
+  background: none;
+  border: none;
+  padding-left: 14px;
+  text-decoration: none;
+  color: #0882af;
+  font-family: "Source Sans Pro", sans-serif;
+  font-weight: 300;
+  font-size: 16px;
+  text-align: left;
+  width: 100%;
+  cursor: pointer;
+}
+
 /* Form Tables */
 
 .verticalTable tr {

--- a/app/controllers/assessments_controller.rb
+++ b/app/controllers/assessments_controller.rb
@@ -64,6 +64,8 @@ class AssessmentsController < ApplicationController
   action_auth_level :set_repo, :instructor
   action_auth_level :import_svn, :instructor
 
+  protect_from_forgery with: :exception
+
   def index
     @is_instructor = @cud.has_auth_level? :instructor
     announcements_tmp = Announcement.where("start_date < :now AND end_date > :now",
@@ -649,7 +651,6 @@ class AssessmentsController < ApplicationController
 
   action_auth_level :releaseAllGrades, :instructor
 
-  protect_from_forgery
   def releaseAllGrades
     # release all grades
     num_released = releaseMatchingGrades { |_| true }
@@ -667,7 +668,6 @@ class AssessmentsController < ApplicationController
 
   action_auth_level :releaseSectionGrades, :course_assistant
 
-  protect_from_forgery
   def releaseSectionGrades
     unless @cud.section? && !@cud.section.empty? && @cud.lecture && !@cud.lecture.empty?
       flash[:error] =
@@ -696,7 +696,6 @@ class AssessmentsController < ApplicationController
 
   action_auth_level :withdrawAllGrades, :instructor
 
-  protect_from_forgery
   def withdrawAllGrades
     @assessment.submissions.each do |submission|
       scores = submission.scores.where(released: true)

--- a/app/controllers/assessments_controller.rb
+++ b/app/controllers/assessments_controller.rb
@@ -649,6 +649,7 @@ class AssessmentsController < ApplicationController
 
   action_auth_level :releaseAllGrades, :instructor
 
+  protect_from_forgery
   def releaseAllGrades
     # release all grades
     num_released = releaseMatchingGrades { |_| true }
@@ -666,6 +667,7 @@ class AssessmentsController < ApplicationController
 
   action_auth_level :releaseSectionGrades, :course_assistant
 
+  protect_from_forgery
   def releaseSectionGrades
     unless @cud.section? && !@cud.section.empty? && @cud.lecture && !@cud.lecture.empty?
       flash[:error] =
@@ -694,6 +696,7 @@ class AssessmentsController < ApplicationController
 
   action_auth_level :withdrawAllGrades, :instructor
 
+  protect_from_forgery
   def withdrawAllGrades
     @assessment.submissions.each do |submission|
       scores = submission.scores.where(released: true)

--- a/app/views/assessments/show.html.erb
+++ b/app/views/assessments/show.html.erb
@@ -45,7 +45,7 @@
 <div class="row">
   <div class="col s12 m4">
 
-    <%# Display any optional instructor admin options %>
+    <%# Display any optional instructor admin options #%>
     <% if @cud.instructor? then %>
       <ul class="collapsible" data-collapsible="accordion">
         <li class="collapsible-menu-link active" id="admin-options" aria-role="button" aria-expanded="true" onclick="toggleAria('admin-options')" onkeydown="toggleAria('admin-options')">
@@ -76,9 +76,13 @@
               <li class="collection-item red-text danger-bottom no-hover"><h4>Danger Zone</h4></li>
 
               <li class="danger-side">
-                <%= link_to "Release all grades", {:action => "releaseAllGrades" }, {:title=>  "Make all scores for this assessment visible to students", :class=>"", data: {confirm: "Are you sure you want to release all grades?"}} %>
-                </li>
-              <li class="danger-side"> <%= link_to "Withdraw all grades", {:action => "withdrawAllGrades" }, {:title=>  "Hide all scores for this assessment from students", data: {confirm: "Are you sure you want to withdraw all grades?"}} %></li>
+                <%= button_to "Release all grades", { :action => "releaseAllGrades" }, { :title=> "Make all scores for this assessment visible to students", data: {confirm: "Are you sure you want to release all grades?"}} %>
+              </li>
+              <li class="danger-side">
+
+                <%= button_to "Withdraw all grades", { :action => "withdrawAllGrades" }, {:title=> "Hide all scores for this assessment from students", data: {confirm: "Are you sure you want to withdraw all grades?"}} %>
+              
+              </li>
               <li class="danger-side danger-bottom"> <%= link_to "Reload config file", {:action => "reload" }, {:title=> "Reload the assessment config file (provided for backward compatibility with legacy assessments)", data: {confirm: "Are you sure you want to reload the config file?"}} %></li>
             </ul>
           </div>
@@ -104,9 +108,11 @@
               <li class="collection-item red-text danger-bottom no-hover"><h4>Danger Zone</h4></li>
               <li class="danger-side"><%= link_to "Reload config file", url_for(:action => 'reload'),
                 :title=> "Reload the assessment configuration file (provided for backward compatibility with legacy assessments)", data: {confirm: "Are you sure you want to reload the config file?"} %></li>
-              <li class="danger-side danger-bottom"><%= link_to "Release section grades", url_for(:action => 'releaseSectionGrades'),
-                :title=> "Make all scores visible to the students in your section. This will work only if your instructor has assigned you to a lecture and section in your Autolab account.", data: {confirm: "Are you sure you want to release section grades?"} %></li>
+              <li class="danger-side danger-bottom">
 
+                <%= button_to "Release section grades", { :action => "releaseSectionGrades" }, { :title=> "Make all scores visible to the students in your section. This will work only if your instructor has assigned you to a lecture and section in your Autolab account.", data: {confirm: "Are you sure you want to release section grades?"}} %>
+
+              </li>
 
             </ul>
           </div>

--- a/app/views/assessments/show.html.erb
+++ b/app/views/assessments/show.html.erb
@@ -45,7 +45,7 @@
 <div class="row">
   <div class="col s12 m4">
 
-    <%# Display any optional instructor admin options #%>
+    <%# Display any optional instructor admin options %>
     <% if @cud.instructor? then %>
       <ul class="collapsible" data-collapsible="accordion">
         <li class="collapsible-menu-link active" id="admin-options" aria-role="button" aria-expanded="true" onclick="toggleAria('admin-options')" onkeydown="toggleAria('admin-options')">
@@ -79,9 +79,7 @@
                 <%= button_to "Release all grades", { :action => "releaseAllGrades" }, { :title=> "Make all scores for this assessment visible to students", data: {confirm: "Are you sure you want to release all grades?"}} %>
               </li>
               <li class="danger-side">
-
                 <%= button_to "Withdraw all grades", { :action => "withdrawAllGrades" }, {:title=> "Hide all scores for this assessment from students", data: {confirm: "Are you sure you want to withdraw all grades?"}} %>
-              
               </li>
               <li class="danger-side danger-bottom"> <%= link_to "Reload config file", {:action => "reload" }, {:title=> "Reload the assessment config file (provided for backward compatibility with legacy assessments)", data: {confirm: "Are you sure you want to reload the config file?"}} %></li>
             </ul>
@@ -109,11 +107,8 @@
               <li class="danger-side"><%= link_to "Reload config file", url_for(:action => 'reload'),
                 :title=> "Reload the assessment configuration file (provided for backward compatibility with legacy assessments)", data: {confirm: "Are you sure you want to reload the config file?"} %></li>
               <li class="danger-side danger-bottom">
-
                 <%= button_to "Release section grades", { :action => "releaseSectionGrades" }, { :title=> "Make all scores visible to the students in your section. This will work only if your instructor has assigned you to a lecture and section in your Autolab account.", data: {confirm: "Are you sure you want to release section grades?"}} %>
-
               </li>
-
             </ul>
           </div>
         </li>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -140,12 +140,12 @@ Rails.application.routes.draw do
         match "bulkGrade", via: [:get, :post]
         post "bulkGrade_complete"
         get "bulkExport"
-        get "releaseAllGrades"
-        get "releaseSectionGrades"
+        post "releaseAllGrades"
+        post "releaseSectionGrades"
         get "viewFeedback"
         get "reload"
         get "statistics"
-        get "withdrawAllGrades"
+        post "withdrawAllGrades"
         get "export"
         patch "edit/*active_tab", action: :update
         get "edit/*active_tab", action: :edit


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR aims to fix the CSRF vulnerability for 'releaseAllGrades' along with other vulnerable endpoints that previously used GET requests instead of POST.

Thanks to Damien and Fan Pu for the discussion about the security flaw and the useful article here about CSRF and rails:
https://guides.rubyonrails.org/security.html#csrf-countermeasures

## Description
- change releaseAllGrades, withdrawAllGrades, and releaseSectionGrades in the
assessment page to be POST requests, from GET requests.
- turn link_to in the frontend for these actions to be forms with button_to
- changed styling of input classes for danger-zone to look like links, to match
the style of the other actions on the page

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

We were sent this issue by huntr.dev, where a contributor pointed out this flaw.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested mainly through local host, seeing if we can directly access `http://localhost:3000/courses/AutoPopulated/assessments/homework0/releaseAllGrades` from the browser, which should no longer work (should get an error saying there doesn't exist a GET request with that endpoint).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR

## Other issues / help required
<!--- Do you have any other relevant issues / questions? --->
<!--- For example, if you require assistance for a certain part of your PR --->
<!--- or are facing specific issues while creating the pull request that you would like to highlight --->
@damianhxy 
