### PR TITLE
Fix application xss

### DIFF
--- a/app/views/doorkeeper/authorizations/new.html.erb
+++ b/app/views/doorkeeper/authorizations/new.html.erb
@@ -13,7 +13,7 @@
 <h3>Authorization Required</h3>
 
 <p class="h4">
-  <%= raw t('.prompt', client_name: "<strong class=\"text-info\">#{ @pre_auth.client.name }</strong>") %>
+  <%= t('.prompt', client_name: "<strong class=\"text-info\">#{ @pre_auth.client.name }</strong>") %>
 </p>
 
 <% if @pre_auth.scopes.count > 0 %>


### PR DESCRIPTION
## Description
- Remove unnecessary raw tag

## Motivation and Context
- Currently, application name is xss-able

## How Has This Been Tested?
- Go to `/oauth/applications`
- Create application with name `<img src=a onerror=alert(document.cookie)>`
- Click on authorize, name should be correctly escaped

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR