### PR TITLE
Update devise_error_messages! calls

### DIFF
--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -1,7 +1,7 @@
 <h2>Resend confirmation instructions</h2>
 
 <%= form_for(resource, :as => resource_name, :url => confirmation_path(resource_name), :html => { :method => :post }) do |f| %>
-  <%= devise_error_messages! %>
+  <%= render "devise/shared/error_messages", resource: resource %>
 
   <div><%= f.label :email %><br />
   <%= f.email_field :email, :autofocus => true %></div>

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,7 +1,7 @@
 <h2>Change your password</h2>
 
 <%= form_for(resource, :as => resource_name, :url => password_path(resource_name), :html => { :method => :put }) do |f| %>
-  <%= devise_error_messages! %>
+	<%= render "devise/shared/error_messages", resource: resource %>
   <%= f.hidden_field :reset_password_token %>
 
 	<div class="input-field">

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,7 +1,7 @@
 <h2>Forgot your password?</h2>
 
 <%= form_for(resource, :as => resource_name, :url => password_path(resource_name), :html => { :method => :post }) do |f| %>
-  <%= devise_error_messages! %>
+	<%= render "devise/shared/error_messages", resource: resource %>
 
 	<div class="input-field" style="margin-bottom: 2rem;">
 		<%= f.email_field :email, :autofocus => true %>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,7 +1,7 @@
 <h2>Change password for <%= resource_name.to_s.humanize %></h2>
 
 <%= form_for(resource, :as => resource_name, :url => registration_path(resource_name), :html => { :method => :put }) do |f| %>
-  <%= devise_error_messages! %>
+	<%= render "devise/shared/error_messages", resource: resource %>
 
 	<div class="input-field">
 	  <%= f.email_field :email, readonly: true %>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,7 +1,7 @@
 <h2>Sign Up</h2>
 
 <%= form_for(resource, :as => resource_name, :url => registration_path(resource_name)) do |f| %>
-  <%= devise_error_messages! %>
+  <%= render "devise/shared/error_messages", resource: resource %>
 
 	<div class="input-field">
 	  <%= f.text_field :first_name, :autofocus => true %>

--- a/app/views/devise/unlocks/new.html.erb
+++ b/app/views/devise/unlocks/new.html.erb
@@ -1,7 +1,7 @@
 <h2>Resend unlock instructions</h2>
 
 <%= form_for(resource, :as => resource_name, :url => unlock_path(resource_name), :html => { :method => :post }) do |f| %>
-  <%= devise_error_messages! %>
+  <%= render "devise/shared/error_messages", resource: resource %>
 
   <div><%= f.label :email %><br />
   <%= f.email_field :email, :autofocus => true %></div>


### PR DESCRIPTION
## Description
- Replace calls to `devise_error_messages!` with `render "devise/shared/error_messages", resource: resource`

## Motivation and Context
**Message spotted in logs:**

DEPRECATION WARNING: [Devise] `DeviseHelper#devise_error_messages!` is deprecated and will be
removed in the next major version.

Devise now uses a partial under "devise/shared/error_messages" to display
error messages by default, and make them easier to customize. Update your
views changing calls from:

    <%= devise_error_messages! %>

to:

    <%= render "devise/shared/error_messages", resource: resource %>

To start customizing how errors are displayed, you can copy the partial
from devise to your `app/views` folder. Alternatively, you can run
`rails g devise:views` which will copy all of them again to your app.


## How Has This Been Tested?
- Attempt to sign up with password not matching / password too short (<8 chars), errors show up as usual (`registrations/new.html.erb`)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR