### PR TITLE
Fix user dropdown on assessments view

### DIFF
--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -10,9 +10,9 @@
         edge: 'right'
       });
 
-      $('.dropdown-trigger').dropdown({
-        coverTrigger: false
-      });
+      // Using this over jQuery approach to avoid any issues when other libraries override .dropdown()
+      var elems = document.querySelectorAll('.dropdown-trigger');
+      M.Dropdown.init(elems, { coverTrigger: false });
     });
   </script>
 


### PR DESCRIPTION
## Description
When initializing user dropdown, use vanilla js `M.Dropdown.init(elems, options)` over jQuery `.dropdown()`.

## Motivation and Context
Currently, on the assessment view page, `git_submission.js` and `handin.js` have the line `require semantic-ui`, which imports all semantic-ui javascript, particularly `semantic-ui/dropdown`. However, this overrides the original materialize dropdown method, causing the user dropdown to not work. The same problem occurs on the metrics watchlist page.

To remedy this and future proof the code, switch to the vanilla js method of initializing the dropdown.

## How Has This Been Tested?
On assessment view page (and a variety of other pages), user dropdown works as intended.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR