### PR TITLE
Bind new submission CUD to correct field

### DIFF
--- a/app/views/submissions/new.html.erb
+++ b/app/views/submissions/new.html.erb
@@ -9,7 +9,7 @@
 
       /* user autocomplete */
       $studentAutocompleteField = $('#student_autocomplete');
-      $hiddenCUDField = $('#extension_course_user_datum_id');
+      $hiddenCUDField = $('#submission_course_user_datum_id');
       $studentAutocompleteField.autocomplete({
         data: {
           <% @cuds.each do |k,v| %>


### PR DESCRIPTION
Reapplying #883 to `master`.
Has been fixed on [autolab-dev](https://github.com/cg2v/Autolab/commit/aebf76654eb96bfde4bc17243ee70f82b7928c07)

## Description
Fix selector for `hiddenCUDField` on create submission page.

## Motivation and Context
Bind the CUD id to the correct form element in Submissions#new, so it is
sent to the server on submit. Otherwise no CUD would be sent and no
submission could be created.

## How Has This Been Tested?
Go to an assignment > manage submissions > create new submission. Now, it should be possible to create a submission. (Previously, a submission would not be created)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR

## Other issues / help required