### PR TITLE
Fix faulty logic for when Github integration is not configured/misconfigured

### DIFF
--- a/app/models/github_integration.rb
+++ b/app/models/github_integration.rb
@@ -132,17 +132,17 @@ class GithubIntegration < ApplicationRecord
                                  client_secret: Rails.configuration.x.github.client_secret)
 
     begin
-      limit = client.rate_limit!.limit
+      limit = client.rate_limit!
     rescue StandardError
-      limit = 0
+      limit = { limit: 0 }
     end
-    limit >= 1000
+    limit
   end
 
   ##
   # Returns whether Autolab is connected to Github
   def self.connected
-    check_github_authorization
+    check_github_authorization.limit > 1000
   end
 
 private

--- a/app/models/github_integration.rb
+++ b/app/models/github_integration.rb
@@ -125,23 +125,24 @@ class GithubIntegration < ApplicationRecord
 
   ##
   # Checks whether a valid Github client ID and secret is passed in
-  # If so, current rate limit information is returned; else
-  # nil is returned
+  # If so, current rate limit should be in the order of thousands;
+  # else it is 60 (as of June 2022)
   def self.check_github_authorization
     client = Octokit::Client.new(client_id: Rails.configuration.x.github.client_id,
                                  client_secret: Rails.configuration.x.github.client_secret)
 
     begin
-      client.rate_limit!
+      limit = client.rate_limit!.limit
     rescue StandardError
-      nil
+      limit = 0
     end
+    limit >= 1000
   end
 
   ##
   # Returns whether Autolab is connected to Github
   def self.connected
-    !check_github_authorization.nil?
+    check_github_authorization
   end
 
 private

--- a/app/views/assessments/_submission_panel.html.erb
+++ b/app/views/assessments/_submission_panel.html.erb
@@ -5,10 +5,9 @@
   <div class="error file-error" id="flash_error" style="background: white;display: none;">
     There was an error processing your file, please try adding it again.
   </div>
-  <% if @assessment.github_submission_enabled %>
+  <% if @assessment.github_submission_enabled and GithubIntegration.connected %>
     <div class="ui pointing secondary tabular menu">
       <a class="item active" data-tab="upload">Upload</a>
-      <!-- TODO should only show if GithubIntegration.connected is true -->
       <a class="item" data-tab="github">Github</a>
     </div>
   <% end %>


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When no Github application IDs and secrets are passed in, it seems like Github still gives a token rate limit of 60 requests per hour, which differs from the old logic which assumed that an exception would be thrown. 

My guess is that either:
1. We only tested previously with bad configs instead of missing configs, which would have thrown an error (more likely);
2. Github changed its behavior of what it does when getting empty credentials. 

The faulty logic meant that the `Connect to Github` option was always available even when Github is not configured, leading to confusion. This PR also fixes a major TODO that was overlooken which resulted in the wrong submission dialogue being rendered in the submission page when Github has not been configured.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes bug mentioned above

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Without configuring Git:

![DeepinScreenshot_select-area_20220601213047](https://user-images.githubusercontent.com/9707110/171529055-ea6b9522-9780-48c0-a6e5-42a37c96e423.png)
![after_fix](https://user-images.githubusercontent.com/9707110/171529057-073728be-34e9-4750-8dbf-5308b4e30a77.png)

With Git configuration:
![DeepinScreenshot_select-area_20220601213120](https://user-images.githubusercontent.com/9707110/171529079-89ea52dc-182e-41e9-b859-258355f16a36.png)
![DeepinScreenshot_select-area_20220601213111](https://user-images.githubusercontent.com/9707110/171529081-2d84f6b0-0d39-4296-b8c1-9ab44520c51d.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR

## Other issues / help required
<!--- Do you have any other relevant issues / questions? --->
<!--- For example, if you require assistance for a certain part of your PR --->
<!--- or are facing specific issues while creating the pull request that you would like to highlight --->

If unsure, feel free to submit first and we'll help you along.
