### PR TITLE
Hide unreleased attachments

### DIFF
--- a/app/controllers/assessments_controller.rb
+++ b/app/controllers/assessments_controller.rb
@@ -451,9 +451,9 @@ class AssessmentsController < ApplicationController
                       @cud
                     end
     @attachments = if @cud.instructor?
-                     @course.attachments
+                     @assessment.attachments
                    else
-                     @course.attachments.where(released: true)
+                     @assessment.attachments.where(released: true)
                    end
     @submissions = @assessment.submissions.where(course_user_datum_id: @effectiveCud.id)
                               .order("version DESC")

--- a/app/controllers/assessments_controller.rb
+++ b/app/controllers/assessments_controller.rb
@@ -450,6 +450,11 @@ class AssessmentsController < ApplicationController
                     else
                       @cud
                     end
+    @attachments = if @cud.instructor?
+                     @course.attachments
+                   else
+                     @course.attachments.where(released: true)
+                   end
     @submissions = @assessment.submissions.where(course_user_datum_id: @effectiveCud.id)
                               .order("version DESC")
     @extension = @assessment.extensions.find_by(course_user_datum_id: @effectiveCud.id)

--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -44,9 +44,15 @@ class AttachmentsController < ApplicationController
       flash[:error] = "Error loading #{@attachment.name} from #{@attachment.filename}"
       redirect_to([@course, :attachments]) && return
     end
-    # Set to application/octet-stream to force download
-    send_file(filename, disposition: "inline",
-                        type: "application/octet-stream", filename: @attachment.filename) && return
+    if @cud.instructor? || @attachment.released?
+      # Set to application/octet-stream to force download
+      send_file(filename, disposition: "inline",
+                          type: "application/octet-stream",
+                          filename: @attachment.filename) && return
+    end
+
+    flash[:error] = "You are unauthorized to view this attachment"
+    redirect_to([@course, @assessment])
   end
 
   action_auth_level :edit, :instructor

--- a/app/views/assessments/index.html.erb
+++ b/app/views/assessments/index.html.erb
@@ -122,7 +122,7 @@
 <% if @attachments.any? %>
   <div class="section">
     <h3 class="section-title"><span class="white">Attachments</span></h3>
-    <ul class="attachments">
+    <ul class="collection with-header attachments">
       <%= render @attachments %>
     </ul>
   </div>

--- a/app/views/assessments/show.html.erb
+++ b/app/views/assessments/show.html.erb
@@ -178,7 +178,7 @@
   <% if @assessment.attachments.length > 0 or @cud.instructor? %>
     <h2>Handouts</h2>
     <ul class="collection with-header attachments">
-      <%= render @assessment.attachments %>
+      <%= render @attachments %>
 
       <% # this code is temporarily "commented out" because Dan wants to preserve the logic for future changes to _attachment.html.erb %>
       <% if false then %>

--- a/app/views/assessments/show.html.erb
+++ b/app/views/assessments/show.html.erb
@@ -175,34 +175,36 @@
 <% download_access = (@cud.instructor?) %>
 
   <%# Display any attachments %>
-  <% if @assessment.attachments.length > 0 or @cud.instructor? %>
-    <h2>Handouts</h2>
-    <ul class="collection with-header attachments">
-      <%= render @attachments %>
+  <% if @attachments.any? or @cud.instructor? %>
+    <div class="section">
+      <h3 class="section-title"><span class="white">Attachments</span></h3>
+      <ul class="collection with-header attachments">
+        <%= render @attachments %>
 
-      <% # this code is temporarily "commented out" because Dan wants to preserve the logic for future changes to _attachment.html.erb %>
-      <% if false then %>
-        <% for a in @assessment.attachments do %>
-          <% if a.released? then %>
-            <% if (Time.now() > @assessment.start_at) or (@cud.instructor?) then %>
-              <li><%= link_to a.name, [@course, @assessment, a] %></li>
-            <% else %>
-              <li><%= a.name %></li>
+        <% # this code is temporarily "commented out" because Dan wants to preserve the logic for future changes to _attachment.html.erb %>
+        <% if false then %>
+          <% for a in @assessment.attachments do %>
+            <% if a.released? then %>
+              <% if (Time.now() > @assessment.start_at) or (@cud.instructor?) then %>
+                <li><%= link_to a.name, [@course, @assessment, a] %></li>
+              <% else %>
+                <li><%= a.name %></li>
+              <% end %>
+            <% elsif @cud.instructor? then %>
+              <li><i><%= link_to a.name, [@course, @assessment, a] %>*</i></li>
             <% end %>
-          <% elsif @cud.instructor? then %>
-            <li><i><%= link_to a.name, [@course, @assessment, a] %>*</i></li>
           <% end %>
         <% end %>
+      <% if @cud.instructor? then %>
+        <li class="collection-item add">
+          <%= link_to new_course_assessment_attachment_path(@course, @assessment) do %>
+            <i class="material-icons left">note_add</i>Add Attachment
+          <% end %>
+          <span class="secondary-content"></span>
+        </li>
       <% end %>
-    <% if @cud.instructor? then %>
-      <li class="collection-item add">
-        <%= link_to new_course_assessment_attachment_path(@course, @assessment) do %>
-          <i class="material-icons left">note_add</i>Add Attachment
-        <% end %>
-        <span class="secondary-content"></span>
-      </li>
-    <% end %>
-    </ul>
+      </ul>
+    </div>
     <hr>
 
   <% end %>


### PR DESCRIPTION
## Description
- Hides unreleased attachments from view when viewing an assessment.
- Prevents users from directly accessing an unreleased attachment (via id manipulation).
- Standardizes attachment display style of course vs assessment

## Motivation and Context
Currently, unreleased attachments are not being correctly hidden when we view an assessment.

Besides, there is no verification before allowing a user to download an attachment. So currently an unreleased attachment can be viewed by modifying the id in the url (which is really bad).

Fixes #1375

## How Has This Been Tested?
- Add released and unreleased attachments to course
- Add released and unreleased attachments to an assessment
- When viewing course or viewing assessment, only released attachments should be viewable
- Downloading released attachments works as usual
- Attempting to directly access an unreleased assessment attachment results in an error, and redirects user to the assessment page
- Attempting to directly access an unreleased course attachment results in an error, and redirects user to the course page

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR

## Other issues / help required
Unsure if the `conditionals` and/or `redirect_to` follows best practices
