### PR TITLE
Resolve more CSRF issues

### DIFF
--- a/app/controllers/course_user_data_controller.rb
+++ b/app/controllers/course_user_data_controller.rb
@@ -229,7 +229,7 @@ class CourseUserDataController < ApplicationController
   action_auth_level :unsudo, :student
   def unsudo
     session[:sudo] = nil
-    flash[:success] = "You are yourself again"
+    flash[:success] = "You are no longer acting as user #{@cud.display_name}"
     redirect_to([@cud.course]) && return
   end
 

--- a/app/controllers/course_user_data_controller.rb
+++ b/app/controllers/course_user_data_controller.rb
@@ -229,7 +229,7 @@ class CourseUserDataController < ApplicationController
   action_auth_level :unsudo, :student
   def unsudo
     session[:sudo] = nil
-    flash[:success] = "You are no longer acting as user #{@cud.display_name}"
+    flash[:success] = "You are no longer acting as user #{@cud.email}"
     redirect_to([@cud.course]) && return
   end
 

--- a/app/views/assessments/show.html.erb
+++ b/app/views/assessments/show.html.erb
@@ -52,9 +52,9 @@
           <div class="collapsible-header"><h5>Admin Options</h5></div>
           <div class="collapsible-body">
             <ul class="options">
-              <li> <%= link_to "Edit assessment", {:action => "edit" }, {:title=> "View and modify the properties for this assessment, including its problems", :class=>""} %></li>
-              <li> <%= link_to "Grade submissions", {:action => "viewGradesheet" }, {:title=> "View and enter grades on the gradesheet" } %></li>
-              <li> <%= link_to "Export assessment", {:action => "export" }, {:title=> "Export persistent properties that will be imported when you install this assessment in a future term" } %></li>
+              <li><%= link_to "Edit assessment", {:action => "edit" }, {:title=> "View and modify the properties for this assessment, including its problems", :class=>""} %></li>
+              <li><%= link_to "Grade submissions", {:action => "viewGradesheet" }, {:title=> "View and enter grades on the gradesheet" } %></li>
+              <li><%= link_to "Export assessment", {:action => "export" }, {:title=> "Export persistent properties that will be imported when you install this assessment in a future term" } %></li>
 
               <% if @assessment.has_autograder? then %>
                 <li><%= link_to "Autograder settings", [:edit, @course, @assessment, :autograder], title: "Modify autograding properties such as the VM image and the timeout value" %></li>
@@ -67,11 +67,11 @@
               <% if @assessment.has_scoreboard? %>
                 <li><%= link_to "Scoreboard settings", [:edit, @course, @assessment, :scoreboard], title: "Configure the appearance of the scoreboard" %></li>
               <% end %>
-              <li> <%= link_to "Manage extensions", [@course, @assessment, :extensions], { title: "Give extensions to students" } %></li>
-              <li> <%= link_to "Manage submissions", [@course, @assessment, :submissions], { title: "Create, view, export, and re-autograde submissions" } %></li>
-              <li> <%= link_to "View statistics", {:action => "statistics" }, {:title=> "View detailed stats for this assessment" } %></li>
-              <li> <%= link_to "Bulk import grades", {:action => "bulkGrade" }, {:title=> "Upload scores or feedback for multiple students from a CSV file" } %></li>
-              <li> <%= link_to "Bulk export grades", {:action => "bulkExport" }, {:title=> "Export grades (with sub-scores) \nfor all students to a CSV file" } %></li>
+              <li><%= link_to "Manage extensions", [@course, @assessment, :extensions], { title: "Give extensions to students" } %></li>
+              <li><%= link_to "Manage submissions", [@course, @assessment, :submissions], { title: "Create, view, export, and re-autograde submissions" } %></li>
+              <li><%= link_to "View statistics", {:action => "statistics" }, {:title=> "View detailed stats for this assessment" } %></li>
+              <li><%= link_to "Bulk import grades", {:action => "bulkGrade" }, {:title=> "Upload scores or feedback for multiple students from a CSV file" } %></li>
+              <li><%= link_to "Bulk export grades", {:action => "bulkExport" }, {:title=> "Export grades (with sub-scores) \nfor all students to a CSV file" } %></li>
 
               <li class="collection-item red-text danger-bottom no-hover"><h4>Danger Zone</h4></li>
 
@@ -123,9 +123,9 @@
         <div class="collapsible-header active"><h5>Options</h5></div>
         <div class="collapsible-body">
           <ul class="options">
-            <li> <%= link_to "View handin history", {:action => 'history'}, {:title=> "View your submissions, scores, and feedback from the course staff" } %> </li>
-            <li> <%= link_to "View writeup", {:action => 'writeup'}, {:title=> "View the assessment writeup", :class=>""}%> </li>
-            <li> <%= link_to "Download handout", {:action => 'handout'}, {:title=> "Download handout materials and starter code" } %> </li>
+            <li><%= link_to "View handin history", {:action => 'history'}, {:title=> "View your submissions, scores, and feedback from the course staff" } %> </li>
+            <li><%= link_to "View writeup", {:action => 'writeup'}, {:title=> "View the assessment writeup", :class=>""}%> </li>
+            <li><%= link_to "Download handout", {:action => 'handout'}, {:title=> "Download handout materials and starter code" } %> </li>
             <% if @assessment.has_groups? %>
               <% if @aud.membership_status != AssessmentUserDatum::UNCONFIRMED then %>
                 <li><%= link_to "Group options", [@course, @assessment, @aud.group], title: "Check your group settings." %></li>
@@ -139,7 +139,7 @@
 
           <% @list.sort { |a,b| a[1] <=> b[1] }.each { |key, value| %>
             <% if value.size > 0  then  %>
-              <li> <%= link_to value, {:action => key}, {:title=>(@list_title[key] || "")} %> </li>
+              <li><%= link_to value, {:action => key}, {:title=>(@list_title[key] || "")} %> </li>
             <% end %>
           <% } %>
           </ul>

--- a/app/views/assessments/show.html.erb
+++ b/app/views/assessments/show.html.erb
@@ -81,7 +81,7 @@
               <li class="danger-side">
                 <%= button_to "Withdraw all grades", { :action => "withdrawAllGrades" }, {:title=> "Hide all scores for this assessment from students", data: {confirm: "Are you sure you want to withdraw all grades?"}} %>
               </li>
-              <li class="danger-side danger-bottom"> <%= link_to "Reload config file", {:action => "reload" }, {:title=> "Reload the assessment config file (provided for backward compatibility with legacy assessments)", data: {confirm: "Are you sure you want to reload the config file?"}} %></li>
+              <li class="danger-side danger-bottom"> <%= link_to "Reload config file", {:action => "reload" }, {:title=> "Reload the assessment config file (provided for backward compatibility with legacy assessments)", data: {confirm: "Are you sure you want to reload the config file?", method: "post"}} %></li>
             </ul>
           </div>
         </li>
@@ -104,8 +104,7 @@
                 <li><%= link_to  "Download section #{@cud.section} submissions", [:downloadAll, @course, @assessment, :submissions, final: true], title: "Download section #{@cud.section} submissions" %></li>
               <% end %>
               <li class="collection-item red-text danger-bottom no-hover"><h4>Danger Zone</h4></li>
-              <li class="danger-side"><%= link_to "Reload config file", url_for(:action => 'reload'),
-                :title=> "Reload the assessment configuration file (provided for backward compatibility with legacy assessments)", data: {confirm: "Are you sure you want to reload the config file?"} %></li>
+              <li class="danger-side"><%= link_to "Reload config file", {:action => "reload" }, {:title=> "Reload the assessment config file (provided for backward compatibility with legacy assessments)", data: {confirm: "Are you sure you want to reload the config file?", method: "post"}} %></li>
               <li class="danger-side danger-bottom">
                 <%= button_to "Release section grades", { :action => "releaseSectionGrades" }, { :title=> "Make all scores visible to the students in your section. This will work only if your instructor has assigned you to a lecture and section in your Autolab account.", data: {confirm: "Are you sure you want to release section grades?"}} %>
               </li>

--- a/app/views/courses/manage.html.erb
+++ b/app/views/courses/manage.html.erb
@@ -54,7 +54,7 @@
 
             <li class="collection-item red-text danger-bottom no-hover"><h4>Danger Zone</h4></li>
             <li class="danger-side"><%= link_to "Release all grades", [:bulk_release, @course, @cud, :gradebook],
-                { title: "Release all grades for all assessments", data: {confirm: "Are you sure you want to release all grades?"}} %></li>
+                { title: "Release all grades for all assessments", data: {confirm: "Are you sure you want to release all grades?", method: "post"}} %></li>
             <li class="danger-side danger-bottom"><%= link_to "Reload course config file", [:reload, @course],
                 { title: "Do this each time your modify the course.rb file", data: {confirm: "Are you sure you want to reload the course config file?"}}%></li>
           </ul>

--- a/app/views/courses/manage.html.erb
+++ b/app/views/courses/manage.html.erb
@@ -56,7 +56,7 @@
             <li class="danger-side"><%= link_to "Release all grades", [:bulk_release, @course, @cud, :gradebook],
                 { title: "Release all grades for all assessments", data: {confirm: "Are you sure you want to release all grades?", method: "post"}} %></li>
             <li class="danger-side danger-bottom"><%= link_to "Reload course config file", [:reload, @course],
-                { title: "Do this each time your modify the course.rb file", data: {confirm: "Are you sure you want to reload the course config file?", method: "post"}}%></li>
+                { title: "Reload each time you modify the course.rb file", data: {confirm: "Are you sure you want to reload the course config file?", method: "post"}}%></li>
           </ul>
         </div>
       </li>

--- a/app/views/courses/manage.html.erb
+++ b/app/views/courses/manage.html.erb
@@ -56,7 +56,7 @@
             <li class="danger-side"><%= link_to "Release all grades", [:bulk_release, @course, @cud, :gradebook],
                 { title: "Release all grades for all assessments", data: {confirm: "Are you sure you want to release all grades?", method: "post"}} %></li>
             <li class="danger-side danger-bottom"><%= link_to "Reload course config file", [:reload, @course],
-                { title: "Do this each time your modify the course.rb file", data: {confirm: "Are you sure you want to reload the course config file?"}}%></li>
+                { title: "Do this each time your modify the course.rb file", data: {confirm: "Are you sure you want to reload the course config file?", method: "post"}}%></li>
           </ul>
         </div>
       </li>

--- a/app/views/gradebooks/view.html.erb
+++ b/app/views/gradebooks/view.html.erb
@@ -94,7 +94,7 @@
     <a class="tip link" title="Course Statistics" href="<%= url_for :action => :statistics %>">
       Statistics
     </a> /
-    <a class="tip regenerate" title="Regenerate (~10 seconds)" href="<%= url_for :action => :invalidate %>">
+    <a class="tip regenerate" title="Regenerate (~10 seconds)" href="<%= url_for :action => :invalidate %>" data-method="post">
       <i class="icon-refresh"></i>
       <%= time_ago_in_words(DateTime.parse @matrix.last_updated) %> old
     </a>

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -47,7 +47,7 @@
 
       <ul class="right hide-on-med-and-down">
         <% if session[:sudo] && @cud then %>
-          <li><%= link_to "(#{@cud.display_name}) Reset user", [:unsudo, @course, @cud] %></li>
+          <li><%= link_to "(#{@cud.display_name}) Reset user", [:unsudo, @course, @cud], data: {method: "post"} %></li>
         <% end %>
 
         <% if @cud %>
@@ -104,7 +104,7 @@
       </div>
         <!-- Usual Navbar Items -->
         <% if session[:sudo] && @cud then %>
-          <li><%= link_to "(#{@cud.display_name}) Reset user", [:unsudo, @course, @cud] %></li>
+          <li><%= link_to "(#{@cud.display_name}) Reset user", [:unsudo, @course, @cud], data: {method: "post"} %></li>
         <% end %>
 
         <% if @cud %>

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -47,7 +47,7 @@
 
       <ul class="right hide-on-med-and-down">
         <% if session[:sudo] && @cud then %>
-          <li><%= link_to "(#{@cud.display_name}) Reset user", [:unsudo, @course, @cud], data: {method: "post"} %></li>
+          <li><%= link_to "(#{@cud.display_name}) Return to instructor view", [:unsudo, @course, @cud], data: {method: "post"} %></li>
         <% end %>
 
         <% if @cud %>
@@ -104,7 +104,7 @@
       </div>
         <!-- Usual Navbar Items -->
         <% if session[:sudo] && @cud then %>
-          <li><%= link_to "(#{@cud.display_name}) Reset user", [:unsudo, @course, @cud], data: {method: "post"} %></li>
+          <li><%= link_to "(#{@cud.display_name}) Return to instructor view", [:unsudo, @course, @cud], data: {method: "post"} %></li>
         <% end %>
 
         <% if @cud %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -27,7 +27,7 @@
   <%= link_to raw('<span class="btn primary">Change Password</span>'), edit_user_registration_path %>
   <% if GithubIntegration.connected %>
     <% if @user.github_integration && @user.github_integration.is_connected %>
-      <%= link_to raw('<span class="btn primary">Revoke Github Token</span>'), github_revoke_user_path(@user) %>
+      <%= link_to raw('<span class="btn primary">Revoke Github Token</span>'), github_revoke_user_path(@user), data: {method: "post"} %>
     <% else %>
       <%= link_to raw('<span class="btn primary">Connect to Github</span>'), github_oauth_user_path(@user) %>
     <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -65,7 +65,7 @@ Rails.application.routes.draw do
   resources :users do
     get "admin"
     get "github_oauth", on: :member
-    get "github_revoke", on: :member
+    post "github_revoke", on: :member
     get "github_oauth_callback", on: :collection
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -199,7 +199,7 @@ Rails.application.routes.draw do
       member do
         get "destroyConfirm"
         match "sudo", via: [:get, :post]
-        get "unsudo"
+        post "unsudo"
       end
     end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -144,7 +144,7 @@ Rails.application.routes.draw do
         post "releaseAllGrades"
         post "releaseSectionGrades"
         get "viewFeedback"
-        get "reload"
+        post "reload"
         get "statistics"
         post "withdrawAllGrades"
         get "export"
@@ -209,7 +209,7 @@ Rails.application.routes.draw do
       match "email", via: [:get, :post]
       get "manage"
       get "moss"
-      get "reload"
+      post "reload"
       match "report_bug", via: [:get, :post]
       post "run_moss"
       get "sudo"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -188,7 +188,7 @@ Rails.application.routes.draw do
 
     resources :course_user_data do
       resource :gradebook, only: :show do
-        get "bulk_release"
+        post "bulk_release"
         get "csv"
         get "invalidate"
         get "statistics"
@@ -204,7 +204,7 @@ Rails.application.routes.draw do
     end
 
     member do
-      get "bulk_release"
+      post "bulk_release"
       get "download_roster"
       match "email", via: [:get, :post]
       get "manage"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -190,7 +190,7 @@ Rails.application.routes.draw do
       resource :gradebook, only: :show do
         post "bulk_release"
         get "csv"
-        get "invalidate"
+        post "invalidate"
         get "statistics"
         get "student"
         get "view"


### PR DESCRIPTION
This PR serves to change `GET` requests to `POST` requests where appropriate to preempt future CSRF attacks.

## Description
Changed the following routes to `POST`
- unsudo (Priority: Medium)
- reload (course / assessment config) (Priority: Low)
- release all grades (Priority: Critical)
- invalidate (Priority: Low)
- github_revoke (Priority: Medium)

## Motivation and Context
Using `GET` incorrectly opens Autolab up to CSRF attacks. Changing the appropriate routes to `POST` protects us against these attacks.

## How Has This Been Tested?
For each of the following, tested that `GET` no longer works, `POST` works as expected, fudging token causes an error
- Unsudo [Sudo to an arbitrary user via Manage Course - Act as user. Check unsudo button both in normal layout, and mobile layout]
- Reload course config [Manage course - reload course config file]
- Reload assessment config [Go to an assignment - reload config file (under Admin Options and CA options)]
- Release all grades [Manage course - release all grades]
- Invalidate [Gradebook - refresh button]
- github_revoke (set up [github integration](https://docs.autolabproject.com/installation/github_integration/) where url is `http://localhost`; connect account. Check revoke button in user profile page] 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR