### PR TITLE
Initial commit

### DIFF
--- a/app/assets/javascripts/annotations.js
+++ b/app/assets/javascripts/annotations.js
@@ -18,7 +18,7 @@ $(document).ready(function () {
   resizeCodeTable();
 });
 
-/* On Window Reisze */
+/* On Window Resize */
 $(window).on('resize', function () {
   resizeCodeTable();
 });

--- a/app/assets/stylesheets/animate.css
+++ b/app/assets/stylesheets/animate.css
@@ -2410,8 +2410,8 @@ Copyright (c) 2014 Daniel Eden
   100% {
     -webkit-transform-origin: left bottom;
     transform-origin: left bottom;
-    -webkit-transform: rotate(0, 0, 1, 45deg);
-    transform: rotate(0, 0, 1, 45deg);
+    -webkit-transform: rotate3d(0, 0, 1, 45deg);
+    transform: rotate3d(0, 0, 1, 45deg);
     opacity: 0;
   }
 }
@@ -2428,9 +2428,9 @@ Copyright (c) 2014 Daniel Eden
     -webkit-transform-origin: left bottom;
     -ms-transform-origin: left bottom;
     transform-origin: left bottom;
-    -webkit-transform: rotate(0, 0, 1, 45deg);
-    -ms-transform: rotate(0, 0, 1, 45deg);
-    transform: rotate(0, 0, 1, 45deg);
+    -webkit-transform: rotate3d(0, 0, 1, 45deg);
+    -ms-transform: rotate3d(0, 0, 1, 45deg);
+    transform: rotate3d(0, 0, 1, 45deg);
     opacity: 0;
   }
 }

--- a/app/assets/stylesheets/annotations.css
+++ b/app/assets/stylesheets/annotations.css
@@ -472,7 +472,6 @@
 
 #pdf-doc .ann-box .score-box {
   float: none;
-  background-color: transparent;
   color: black;
   border-radius: 2px;
   font-size: 12px;

--- a/app/assets/stylesheets/beta.css
+++ b/app/assets/stylesheets/beta.css
@@ -469,7 +469,6 @@ table.announcements a {
 input[type="button"] {
   display: inline-block;
   margin: 2px;
-  color: #fff;
   cursor: pointer;
   text-decoration: none;
   padding: 5px;
@@ -526,8 +525,6 @@ div.navLinks .navbutton,
   cursor: pointer;
   color: #eee;
   position: relative;
-  margin: 0px;
-  padding: 2px;
   list-style: none;
   display: block;
   padding: 10px 15px;
@@ -641,7 +638,6 @@ li:hover .half {
   font-size: 12px;
   color: #888;
   padding: 15px;
-  background-color: #eaebed;
   background-color: #e5e5e5;
   background: -webkit-gradient(
     linear,
@@ -752,7 +748,6 @@ input.button {
   padding: 8px;
   margin: 2px;
   margin-bottom: 10px;
-  border: none;
   outline: none;
   color: #888;
   background-color: #f5f5f5;
@@ -767,7 +762,6 @@ input[type="submit"] {
   min-width: 70px;
   font-size: 12px;
   margin: 2px;
-  color: #fff;
   cursor: pointer;
   text-decoration: none;
   padding: 5px;
@@ -813,7 +807,6 @@ textarea {
   padding: 8px;
   margin: 2px;
   margin-bottom: 10px;
-  border: none;
   outline: none;
   color: #000;
   -webkit-border-radius: 5px;
@@ -992,7 +985,7 @@ th:hover a.graphme:hover {
   position: absolute;
   top: 0px;
   left: 0px;
-  z-axis: 100000;
+  z-index: 100000;
 }
 
 .blackbox {
@@ -1064,7 +1057,6 @@ table.prettyBorder th {
   font-size: 12px;
   color: #888;
   padding: 5px;
-  background-color: #eaebed;
   background-color: #e5e5e5;
   background: -webkit-gradient(
     linear,

--- a/app/assets/stylesheets/gradesheet.css.scss
+++ b/app/assets/stylesheets/gradesheet.css.scss
@@ -165,7 +165,6 @@ td.id {
 
 #grades .popover {
   cursor: auto;
-  display: none;
   color: #666;
   position: absolute;
   top: 0;

--- a/app/assets/stylesheets/mobile.css
+++ b/app/assets/stylesheets/mobile.css
@@ -181,7 +181,6 @@ img.select{
 	display:block;
 	margin:10px 15px;
 	text-align:center;
-	color:#FFF;
 	cursor:pointer;
 	text-decoration:none;
 	padding:15px;

--- a/app/controllers/annotations_controller.rb
+++ b/app/controllers/annotations_controller.rb
@@ -1,5 +1,5 @@
 # All modifications to the annotations are meant to be asynchronous and
-# thus this contorller only exposes javascript interfaces.
+# thus this controller only exposes javascript interfaces.
 #
 # Only people acting as instructors or CA's should be able to do anything
 # but view the annotations and since all of these mutate them, they are

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,7 +9,7 @@
 class ApplicationController < ActionController::Base
   helper :all # include all helpers, all the time
 
-  before_action :configure_permitted_paramters, if: :devise_controller?
+  before_action :configure_permitted_parameters, if: :devise_controller?
   before_action :maintenance_mode?
   before_action :run_scheduler
 
@@ -78,7 +78,7 @@ class ApplicationController < ActionController::Base
   def self.action_no_auth(action)
     skip_before_action :verify_authenticity_token, raise: false
     skip_before_action :authenticate_user!, raise: false
-    skip_before_action configure_permitted_paramters: [action]
+    skip_before_action configure_permitted_parameters: [action]
     skip_before_action maintenance_mode: [action]
     skip_before_action run_scheduler: [action]
 
@@ -90,7 +90,7 @@ class ApplicationController < ActionController::Base
 
 protected
 
-  def configure_permitted_paramters
+  def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_in) { |u| u.permit(:email) }
     devise_parameter_sanitizer.permit(:sign_up) do |u|
       u.permit(:email, :first_name, :last_name, :password, :password_confirmation)

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -46,7 +46,7 @@ class HomeController < ApplicationController
       redirect_to(controller: "course", course: @course.name,
                   action: "index") && return
     else
-      flash[:error] = "An internal error occured. Please contact the " \
+      flash[:error] = "An internal error occurred. Please contact the " \
                     "Autolab Development team at the " \
                     "contact link below"
       redirect_to(controller: "home", action: "index") && return

--- a/app/controllers/metrics_controller.rb
+++ b/app/controllers/metrics_controller.rb
@@ -47,9 +47,9 @@ class MetricsController < ApplicationController
     # (a json containing more info pertaining to violation)
     #
     # risk_conditions: dictionary of risk conditions found in watchlist instances,
-    # key being the risk_conditon_id each entry contains the condition_type
+    # key being the risk_condition_id each entry contains the condition_type
     #
-    # users: dicitonary of users found in watchlist instances, key being the course_user_datum_id
+    # users: dictionary of users found in watchlist instances, key being the course_user_datum_id
     # each entry contains the first name, last name and email
     #
     # params required would be the course name

--- a/app/controllers/schedulers_controller.rb
+++ b/app/controllers/schedulers_controller.rb
@@ -27,7 +27,7 @@ class SchedulersController < ApplicationController
       flash[:success] = "Scheduler created!"
       redirect_to(course_schedulers_path(@course)) and return
     else
-      flash[:error] = "Create failed. Pleaes check all fields."
+      flash[:error] = "Create failed. Please check all fields."
       redirect_to(action: "new") and return
     end
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -70,7 +70,7 @@ class UsersController < ApplicationController
   end
 
   # GET users/new
-  # only adminstrator and instructors are allowed
+  # only administrator and instructors are allowed
   action_auth_level :new, :instructor
   def new
     if current_user.administrator? || current_user.instructor?

--- a/app/views/assessments/_bulkGrade_initial.html.erb
+++ b/app/views/assessments/_bulkGrade_initial.html.erb
@@ -22,7 +22,7 @@ Choose a file that contain rows of problem scores or feedback in the following c
     <div class="radio">
       <%= f.label(:data_type_feedback) do %>
         <%= f.radio_button :data_type, "feedback" %>
-		<span>Feedback</span></br>
+		<span>Feedback</span><br>
 		<span class="info">use escape characters in place of newlines (\n) and tabs (\t)</span>
       <% end %>
     </div>

--- a/app/views/assessments/_popover.html.erb
+++ b/app/views/assessments/_popover.html.erb
@@ -12,7 +12,7 @@
 <% if s.filename %>
     <tr><th>Type</th><td><%= s.mime_type %></td></tr>
 <% end %>
-    <tr><th>Version</td><td class="version">
+    <tr><th>Version</th><td class="version">
         <% version = s.version == 0 ? "Unofficial" : s.version %>
         <%= version %>
         <% if @cud.instructor? %>
@@ -22,12 +22,12 @@
     <% if @cud.instructor? && @assessment.version_penalty? %>
       <tr><th>Version Over Threshold By</th><td><%= s.version_over_threshold_by %></tr>
     <% end %>
-    <tr><th>Submitted on</td><td><%= s.created_at %></td></tr>
+    <tr><th>Submitted on</th><td><%= s.created_at %></td></tr>
     <% if @cud.instructor? %>
         <tr><th>Used grace days</th><td><%= s.grace_days_used %></tr>
         <tr><th>+ Penalty late days</th><td><%= s.penalty_late_days %></td></tr>
         <tr><th>= Days late</th><td><%= s.days_late %></td></tr>
-        <tr><th>Grade Type</td><td>
+        <tr><th>Grade Type</th><td>
             <%= link_to grade_type_to_s(s.aud.grade_type),
 edit_course_assessment_assessment_user_datum_path(@course, @assessment, s.aud) %>
         </td></tr>

--- a/app/views/assessments/_submission_panel.html.erb
+++ b/app/views/assessments/_submission_panel.html.erb
@@ -67,7 +67,7 @@
       <div class="connect-github-account">
         <br />
         <label> Click below to connect your Github account </label> <br />
-        <%= link_to raw('<span class="btn primary">Connect</span>'), github_oauth_user_path(@cud.user) %> </br>
+        <%= link_to raw('<span class="btn primary">Connect</span>'), github_oauth_user_path(@cud.user) %> <br>
     </div>
   <% end %>
 </div>

--- a/app/views/assessments/edit.html.erb
+++ b/app/views/assessments/edit.html.erb
@@ -21,7 +21,6 @@
     <% [ "basic", "handin", "penalties", "problems", "advanced" ].each do |tab_name| %>
       <%= (tab_name == params[:active_tab]) ? tag(:li, {:class => "active tab"}) : tag(:li, class: :tab) %>
         <%= link_to tab_name.titleize, "#tab_#{tab_name}" %>
-      </li>
     <% end %>
     </ul>
   </div>

--- a/app/views/assessments/install_assessment.html.erb
+++ b/app/views/assessments/install_assessment.html.erb
@@ -50,7 +50,7 @@ Choose one of the following methods to install an assessment
   <% end %>
 </div>
 
-<!-- This selction is blocked off because it breaks things  -->
+<!-- This section is blocked off because it breaks things  -->
 <div class="section">
   <h4><li>Import from tarball</h4>
   <h5>You can import a tarball with the assessment directory.</h5>

--- a/app/views/assessments/show.html.erb
+++ b/app/views/assessments/show.html.erb
@@ -312,7 +312,7 @@
         locals: { submission: submission,
         download_access: download_access } %>
     <% end %>
-    <%= link_to "See all submissions", {:action => "history"} %></li>
+    <%= link_to "See all submissions", {:action => "history"} %>
 
   <% end %>
 </div>

--- a/app/views/gradebooks/student.html.erb
+++ b/app/views/gradebooks/student.html.erb
@@ -119,7 +119,7 @@
               <th>Category Average</th>
               <% if @course.grace_days > 0 %><th></th><% end %>
               <th></th>
-              <th class="cat_avg"><%= computed_score { @_cud.category_average cat, @cud } %></td>
+              <th class="cat_avg"><%= computed_score { @_cud.category_average cat, @cud } %></th>
             </tr>
           </table>
         </div>

--- a/app/views/submissions/annotationsHelp.html.erb
+++ b/app/views/submissions/annotationsHelp.html.erb
@@ -37,6 +37,6 @@
   <li>These annotations do not affect the actual scores on these problems.</li>
   <li>The annotation summary does not automatically update when you submit an annotation. Click the <em>Reload</em> button to reload the annotation summary.</li>
   <li>Points can be positive or negative.</li>
-  <li>Any line of code greator than 80 characters will wrap onto the next line.</li>
+  <li>Any line of code greater than 80 characters will wrap onto the next line.</li>
 </ul>
 </div>

--- a/docs/api-managing-authorized-apps.html
+++ b/docs/api-managing-authorized-apps.html
@@ -21,7 +21,6 @@ body .markdown-body
 }
 
 .markdown-body {
-  font-family: sans-serif;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
   color: #333333;
@@ -483,7 +482,6 @@ body .markdown-body
   display: block;
   width: 100%;
   overflow: auto;
-  word-break: normal;
   word-break: keep-all;
 }
 
@@ -655,7 +653,7 @@ body .markdown-body
 
 .markdown-body .admonition:before {
   content: "\f056\00a0";
-  color: 333;
+  color: #333;
 }
 
 .markdown-body .attention:before {
@@ -965,7 +963,6 @@ body .markdown-body
   }
 
   .markdown-body pre {
-    white-space: pre;
     white-space: pre-wrap;
     word-wrap: break-word;
   }

--- a/lib/modules/views/autograderDev.html.erb
+++ b/lib/modules/views/autograderDev.html.erb
@@ -31,7 +31,7 @@ end %>
   %></td>
 </tr>
 <tr>
-  <td colspan=2><%= submit_tag("Go Go Gadget Autograde") %></td></tr>
+  <td colspan=2><%= submit_tag("Go Go Gadget Autograde") %></td>
 </tr>
 </table>
 </form>

--- a/spec/factories/assessments.rb
+++ b/spec/factories/assessments.rb
@@ -8,7 +8,7 @@ FactoryBot.define do
     sequence(:name) { |n| "assessment_#{n}" }
     sequence(:display_name) { |n| "Assessment #{n}" }
     # We still want these so that assessments can have submissions
-    # but they should always be mocked unless we're explicity
+    # but they should always be mocked unless we're explicitly
     # testing file system interaction.
     handin_filename { |n| "handin_file_#{n}" }
     handin_directory { |n| "handin_directory_#{n}" }


### PR DESCRIPTION
## Description
- Fix general text typos
- Remove CSS properties that are later overridden (i.e. same property defined twice for the same selector)
- Fix HTML tags and remove extraneous tags

## Motivation and Context
General code clean-up based on RubyMine's problem analysis.

## How Has This Been Tested?
In the case of extraneous HTML tags, verified that pages appear the same (generally, Ruby seems to absorb extraneous `<li>` tags, so it is functionally the same).

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR