### PR TITLE
Fix XSS in metrics watchlist

### DIFF
--- a/app/assets/javascripts/watchlist.js
+++ b/app/assets/javascripts/watchlist.js
@@ -1,6 +1,14 @@
 // Loads all Semantic javascripts
 //= require semantic-ui
 
+const escapeHtml = (unsafe) => {
+  return unsafe.replaceAll('&', '&amp;')
+               .replaceAll('<', '&lt;')
+               .replaceAll('>', '&gt;')
+               .replaceAll('"', '&quot;')
+               .replaceAll("'", '&#039;');
+}
+
 // watchlist api endpoints
 const watchlist_endpoints = {
 	update: 'update_watchlist_instances',
@@ -23,8 +31,8 @@ function get_name_email_html(name, email) {
       <div class="ui checkbox select_single">
         <input type="checkbox"/>
         <label>
-          <p class="name_label"> ${name} </p>
-          <p class="email_label"> ${email} </p>
+          <p class="name_label"> ${escapeHtml(name)} </p>
+          <p class="email_label"> ${escapeHtml(email)} </p>
         </label>
       </div>`;
 }


### PR DESCRIPTION
## Description
Escape student names and emails on the metrics watchlist page.

## Motivation and Context
Currently, student names and emails are not escaped on the metrics watchlist page. This can possibly lead to XSS attacks.

## How Has This Been Tested?
Create user with a name containing `<img src="a" onerror="alert(document.cookie)">`. Make user use a grace day and apply the grace day metric to get user to show up on watchlist.

Before changes
<img width="786" alt="Screen Shot 2022-06-01 at 21 51 53" src="https://user-images.githubusercontent.com/9074856/171530507-8fd29d3f-5583-4e65-8958-54dff3897a08.png">
After changes
<img width="787" alt="Screen Shot 2022-06-01 at 21 51 59" src="https://user-images.githubusercontent.com/9074856/171530511-3a8ac654-15ac-4833-b44c-94f2235081c5.png">
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR
