### PR TITLE
Ignore extra trailing newlines after score JSON

### DIFF
--- a/app/helpers/assessment_autograde_core.rb
+++ b/app/helpers/assessment_autograde_core.rb
@@ -364,7 +364,7 @@ module AssessmentAutogradeCore
         submissions.each do |submission|
           score = submission.scores.find_or_initialize_by(problem_id: problem.id)
           score.score = scores[key]
-          score.feedback = lines.join
+          score.feedback = feedback
           score.released = @autograde_prop.release_score
           score.grader_id = 0
           score.save!

--- a/app/helpers/assessment_autograde_core.rb
+++ b/app/helpers/assessment_autograde_core.rb
@@ -340,12 +340,12 @@ module AssessmentAutogradeCore
   #
   def saveAutograde(submissions, feedback)
     begin
-      lines = feedback.lines
+      lines = feedback.chomp.lines
       raise AutogradeError.new("The Autograder returned no output", :autograde_no_output) if lines.empty?
 
       # The last line of the output is assumed to be the
       # autoresult string from the autograding driver
-      autoresult = lines[lines.length - 1].chomp
+      autoresult = lines[lines.length - 1]
 
       if @assessment.overwrites_method?(:parseAutoresult)
         scores = @assessment.config_module.parseAutoresult(autoresult, true)

--- a/app/helpers/assessment_autograde_core.rb
+++ b/app/helpers/assessment_autograde_core.rb
@@ -340,7 +340,7 @@ module AssessmentAutogradeCore
   #
   def saveAutograde(submissions, feedback)
     begin
-      lines = feedback.chomp.lines
+      lines = feedback.rstrip.lines
       raise AutogradeError.new("The Autograder returned no output", :autograde_no_output) if lines.empty?
 
       # The last line of the output is assumed to be the


### PR DESCRIPTION
## Description
- Chomp before splitting lines

## Motivation and Context
Score parsing currently fails when there is more than one trailing newline after the score JSON returned by the Autograder. However, it is preferable for parsing to still work in that case.

Fixes #1528

## How Has This Been Tested?
- Autograding works when driver does not output any trailing newline
- Autograding works when driver outputs 1 trailing newline
- Autograding works when driver outputs >1 trailing newlines

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR