### PR TITLE
Fix infinite extension display

### DIFF
--- a/app/views/assessments/show.html.erb
+++ b/app/views/assessments/show.html.erb
@@ -156,12 +156,29 @@
       <div class="card-content">
         <p class="valign-wrapper">
           <i class="material-icons valign">access_time</i>
-            &nbsp;&nbsp;Due<% if @extension then %>&nbsp;(with <%=@extension.days %> day extension)<% end %>:&nbsp;
-            <b><span class="moment-date-time" data-format="MMMM Do YYYY, h:mm a z"> <%= due_at_display @aud.due_at %></span></b>
+            &nbsp;&nbsp;Due
+            <% if @extension %>
+              (with <% if @extension.infinite? %> infinite <% else %><%= @extension.days %> day<% end %> extension)
+            <% end %>:&nbsp;
+            <b>
+              <% if @extension and @extension.infinite? %>
+                <%= due_at_display @aud.due_at %>
+              <% else %>
+                <span class="moment-date-time" data-format="MMMM Do YYYY, h:mm a z"><%= due_at_display @aud.due_at %></span>
+              <% end %>
+            </b>
         </p>
 
         <p class="valign-wrapper">
-          <i class="valign material-icons">today</i>&nbsp;&nbsp;Last day to handin:&nbsp;&nbsp;<b><span class="moment-date-time" data-format="MMMM Do YYYY, h:mm a z"> <%= end_at_display(@aud.end_at false) %></span></b>
+          <i class="valign material-icons">today</i>
+          &nbsp;&nbsp;Last day to handin:&nbsp;
+          <b>
+            <% if @extension and @extension.infinite? %>
+              <%= end_at_display(@aud.end_at false) %>
+            <% else %>
+            <span class="moment-date-time" data-format="MMMM Do YYYY, h:mm a z"><%= end_at_display(@aud.end_at false) %></span>
+            <% end %>
+          </b>
         </p>
 
         <% if @cud.instructor? and @assessment.exam? %>

--- a/app/views/assessments/show.html.erb
+++ b/app/views/assessments/show.html.erb
@@ -157,9 +157,7 @@
         <p class="valign-wrapper">
           <i class="material-icons valign">access_time</i>
             &nbsp;&nbsp;Due
-            <% if @extension %>
-              (with <% if @extension.infinite? %> infinite <% else %> <%= pluralize(@extension.days, "day") %> <% end %> extension)
-            <% end %>:&nbsp;
+            <% if @extension %>(with <% if @extension.infinite? %> infinite <% else %> <%= pluralize(@extension.days, "day") %> <% end %> extension)<% end %>:&nbsp;
             <b>
               <% if @extension and @extension.infinite? %>
                 <%= due_at_display @aud.due_at %>

--- a/app/views/assessments/show.html.erb
+++ b/app/views/assessments/show.html.erb
@@ -159,7 +159,7 @@
             &nbsp;&nbsp;Due
             <% if @extension %>(with <% if @extension.infinite? %> infinite <% else %> <%= pluralize(@extension.days, "day") %> <% end %> extension)<% end %>:&nbsp;
             <b>
-              <% if @extension and @extension.infinite? %>
+              <% if @extension&.infinite? %>
                 <%= due_at_display @aud.due_at %>
               <% else %>
                 <span class="moment-date-time" data-format="MMMM Do YYYY, h:mm a z"><%= due_at_display @aud.due_at %></span>
@@ -171,10 +171,10 @@
           <i class="valign material-icons">today</i>
           &nbsp;&nbsp;Last day to handin:&nbsp;
           <b>
-            <% if @extension and @extension.infinite? %>
+            <% if @extension&.infinite? %>
               <%= end_at_display(@aud.end_at false) %>
             <% else %>
-            <span class="moment-date-time" data-format="MMMM Do YYYY, h:mm a z"><%= end_at_display(@aud.end_at false) %></span>
+              <span class="moment-date-time" data-format="MMMM Do YYYY, h:mm a z"><%= end_at_display(@aud.end_at false) %></span>
             <% end %>
           </b>
         </p>

--- a/app/views/assessments/show.html.erb
+++ b/app/views/assessments/show.html.erb
@@ -158,7 +158,7 @@
           <i class="material-icons valign">access_time</i>
             &nbsp;&nbsp;Due
             <% if @extension %>
-              (with <% if @extension.infinite? %> infinite <% else %><%= @extension.days %> day<% end %> extension)
+              (with <% if @extension.infinite? %> infinite <% else %> <%= pluralize(@extension.days, "day") %> <% end %> extension)
             <% end %>:&nbsp;
             <b>
               <% if @extension and @extension.infinite? %>


### PR DESCRIPTION
Ensure that "Due" and "Last day to handin" fields display correctly when a student is given infinite extension

## Description
- Add logic when student has infinite extension

## Motivation and Context
Currently, `due_at_display` and `end_at_display` are wrapped in a `span` block with class `moment-date-time`. However, they return a message when a student has infinite extension, which then gets rendered as "Invalid Date".

Furthermore, "(with ... day extension)" message does not take into account infinite extensions.

## How Has This Been Tested?
- Give student a 1 day extension and then use "act as user" to act as student. Observe that extension displays correctly (message "with 1 day extension") and correct dates
- Give student a >1 day extension and then use "act as user" to act as student. Observe that extension displays correctly (message "with xx days extension") and correct dates
- Give student an infinite extension and then use "act as user" to act as student. Observe that extension displays correctly (message "with infinite extension") and correct dates ("Not applicable (infinite extension granted)")

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR