### PR TITLE
Hide unreleased assessment attachments

### DIFF
--- a/app/controllers/assessments_controller.rb
+++ b/app/controllers/assessments_controller.rb
@@ -74,7 +74,16 @@ class AssessmentsController < ApplicationController
     @attachments = if @cud.instructor?
                      @course.attachments
                    else
-                     @course.attachments.where(released: true)
+                     # Attachments that are released, and whose related assessment is also released
+                     course_attachments = @course.attachments
+                                                 .where(released: true)
+                                                 .left_outer_joins(:assessment)
+
+                     # Either assessment_id is nil (i.e. course attachment)
+                     # Or the assessment has started
+                     course_attachments.where(assessment_id: nil)
+                                       .or(course_attachments.where("assessments.start_at < ?",
+                                                                    Time.current))
                    end
   end
 


### PR DESCRIPTION
## Description
- Change logic to only display attachments whose corresponding assessments are released (note that we use a `left_outer_join` in order to include attachments that belong to the course, since they will have an `assessment_id` of `nil`)

## Motivation and Context
Currently, released attachments of unreleased assessments are viewable to students (but not downloadable). While not a major issue, this is not desirable if e.g. the instructor wants to mark certain attachments as released ahead of time but does not want students to see their names.

Fixes #1527

## How Has This Been Tested?
Created released and unreleased attachments for course, unreleased assessment (Homework 0), and released assessment (Homework 1). Student should only be able to see released attachments for course and Homework 1.

As instructor:
<img width="1012" alt="Screen Shot 2022-06-04 at 02 02 25" src="https://user-images.githubusercontent.com/9074856/171987086-c864486e-31cc-44d2-9eb7-e82fe7c05371.png">

As student:
<img width="998" alt="Screen Shot 2022-06-04 at 02 02 41" src="https://user-images.githubusercontent.com/9074856/171987089-670edd7a-249f-49e8-88cf-a03df6566ef2.png">

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR

## Other issues / help required

Unsure if syntax follows best practices.
