### PR TITLE
Fixes Issue of Bulk Release Name Change

### DIFF
--- a/app/views/courses/manage.html.erb
+++ b/app/views/courses/manage.html.erb
@@ -53,7 +53,7 @@
                 { title: "Use the Stanford Moss server to detect copying" } %></li>
 
             <li class="collection-item red-text danger-bottom no-hover"><h4>Danger Zone</h4></li>
-            <li class="danger-side"><%= link_to "Release all grades", [:bulkRelease, @course, @cud, :gradebook],
+            <li class="danger-side"><%= link_to "Release all grades", [:bulk_release, @course, @cud, :gradebook],
                 { title: "Release all grades for all assessments", data: {confirm: "Are you sure you want to release all grades?"}} %></li>
             <li class="danger-side danger-bottom"><%= link_to "Reload course config file", [:reload, @course],
                 { title: "Do this each time your modify the course.rb file", data: {confirm: "Are you sure you want to reload the course config file?"}}%></li>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -188,7 +188,7 @@ Rails.application.routes.draw do
 
     resources :course_user_data do
       resource :gradebook, only: :show do
-        get "bulkRelease"
+        get "bulk_release"
         get "csv"
         get "invalidate"
         get "statistics"
@@ -204,7 +204,7 @@ Rails.application.routes.draw do
     end
 
     member do
-      get "bulkRelease"
+      get "bulk_release"
       get "download_roster"
       match "email", via: [:get, :post]
       get "manage"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Variable name change as part of #1437 was not propagated properly. This PR fixes that.

## Description
<!--- Describe your changes in detail -->

Changes bulkRelease to bulk_release at the relevant pages

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Bug report

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Visit:
http://localhost:3000/courses/AutoPopulated/manage
and click release all grades

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR

## Other issues / help required
<!--- Do you have any other relevant issues / questions? --->
<!--- For example, if you require assistance for a certain part of your PR --->
<!--- or are facing specific issues while creating the pull request that you would like to highlight --->

If unsure, feel free to submit first and we'll help you along.
