### PR TITLE
Fix scheduler csrf

### DIFF
--- a/app/assets/stylesheets/style.css.scss
+++ b/app/assets/stylesheets/style.css.scss
@@ -612,24 +612,6 @@ ul.moss-inner-list > li > input[type="checkbox"]:checked ~ div {
 }
 
 /**
- * Buttons that behave as links. Used for Visual Run on Manage Scheduler Page
- * Similar to style for .danger-side input
- */
-.btnLink {
-  background: none;
-  border: none;
-  padding-left: 0px;
-  text-decoration: none;
-  color: #0882af;
-  font-family: "Source Sans Pro", sans-serif;
-  font-weight: 300;
-  font-size: 15px;
-  text-align: left;
-  width: 100%;
-  cursor: pointer;
-}
-
-/**
  * Spans that behave as links.  Used for LDAP lookup on Create User Page
  **/
 .spanLink {
@@ -1094,20 +1076,6 @@ form p:last-child {
 
 .options .collection-item {
   padding-left: 14px;
-}
-
-.danger-side input {
-  background: none;
-  border: none;
-  padding-left: 14px;
-  text-decoration: none;
-  color: #0882af;
-  font-family: "Source Sans Pro", sans-serif;
-  font-weight: 300;
-  font-size: 16px;
-  text-align: left;
-  width: 100%;
-  cursor: pointer;
 }
 
 /* Form Tables */

--- a/app/assets/stylesheets/style.css.scss
+++ b/app/assets/stylesheets/style.css.scss
@@ -612,6 +612,24 @@ ul.moss-inner-list > li > input[type="checkbox"]:checked ~ div {
 }
 
 /**
+ * Buttons that behave as links. Used for Visual Run on Manage Scheduler Page
+ * Similar to style for .danger-side input
+ */
+.btnLink {
+  background: none;
+  border: none;
+  padding-left: 0px;
+  text-decoration: none;
+  color: #0882af;
+  font-family: "Source Sans Pro", sans-serif;
+  font-weight: 300;
+  font-size: 15px;
+  text-align: left;
+  width: 100%;
+  cursor: pointer;
+}
+
+/**
  * Spans that behave as links.  Used for LDAP lookup on Create User Page
  **/
 .spanLink {

--- a/app/views/assessments/show.html.erb
+++ b/app/views/assessments/show.html.erb
@@ -76,10 +76,10 @@
               <li class="collection-item red-text danger-bottom no-hover"><h4>Danger Zone</h4></li>
 
               <li class="danger-side">
-                <%= button_to "Release all grades", { :action => "releaseAllGrades" }, { :title=> "Make all scores for this assessment visible to students", data: {confirm: "Are you sure you want to release all grades?"}} %>
+                <%= link_to "Release all grades", { :action => "releaseAllGrades" }, { :title=> "Make all scores for this assessment visible to students", data: {confirm: "Are you sure you want to release all grades?", method: "post"}} %>
               </li>
               <li class="danger-side">
-                <%= button_to "Withdraw all grades", { :action => "withdrawAllGrades" }, {:title=> "Hide all scores for this assessment from students", data: {confirm: "Are you sure you want to withdraw all grades?"}} %>
+                <%= link_to "Withdraw all grades", { :action => "withdrawAllGrades" }, {:title=> "Hide all scores for this assessment from students", data: {confirm: "Are you sure you want to withdraw all grades?", method: "post"}} %>
               </li>
               <li class="danger-side danger-bottom"> <%= link_to "Reload config file", {:action => "reload" }, {:title=> "Reload the assessment config file (provided for backward compatibility with legacy assessments)", data: {confirm: "Are you sure you want to reload the config file?"}} %></li>
             </ul>
@@ -107,7 +107,7 @@
               <li class="danger-side"><%= link_to "Reload config file", url_for(:action => 'reload'),
                 :title=> "Reload the assessment configuration file (provided for backward compatibility with legacy assessments)", data: {confirm: "Are you sure you want to reload the config file?"} %></li>
               <li class="danger-side danger-bottom">
-                <%= button_to "Release section grades", { :action => "releaseSectionGrades" }, { :title=> "Make all scores visible to the students in your section. This will work only if your instructor has assigned you to a lecture and section in your Autolab account.", data: {confirm: "Are you sure you want to release section grades?"}} %>
+                <%= link_to "Release section grades", { :action => "releaseSectionGrades" }, { :title=> "Make all scores visible to the students in your section. This will work only if your instructor has assigned you to a lecture and section in your Autolab account.", data: {confirm: "Are you sure you want to release section grades?", method: "post"}} %>
               </li>
             </ul>
           </div>

--- a/app/views/schedulers/index.html.erb
+++ b/app/views/schedulers/index.html.erb
@@ -17,7 +17,7 @@
     <td><%=h scheduler.action %></td>
     <td><%=h scheduler.next %></td>
     <td><%=h scheduler.interval %></td>
-    <td><%= button_to 'Visual Run', {:action=>"run", :scheduler_id=>scheduler.id}, class: "btnLink" %></td>
+    <td><%= link_to 'Visual Run', {:action=>"run", :scheduler_id=>scheduler.id}, data: { method: "post" } %></td>
     <td><%= link_to 'Show', {:action=>"show",:id=>scheduler.id} %>
     <%= link_to 'Edit', edit_course_scheduler_path(@course, scheduler) %>
     <%= link_to 'Destroy', course_scheduler_path(@course, scheduler), method: "delete", data: {confirm: 'Are you sure?'} %></td>

--- a/app/views/schedulers/index.html.erb
+++ b/app/views/schedulers/index.html.erb
@@ -17,7 +17,7 @@
     <td><%=h scheduler.action %></td>
     <td><%=h scheduler.next %></td>
     <td><%=h scheduler.interval %></td>
-    <td><%= link_to 'Visual Run', {:action=>"run", :scheduler_id=>scheduler.id} %></td>
+    <td><%= button_to 'Visual Run', {:action=>"run", :scheduler_id=>scheduler.id}, class: "btnLink" %></td>
     <td><%= link_to 'Show', {:action=>"show",:id=>scheduler.id} %>
     <%= link_to 'Edit', edit_course_scheduler_path(@course, scheduler) %>
     <%= link_to 'Destroy', course_scheduler_path(@course, scheduler), method: "delete", data: {confirm: 'Are you sure?'} %></td>

--- a/app/views/schedulers/run.html.erb
+++ b/app/views/schedulers/run.html.erb
@@ -1,7 +1,7 @@
 <% content_for :javascripts do %>
     <script type="text/javascript">
         $(function () {
-            $.get("visualRun", function (returned) {
+            $.post("visualRun", function (returned) {
                 $(".output").html(returned)
             })
         })

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -71,8 +71,8 @@ Rails.application.routes.draw do
 
   resources :courses, param: :name do
     resources :schedulers do
-      get "visualRun", action: :visual_run
-      get "run"
+      post "visualRun", action: :visual_run
+      post "run"
     end
 
     resource :metrics, only: :index do


### PR DESCRIPTION
## Description
- Change routes from `GET` to `POST`
- Make necessary style and code changes

## Motivation and Context
Currently, the scheduler run route is accessed via `GET`, allowing for CSRF.

## How Has This Been Tested?
- Create a scheduler (at `/courses/<course-name>/schedulers`)
- GET requests to `/courses/<course-name>/schedulers/<scheduler-id>/run` and `/courses/<course-name>/schedulers/<scheduler-id>/visualRun` are no longer possible
- Clicking Visual Run button works as usual
- Attempting to alter `authenticity_token` field results in an error

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR