### PR TITLE
Better config reload error handling

### DIFF
--- a/app/controllers/assessments_controller.rb
+++ b/app/controllers/assessments_controller.rb
@@ -607,11 +607,9 @@ class AssessmentsController < ApplicationController
 
   def reload
     @assessment.load_config_file
-    # rubocop:disable Lint/RescueException
-  rescue Exception => e
+  rescue StandardError, SyntaxError => e
     @error = e
     # let the reload view render
-    # rubocop:enable Lint/RescueException
   else
     flash[:success] = "Success: Assessment config file reloaded!"
     redirect_to(action: :show) && return

--- a/app/controllers/assessments_controller.rb
+++ b/app/controllers/assessments_controller.rb
@@ -607,8 +607,11 @@ class AssessmentsController < ApplicationController
 
   def reload
     @assessment.load_config_file
-  rescue StandardError
+    # rubocop:disable Lint/RescueException
+  rescue Exception => e
+    @error = e
     # let the reload view render
+    # rubocop:enable Lint/RescueException
   else
     flash[:success] = "Success: Assessment config file reloaded!"
     redirect_to(action: :show) && return

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -223,11 +223,9 @@ class CoursesController < ApplicationController
   action_auth_level :reload, :instructor
   def reload
     @course.reload_course_config
-    # rubocop:disable Lint/RescueException
-  rescue Exception => e
+  rescue StandardError, SyntaxError => e
     @error = e
     # let the reload view render
-    # rubocop:enable Lint/RescueException
   else
     flash[:success] = "Success: Course config file reloaded!"
     redirect_to([@course]) && return

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -222,8 +222,13 @@ class CoursesController < ApplicationController
 
   action_auth_level :reload, :instructor
   def reload
-    render && return unless @course.reload_course_config
-
+    @course.reload_course_config
+    # rubocop:disable Lint/RescueException
+  rescue Exception => e
+    @error = e
+    # let the reload view render
+    # rubocop:enable Lint/RescueException
+  else
     flash[:success] = "Success: Course config file reloaded!"
     redirect_to([@course]) && return
   end

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -218,6 +218,9 @@ class Assessment < ApplicationRecord
     # read from source
     config_source = File.open(source_config_file_path, "r", &:read)
 
+    # validate syntax of config
+    RubyVM::InstructionSequence.compile(config_source)
+
     # uniquely rename module (so that it's unique among all assessment modules loaded in Autolab)
     config = config_source.gsub("module #{source_config_module_name}",
                                 "module #{config_module_name}")

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -225,6 +225,9 @@ class Assessment < ApplicationRecord
     config = config_source.gsub("module #{source_config_module_name}",
                                 "module #{config_module_name}")
 
+    # backup old config
+    File.rename(config_file_path, config_file_path.sub_ext(".rb.bak"))
+
     # write to config_file_path
     File.open(config_file_path, "w") { |f| f.write config }
 

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -158,6 +158,12 @@ class Course < ApplicationRecord
     lines = s.readlines
     s.close
 
+    # read from source
+    config_source = File.open(src, "r", &:read)
+
+    # validate syntax of config
+    RubyVM::InstructionSequence.compile(config_source)
+
     d = File.open(dest, "w")
     d.write("require 'CourseBase.rb'\n\n")
     d.write("module Course#{course.camelize}\n")

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -164,6 +164,9 @@ class Course < ApplicationRecord
     # validate syntax of config
     RubyVM::InstructionSequence.compile(config_source)
 
+    # backup old config
+    File.rename(dest, dest.sub_ext(".rb.bak"))
+
     d = File.open(dest, "w")
     d.write("require 'CourseBase.rb'\n\n")
     d.write("module Course#{course.camelize}\n")

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -182,18 +182,9 @@ class Course < ApplicationRecord
   # Reload the course config file and extend the loaded methods
   # to AdminsController
   def reload_course_config
-    mod = nil
-    begin
-      mod = reload_config_file
-
-    # rubocop:disable Lint/RescueException
-    rescue Exception
-      return false
-    end
-    # rubocop:enable Lint/RescueException
+    mod = reload_config_file
 
     AdminsController.extend(mod)
-    true
   end
 
   def sanitized_name

--- a/app/views/courses/reload.html.erb
+++ b/app/views/courses/reload.html.erb
@@ -1,7 +1,18 @@
-<h2>Error Parsing your Course Configuration File:</h2><pre> <%=h @error.to_s %></pre>
-<br>
-<a href="<%= %>">Click here once you have fixed the
-  above error</a>
+<h2>Error Parsing your Course Configuration File:</h2>
 
+<div>
+  <pre><%= @error.to_s %></pre>
+</div>
+
+<div>
+  <%= link_to "Click here once you have fixed the above error", [:reload, @course] %>
+</div>
+
+<% # this rails function returns a <pre> containing the error as YAML %>
+<div>
 <%= debug @error %>
-<pre><%= @error.backtrace.join("\n") %></pre>
+</div>
+
+<div>
+  <pre><%= @error.backtrace.join("\n") %></pre>
+</div>


### PR DESCRIPTION
Modify course and assessment config reload code to better handle cases where an invalid config is provided

## Description
- Modified course `reload.html` to be consistent with assignment `reload.html`
- Validate syntax of config (via compilation) before saving
- Correctly catch (certain classes of) exceptions when attempting to load config files
- Make backups of last-known good configs when reloading

## Motivation and Context
Currently, course config reload does not set the `@error` variable, so the error page is not correctly rendered.

Furthermore, config reload does not check the syntax of the config file before saving it, meaning that it's possible to reload a file with invalid syntax and corrupt the config.

Also fixes #1516

## How Has This Been Tested?
- Under normal circumstances, course config reload still works
- Under normal circumstances, assessment config reload still works
- When reloading, observe that a backup copy of the original config is made
- Corrupt course config `courses/<course-name>/course.rb` and reload config. Error should be correctly caught and config in `courseConfig/<course-name>.rb` unaffected
- Corrupt assessment config `courses/<course-name>/<assessment-name>/<assessment-name>.rb` and reload config. Error should be correctly caught and config in `assessmentConfig/<course-name>-<assessment-name>.rb` unaffected

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR