### PR TITLE
Reload fixes

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -121,15 +121,17 @@ class CoursesController < ApplicationController
       new_cud.instructor = true
 
       if new_cud.save
-        if @newCourse.reload_course_config
-          flash[:success] = "New Course #{@newCourse.name} successfully created!"
-          redirect_to(edit_course_path(@newCourse)) && return
-        else
+        begin
+          @newCourse.reload_course_config
+        rescue StandardError, SyntaxError
           # roll back course creation and instruction creation
           new_cud.destroy
           @newCourse.destroy
           flash[:error] = "Can't load course config for #{@newCourse.name}."
           render(action: "new") && return
+        else
+          flash[:success] = "New Course #{@newCourse.name} successfully created!"
+          redirect_to(edit_course_path(@newCourse)) && return
         end
       else
         # roll back course creation

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -83,7 +83,9 @@ class Course < ApplicationRecord
     end
 
     # Load course config
-    unless newCourse.reload_course_config
+    begin
+      newCourse.reload_course_config
+    rescue StandardError, SyntaxError
       # roll back course and CUD creation
       newCUD.destroy
       newCourse.destroy

--- a/app/views/assessments/reload.html.erb
+++ b/app/views/assessments/reload.html.erb
@@ -5,7 +5,7 @@
 </div>
 
 <div>
-  <%= link_to "Click here once you have fixed the above error", [:reload, @course, @assessment] %>
+  <%= link_to "Click here once you have fixed the above error", [:reload, @course, @assessment], data: {method: "post"} %>
 </div>
 
 <% # this rails function returns a <pre> containing the error as YAML %>

--- a/app/views/courses/reload.html.erb
+++ b/app/views/courses/reload.html.erb
@@ -5,7 +5,7 @@
 </div>
 
 <div>
-  <%= link_to "Click here once you have fixed the above error", [:reload, @course] %>
+  <%= link_to "Click here once you have fixed the above error", [:reload, @course], data: {method: "post"} %>
 </div>
 
 <% # this rails function returns a <pre> containing the error as YAML %>

--- a/app/views/home/error.html.erb
+++ b/app/views/home/error.html.erb
@@ -4,20 +4,20 @@
 
 <% if flash[:error] %><p><b><%= flash[:error] %></b></p><% end %>
 
-<p><b>Oops!</b> Autolab seems to have done something wrong.  We have been notified about this and will look into it. If you would like to file a Bug Report, you may email us at <a href="mailto:<%= Rails.configuration.school['support_email'] %>"><%= Rails.configuration.school['support_email'] %></a> or open an issue in our <a href="https://github.com/autolab/Autolab/issues/">issue tracker</a> on GitHub.</p>
+<p><b>Oops!</b> Autolab seems to have done something wrong. We have been notified about this and will look into it. If you would like to file a Bug Report, you may email us at <a href="mailto:<%= Rails.configuration.school['support_email'] %>"><%= Rails.configuration.school['support_email'] %></a> or open an issue in our <a href="https://github.com/autolab/Autolab/issues/">issue tracker</a> on GitHub.</p>
 
 <%= image_tag "DonkeyKong.jpg", width: '200px' %>
 
 <% if @error then %>
   <br><br>
-  <p><i>Remember that if you modify any config files, you'll need to  reload them for the changes to take effect.</i><br>
+  <p><i>Remember that if you modify any config files, you'll need to reload them for the changes to take effect.</i><br>
     <% if @course_name then %>
       <b><%= link_to "Reload Course Config",
-              reload_course_path(name: @course_name) %></b><br>
+              reload_course_path(name: @course_name), data: {method: "post"} %></b><br>
       <% if @assessment_name then %>
         <b><%= link_to "Reload Assessment Config",
                 reload_course_assessment_path(course_name: @course_name,
-                  name: @assessment_name) %></b>
+                  name: @assessment_name), data: {method: "post"} %></b>
       <% end %>
     <% end %>
   </p>


### PR DESCRIPTION
## Description
- Updated error pages to correctly use `POST` for reload links
- Changed `if ... else ...` blocks using `reload_course_config` to use `begin ... rescue ... else ... end` instead.

## Motivation and Context
#1522 changed the semantics of `reload_course_config`: instead of returning `true` or `false`, it now returns nothing but throws an exception upon a `SyntaxError` in the config file. However, some parts of the code have yet to be updated to reflect this.

#1521 also changed the `:reload` methods from `GET` to `POST`, however this was not updated on several error pages.

## How Has This Been Tested?
TBC after #1522 merged.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR