### PR TITLE
Change refresh_watchlist_instances to POST

### DIFF
--- a/app/assets/javascripts/watchlist.js
+++ b/app/assets/javascripts/watchlist.js
@@ -632,7 +632,7 @@ function refresh_watchlist(){
 
   // uses formantic ui loading class 
   $("#refresh_btn").addClass('loading');
-  $.getJSON(watchlist_endpoints['refresh'],function(){
+  $.post(watchlist_endpoints['refresh'],function(){
     
     // set last updated time to now on success
     $('#last-updated-time')
@@ -643,7 +643,7 @@ function refresh_watchlist(){
       type:"positive",
       header:"Successfully refreshed watchlist instances",
       message: "The latest instances should be showing now",
-    });
+    }, "json");
     
   }).fail(function(){
     render_banner({

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -80,7 +80,7 @@ Rails.application.routes.draw do
       get "get_current_metrics"
       get "get_watchlist_instances"
       get "get_num_pending_instances"
-      get "refresh_watchlist_instances"
+      post "refresh_watchlist_instances"
       get "get_watchlist_category_blocklist"
       post "update_current_metrics"
       post "update_watchlist_instances"


### PR DESCRIPTION
## Description
- Modify `refresh_watchlist_instances` route to use `POST`
- Modify frontend js to use `POST`

## Motivation and Context
Currently, the refresh endpoint uses `GET` and is vulnerable to CSRF attacks.

## How Has This Been Tested?
- Go to a course and define a metric
- Accessing `/courses/<course-name>/metrics/refresh_watchlist_instances` should no longer work
- Clicking on refresh button works as expected
- Fudging CSRF token leads to request failing

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR