### PR TITLE
Update github_integration.md

### DIFF
--- a/docs/installation/github_integration.md
+++ b/docs/installation/github_integration.md
@@ -25,14 +25,14 @@ In order to setup Github submission, you will first need to create a Github Appl
 
 2. If you do not have a `.env` file in your Autolab root yet (it may not be present on older installations), create it by running the following script from the Autolab root directory:
 
-    :::bash
-    ./bin/initialize_secrets.sh
+        :::bash
+    	./bin/initialize_secrets.sh
 
 3. Open up `.env` in your favorite editor, and update `GITHUB_CLIENT_ID` and `GITHUB_CLIENT_SECRET` to use the client ID and client secrets generated previously:
 
-    :::bash
-	GITHUB_CLIENT_ID=replace_with_your_client_ID
-	GITHUB_CLIENT_SECRET=replace_with_your_client_secret
+        :::bash
+        GITHUB_CLIENT_ID=replace_with_your_client_ID
+        GITHUB_CLIENT_SECRET=replace_with_your_client_secret
 
 ## Verifying Github Integration
 In order to verify whether your deployment has been setup correctly,


### PR DESCRIPTION
## Description
Fix indentation of code block.

## Motivation and Context
Code block was incorrectly indented (has to be exactly 8 spaces), leading to `:::bash` displaying verbatim.

## How Has This Been Tested?
Tested locally using `mkdocs`.

Before
<img width="953" alt="Screen Shot 2022-06-02 at 21 28 07" src="https://user-images.githubusercontent.com/9074856/171769379-ee20ded4-eeb0-41d7-b02a-4868622bd59d.png">

After
<img width="967" alt="Screen Shot 2022-06-02 at 21 27 59" src="https://user-images.githubusercontent.com/9074856/171769371-f7ea19cd-7622-4c13-a04f-d62ea39ab4f4.png">


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [x] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [x] I have updated the documentation accordingly, included in this PR