### PR TITLE
Hotfix for metrics grace days

### DIFF
--- a/app/models/watchlist_instance.rb
+++ b/app/models/watchlist_instance.rb
@@ -468,13 +468,17 @@ class WatchlistInstance < ApplicationRecord
     return unless latest_aud_before_date.global_cumulative_grace_days_used >= grace_day_threshold
 
     violation_info = {}
+    allowlist_asmt_cumulative_gdu = 0
     auds_before_date.each do |aud|
-      violation_info[aud.assessment.display_name] = aud.grace_days_used if aud.grace_days_used > 0
+      if aud.grace_days_used > 0
+        allowlist_asmt_cumulative_gdu += aud.grace_days_used
+        violation_info[aud.assessment.display_name] = aud.grace_days_used
+      end
     end
 
     # The logic might fall through if the grace days were used on blocklisted assessments
     # This ensures no funky "0 grace day used" instance is added
-    return if violation_info.empty?
+    return if allowlist_asmt_cumulative_gdu < grace_day_threshold
 
     WatchlistInstance.new(course_user_datum_id: cud.id, course_id: course.id,
                           risk_condition_id: condition_id,

--- a/app/models/watchlist_instance.rb
+++ b/app/models/watchlist_instance.rb
@@ -471,6 +471,11 @@ class WatchlistInstance < ApplicationRecord
     auds_before_date.each do |aud|
       violation_info[aud.assessment.display_name] = aud.grace_days_used if aud.grace_days_used > 0
     end
+
+    # The logic might fall through if the grace days were used on blocklisted assessments
+    # This ensures no funky "0 grace day used" instance is added
+    return if violation_info.empty?
+
     WatchlistInstance.new(course_user_datum_id: cud.id, course_id: course.id,
                           risk_condition_id: condition_id,
                           violation_info: violation_info)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
On the current master branch, metrics still take into consideration the number of grace days of assessments whose category is blocklisted. This PR fixes the problem by comparing the sum of grace days used on allowlisted assessments to the risk condition's threshold.

## Motivation and Context
To improve metrics feature.

## How Has This Been Tested?
Play around with grace day usage and blocklist a category of assessments ignoring whose grace day usage will invalidate a watchlist instance for that risk condition. Blocklist that category that verify that no watchlist instances appear for them.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR

## Other issues / help required
<!--- Do you have any other relevant issues / questions? --->
<!--- For example, if you require assistance for a certain part of your PR --->
<!--- or are facing specific issues while creating the pull request that you would like to highlight --->

If unsure, feel free to submit first and we'll help you along.
