### PR TITLE
Hotfix for CSRF protection

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -76,15 +76,15 @@ class ApplicationController < ActionController::Base
   end
 
   def self.action_no_auth(action)
-    skip_before_action :verify_authenticity_token, raise: false
-    skip_before_action :authenticate_user!, raise: false
-    skip_before_action configure_permitted_paramters: [action]
-    skip_before_action maintenance_mode: [action]
-    skip_before_action run_scheduler: [action]
+    skip_before_action :verify_authenticity_token, only: [action], raise: false
+    skip_before_action :authenticate_user!, only: [action], raise: false
+    skip_before_action configure_permitted_paramters, only: [action]
+    skip_before_action maintenance_mode, only: [action]
+    skip_before_action run_scheduler, only: [action]
 
-    skip_before_action authenticate_user: [action], raise: false
+    skip_before_action authenticate_user, only: [action], raise: false
     skip_before_action :authorize_user_for_course, only: [action]
-    skip_before_action authenticate_for_action: [action], raise: false
+    skip_before_action authenticate_for_action, only: [action], raise: false
     skip_before_action :update_persistent_announcements, only: [action], raise: false
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -77,12 +77,12 @@ class ApplicationController < ActionController::Base
   def self.action_no_auth(action)
     skip_before_action :verify_authenticity_token, only: [action], raise: false
     skip_before_action :authenticate_user!, only: [action], raise: false
-    skip_before_action :configure_permitted_paramters, only: [action]
-    skip_before_action :maintenance_mode?, only: [action]
-    skip_before_action :run_scheduler, only: [action]
+    skip_before_action :configure_permitted_paramters, only: [action], raise: false
+    skip_before_action :maintenance_mode?, only: [action], raise: false
+    skip_before_action :run_scheduler, only: [action], raise: false
 
     skip_before_action :authenticate_user, only: [action], raise: false
-    skip_before_action :authorize_user_for_course, only: [action]
+    skip_before_action :authorize_user_for_course, only: [action], raise: false
     skip_before_action :authenticate_for_action, only: [action], raise: false
     skip_before_action :update_persistent_announcements, only: [action], raise: false
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -65,7 +65,7 @@ class ApplicationController < ActionController::Base
 
     if level == :administrator
       skip_before_action :authorize_user_for_course, only: [action], raise: false
-      skip_before_action authenticate_for_action: [action]
+      skip_before_action :authenticate_for_action, only: [action]
       skip_before_action :update_persistent_announcements, only: [action], raise: false
     end
 
@@ -78,13 +78,13 @@ class ApplicationController < ActionController::Base
   def self.action_no_auth(action)
     skip_before_action :verify_authenticity_token, only: [action], raise: false
     skip_before_action :authenticate_user!, only: [action], raise: false
-    skip_before_action configure_permitted_paramters, only: [action]
-    skip_before_action maintenance_mode, only: [action]
-    skip_before_action run_scheduler, only: [action]
+    skip_before_action :configure_permitted_paramters, only: [action]
+    skip_before_action :maintenance_mode?, only: [action]
+    skip_before_action :run_scheduler, only: [action]
 
-    skip_before_action authenticate_user, only: [action], raise: false
+    skip_before_action :authenticate_user, only: [action], raise: false
     skip_before_action :authorize_user_for_course, only: [action]
-    skip_before_action authenticate_for_action, only: [action], raise: false
+    skip_before_action :authenticate_for_action, only: [action], raise: false
     skip_before_action :update_persistent_announcements, only: [action], raise: false
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -65,7 +65,7 @@ class ApplicationController < ActionController::Base
 
     if level == :administrator
       skip_before_action :authorize_user_for_course, only: [action], raise: false
-      skip_before_action :authenticate_for_action, only: [action]
+      skip_before_action :authenticate_for_action, only: [action], raise: false
       skip_before_action :update_persistent_announcements, only: [action], raise: false
     end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -65,7 +65,6 @@ class ApplicationController < ActionController::Base
 
     if level == :administrator
       skip_before_action :authorize_user_for_course, only: [action], raise: false
-      skip_before_action :authenticate_for_action, only: [action], raise: false
       skip_before_action :update_persistent_announcements, only: [action], raise: false
     end
 

--- a/app/controllers/assessments_controller.rb
+++ b/app/controllers/assessments_controller.rb
@@ -64,8 +64,6 @@ class AssessmentsController < ApplicationController
   action_auth_level :set_repo, :instructor
   action_auth_level :import_svn, :instructor
 
-  protect_from_forgery with: :exception
-
   def index
     @is_instructor = @cud.has_auth_level? :instructor
     announcements_tmp = Announcement.where("start_date < :now AND end_date > :now",


### PR DESCRIPTION
Amendment to PR #1512

## Description
- Remove duplicate `protect_from_forgery` added in #1512
- Correctly specify `only: [action]` for `skip_before_action` statements inside `action_no_auth`

## Motivation and Context
#1512 added CSRF protection by repeating `protect_from_forgery`. However, this overrides the `skip_before_action` inside `action_no_auth`. Since Tango does not have a CSRF token, this means autograding feedback is rejected.

In reality, there is no need to repeat `protect_from_forgery`; it wasn't working because the `skip_before_action` did not specify `only: [action]`.

## How Has This Been Tested?
- CSRF protection for releaseAllGrades, withdrawAllGrades, releaseSectionGrades still work as expected
- Autograding feedback works as expected
- Ensure that admin routes `/admin/github_integration` and `/admin/email_instructors` are only accessible by admins

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR