### PR TITLE
Disambiguate timezones

### DIFF
--- a/app/views/assessments/show.html.erb
+++ b/app/views/assessments/show.html.erb
@@ -161,7 +161,7 @@
               <% if @extension&.infinite? %>
                 <%= due_at_display @aud.due_at %>
               <% else %>
-                <span class="moment-date-time" data-format="MMMM Do YYYY, h:mm a z"><%= due_at_display @aud.due_at %></span>
+                <span class="moment-date-time" data-format="MMMM Do YYYY, h:mm a z [(UTC] Z[)]"><%= due_at_display @aud.due_at %></span>
               <% end %>
             </b>
         </p>
@@ -173,7 +173,7 @@
             <% if @extension&.infinite? %>
               <%= end_at_display(@aud.end_at false) %>
             <% else %>
-              <span class="moment-date-time" data-format="MMMM Do YYYY, h:mm a z"><%= end_at_display(@aud.end_at false) %></span>
+              <span class="moment-date-time" data-format="MMMM Do YYYY, h:mm a z [(UTC] Z[)]"><%= end_at_display(@aud.end_at false) %></span>
             <% end %>
           </b>
         </p>

--- a/app/views/assessments/show.html.erb
+++ b/app/views/assessments/show.html.erb
@@ -156,8 +156,7 @@
       <div class="card-content">
         <p class="valign-wrapper">
           <i class="material-icons valign">access_time</i>
-            &nbsp;&nbsp;Due
-            <% if @extension %>(with <% if @extension.infinite? %> infinite <% else %> <%= pluralize(@extension.days, "day") %> <% end %> extension)<% end %>:&nbsp;
+            &nbsp;&nbsp;Due<% if @extension %> (with <% if @extension.infinite? %> infinite <% else %> <%= pluralize(@extension.days, "day") %> <% end %> extension)<% end %>:&nbsp;
             <b>
               <% if @extension&.infinite? %>
                 <%= due_at_display @aud.due_at %>


### PR DESCRIPTION
## Description
- Add UTC offset to due date
- Address extra whitespace before colon

## Motivation and Context
The current use of timezone abbreviations can be ambiguous at times, leading to students misunderstanding the actual deadline.

Also, #1523 introduced a minor visual bug whereby there is an extra space before the colon when the user has no extensions.

Fixes #1369

## How Has This Been Tested?
- Ensured visual correctness when a student has an extension, and when a student does not
- Formatted time string now includes a "(UTC +/- xxxx)" at the end

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)