### PR TITLE
Hotfix for #1522

### DIFF
--- a/app/controllers/assessments_controller.rb
+++ b/app/controllers/assessments_controller.rb
@@ -284,7 +284,9 @@ class AssessmentsController < ApplicationController
 
     flash[:success] = "Successfully installed #{@assessment.name}."
     # reload the course config file
-    redirect_to([:reload, @course, @assessment]) && return
+    @course.reload_course_config
+
+    redirect_to([@course, @assessment]) && return
   end
 
   def assessmentInitialize(assignName)

--- a/app/controllers/assessments_controller.rb
+++ b/app/controllers/assessments_controller.rb
@@ -417,6 +417,14 @@ class AssessmentsController < ApplicationController
 
     @assessment.attachments.each(&:destroy)
 
+    # Delete config file copy in assessmentConfig
+    if File.exist? @assessment.config_file_path
+      File.delete @assessment.config_file_path
+    end
+    if File.exist? @assessment.config_backup_file_path
+      File.delete @assessment.config_backup_file_path
+    end
+
     name = @assessment.display_name
     @assessment.destroy # awwww!!!!
     flash[:success] = "The assessment #{name} has been deleted."

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -165,6 +165,14 @@ class CoursesController < ApplicationController
   # DELETE courses/:id/
   action_auth_level :destroy, :administrator
   def destroy
+    # Delete config file copy in courseConfig
+    if File.exist? @course.config_file_path
+      File.delete @course.config_file_path
+    end
+    if File.exist? @course.config_backup_file_path
+      File.delete @course.config_backup_file_path
+    end
+
     if @course.destroy
       flash[:success] = "Course destroyed."
     else

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -133,6 +133,10 @@ class Assessment < ApplicationRecord
     Rails.root.join("assessmentConfig", "#{course.name}-#{sanitized_name}.rb")
   end
 
+  def config_backup_file_path
+    config_file_path.sub_ext(".rb.bak")
+  end
+
   def config_module_name
     (sanitized_name + course.sanitized_name).camelize
   end
@@ -226,7 +230,9 @@ class Assessment < ApplicationRecord
                                 "module #{config_module_name}")
 
     # backup old config
-    File.rename(config_file_path, config_file_path.sub_ext(".rb.bak"))
+    if File.exist?(config_file_path)
+      File.rename(config_file_path, config_backup_file_path)
+    end
 
     # write to config_file_path
     File.open(config_file_path, "w") { |f| f.write config }

--- a/app/views/courses/edit.html.erb
+++ b/app/views/courses/edit.html.erb
@@ -27,10 +27,8 @@
 
 	<br>
 	<div class="row">
-		<div class="col s2 ">
-			<%= f.submit 'Save', { :class=> "btn primary" } %>
-		</div>
 		<div class="col s3">
+			<%= f.submit 'Save', { :class=> "btn primary" } %>
 			<% if current_user.administrator? %>
 			<%= link_to "Delete Course", course_path(@course), method: :delete,
 				data: {confirm: "Are you sure to destroy #{@course.full_name}?"}, class: "btn" %>


### PR DESCRIPTION
## Description
### Courses
- Upon course deletion, delete course config (and backup) from `courseConfig`. Note that the original config will still be preserved as course folder is not deleted from `courses`.
- Make `config_file_path` method public in `course.rb` and add `config_backup_file_path` method
- Add `source_config_file_path` method in `course.rb` (analogous to `assessment.rb#source_config_file_path`)
- Modify `reload_config_file` to check for config existence before attempting to make a backup
- Refactor `reload_config_file` as follows (functionally the same)
  - `src` > `source_config_file_path`
  - `dest` > `config_file_path`
  - `"Course#{course.camelize}"` > `"#{config_module_name}"`
  - Remove unneeded disabling of `Style/EvalWithLocation` lint check
- On edit course page, remove extraneous space between buttons
### Assessments
- Upon assessment deletion, delete assessment config (and backup) from `assessmentConfig`. Note that the original config will still be preserved as assessment folder is not deleted from `courses/<course>`.
- Add `config_backup_file_path` public method to `assessment.rb`
- Modify `load_config_file` to check for config existence before attempting to make a backup
- Modify `create` to directly reload course config via `@course.reload_course_config` rather than indirectly via `reload`

## Motivation and Context
Fixes an issue with #1522 during tarball assessment install whereby the code attempts to make a backup of a non-existent config file (as it has yet to be written).

Fixes an issue where creating an assessment via Assessment Builder leads to a 404 page (but assessment is created nevertheless). This is due to `reload` having been changed to a `POST` method during a previous CSRF fix PR.

Modifies the delete course and assessment methods to also delete the config copies from `courseConfig` and `assessmentConfig`. This is accordance with `assessments_controller.rb#uninstall`. Besides, the original course and assessment folders are preserved (under `courses`), so this is non-destructive. Practically, this doesn't change anything, but avoids making an unnecessary backup file if we create a course / assessment with the same name.

Finally, some refactoring was done in `course.rb` to increase readability of code.
## How Has This Been Tested?
### Courses
- Create new course (Manage Autolab > Create New Course)
- Observe course folder created under `courses` and course config created under `courseConfig` (but no backup file created)
- Reload course config (Manage Course > Reload Course Config File)
- Observe course config backup created under `courseConfig`, i.e. `<course>.rb.bak`
- Delete course (Mange Course > Edit Course > Delete Course)
- Observe course config and backup deleted from `courseConfig`, but course folder preserved under `courses`
### Assessments
#### From Tarball
- Create new assessment by importing `hello.tar`
- Observe assessment created under `courses/<course>` and assessment config created under `assessmentConfig` (but no backup file created)
- Reload config file
- Observe assessment config backup created under `assessmentConfig`, i.e. `<course>-<asst>.rb.bak`
- Delete assessment (Edit Assessment > Delete Assessment)
- Observe assessment config and backup deleted from `assessmentConfig`, but assessment folder preserved under `courses/<course>`
#### Import
- After the steps above, create new assessment from file system (there should be a `hello` option)
- Remaining observations are the same
#### Manual
- Create new assessment using assessment builder
- Remaining observations are the same

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR