### PR TITLE
Fix Flash links

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -19,7 +19,6 @@ class ApplicationController < ActionController::Base
   before_action :authenticate_for_action
   before_action :update_persistent_announcements
   before_action :set_breadcrumbs
-  before_action :mark_flash_html_safe
 
   rescue_from ActionView::MissingTemplate do |_exception|
     redirect_to("/home/error_404")
@@ -310,19 +309,6 @@ protected
                     else
                       (view_context.link_to @course.full_name, [@course], id: "courseTitle")
                     end
-  end
-
-  # To display flash messages verbatim, set flash[:html_safe] = true
-  # Might want to consider separate flags for different flash types
-  def mark_flash_html_safe
-    return unless flash[:html_safe]
-
-    flash.delete(:html_safe)
-    flash.each do |name, _|
-      # rubocop:disable Rails/OutputSafety
-      flash.now[name] = flash[name].html_safe
-      # rubocop:enable Rails/OutputSafety
-    end
   end
 
   def pluralize(count, singular, plural = nil)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -19,6 +19,7 @@ class ApplicationController < ActionController::Base
   before_action :authenticate_for_action
   before_action :update_persistent_announcements
   before_action :set_breadcrumbs
+  before_action :mark_flash_html_safe
 
   rescue_from ActionView::MissingTemplate do |_exception|
     redirect_to("/home/error_404")
@@ -309,6 +310,19 @@ protected
                     else
                       (view_context.link_to @course.full_name, [@course], id: "courseTitle")
                     end
+  end
+
+  # To display flash messages verbatim, set flash[:html_safe] = true
+  # Might want to consider separate flags for different flash types
+  def mark_flash_html_safe
+    return unless flash[:html_safe]
+
+    flash.delete(:html_safe)
+    flash.each do |name, _|
+      # rubocop:disable Rails/OutputSafety
+      flash.now[name] = flash[name].html_safe
+      # rubocop:enable Rails/OutputSafety
+    end
   end
 
   def pluralize(count, singular, plural = nil)

--- a/app/controllers/assessment/autograde.rb
+++ b/app/controllers/assessment/autograde.rb
@@ -194,6 +194,7 @@ module AssessmentAutograde
         if @cud.instructor?
           link = (view_context.link_to "Autograder Settings", [:edit, course, assessment, :autograder])
           flash[:error] += " Visit #{link} to set the autograding properties."
+          flash[:html_safe] = true
         else
           flash[:error] += " Please contact your instructor."
         end
@@ -207,6 +208,7 @@ module AssessmentAutograde
         if @cud.instructor?
           link = (view_context.link_to "Autograder Settings", [:edit, course, assessment, :autograder])
           flash[:error] += " (Verify the autograding properties at #{link}.)\nErrorMsg: " + e.additional_data
+          flash[:html_safe] = true
         end
       when :missing_autograder_file
         flash[:error] = "One or more files are missing in the server. Please contact the instructor. The missing files are: " + e.additional_data
@@ -219,8 +221,8 @@ module AssessmentAutograde
 
     link = "<a href=\"#{url_for(controller: 'jobs', action: 'getjob', id: job)}\">Job ID = #{job}</a>"
     flash[:success] = ("Submitted file #{submissions[0].filename} (#{link}) for autograding." \
-      " Refresh the page to see the results.").html_safe
-
+      " Refresh the page to see the results.")
+    flash[:html_safe] = true
     job
   end
 

--- a/app/controllers/assessment/autograde.rb
+++ b/app/controllers/assessment/autograde.rb
@@ -116,7 +116,7 @@ module AssessmentAutograde
       flash[:success] = ("Regrading #{link}")
     end
 
-    # For both :success and :failure
+    # For both :success and :error
     flash[:html_safe] = true
 
     redirect_to([@course, @assessment, :submissions]) && return
@@ -163,7 +163,7 @@ module AssessmentAutograde
       flash[:success] = ("Regrading the most recent submissions from #{link}")
     end
 
-    # For both :success and :failure
+    # For both :success and :error
     flash[:html_safe] = true
 
     redirect_to([@course, @assessment, :submissions]) && return

--- a/app/controllers/assessment/autograde.rb
+++ b/app/controllers/assessment/autograde.rb
@@ -116,6 +116,9 @@ module AssessmentAutograde
       flash[:success] = ("Regrading #{link}")
     end
 
+    # For both :success and :failure
+    flash[:html_safe] = true
+
     redirect_to([@course, @assessment, :submissions]) && return
   end
 
@@ -159,6 +162,9 @@ module AssessmentAutograde
       link = "<a href=\"#{url_for(controller: 'jobs')}\">#{pluralize(success_jobs, "student")}</a>"
       flash[:success] = ("Regrading the most recent submissions from #{link}")
     end
+
+    # For both :success and :failure
+    flash[:html_safe] = true
 
     redirect_to([@course, @assessment, :submissions]) && return
   end

--- a/app/controllers/assessment/autograde.rb
+++ b/app/controllers/assessment/autograde.rb
@@ -98,8 +98,9 @@ module AssessmentAutograde
       end
     end
 
-    if failed_list.length > 0
-      flash[:error] = "Warning: Could not regrade #{failed_list.length} submission(s):<br>"
+    failure_jobs = failed_list.length
+    if failure_jobs > 0
+      flash[:error] = "Warning: Could not regrade #{pluralize(failure_jobs, "submission")}:<br>"
       failed_list.each do |failure|
         if failure[:error].error_code == :nil_submission
           flash[:error] += "Unrecognized submission ID<br>"
@@ -109,10 +110,10 @@ module AssessmentAutograde
       end
     end
 
-    success_jobs = submission_ids.size - failed_list.length
+    success_jobs = submission_ids.size - failure_jobs
     if success_jobs > 0
-      link = "<a href=\"#{url_for(controller: 'jobs')}\">#{success_jobs} submission</a>"
-      flash[:success] = ("Regrading #{link}").html_safe
+      link = "<a href=\"#{url_for(controller: 'jobs')}\">#{pluralize(success_jobs, "submission")}</a>"
+      flash[:success] = ("Regrading #{link}")
     end
 
     redirect_to([@course, @assessment, :submissions]) && return
@@ -141,8 +142,9 @@ module AssessmentAutograde
       end
     end
 
-    if failed_list.length > 0
-      flash[:error] = "Warning: Could not regrade #{failed_list.length} submission(s):<br>"
+    failure_jobs = failed_list.length
+    if failure_jobs > 0
+      flash[:error] = "Warning: Could not regrade #{pluralize(failure_jobs, "submission")}:<br>"
       failed_list.each do |failure|
         if failure[:error].error_code == :nil_submission
           flash[:error] += "Unrecognized submission ID<br>"
@@ -152,10 +154,10 @@ module AssessmentAutograde
       end
     end
 
-    success_jobs = last_submissions.size - failed_list.length
+    success_jobs = last_submissions.size - failure_jobs
     if success_jobs > 0
-      link = "<a href=\"#{url_for(controller: 'jobs')}\">#{success_jobs} students</a>"
-      flash[:success] = ("Regrading the most recent submissions from #{link}").html_safe
+      link = "<a href=\"#{url_for(controller: 'jobs')}\">#{pluralize(success_jobs, "student")}</a>"
+      flash[:success] = ("Regrading the most recent submissions from #{link}")
     end
 
     redirect_to([@course, @assessment, :submissions]) && return

--- a/app/controllers/assessment/grading.rb
+++ b/app/controllers/assessment/grading.rb
@@ -164,6 +164,7 @@ private
     rescue CSV::MalformedCSVError => e
       flash[:error] = "Failed to parse CSV -- make sure the grades " \
                       "are formatted correctly: <pre>#{e}</pre>"
+      flash[:html_safe] = true
       return false, []
     end
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -68,7 +68,6 @@
 
         <!-- Flashes -->
         <div id="flashes">
-          <!-- Ruby escapes msg by default, no need for sanitization -->
           <% flash.each do |name, msg| %>
             <% if name == "roster_error" %>
               <div class="error" id="flash_error">
@@ -76,6 +75,8 @@
                             locals: {roster_errors: msg} %>
               </div>
             <% else %>
+              <%# msg is escaped by default %>
+              <%# if you must output raw html, set flash[:html_safe] = true in controller %>
               <%= content_tag :div, msg, id: "flash_#{name}",
                   class: "#{name}" %>
             <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -68,6 +68,10 @@
 
         <!-- Flashes -->
         <div id="flashes">
+          <%# msg is escaped by default %>
+          <%# if you must output raw html, set flash[:html_safe] = true in controller %>
+          <% html_safe = flash[:html_safe] %>
+          <% flash.delete(:html_safe) %>
           <% flash.each do |name, msg| %>
             <% if name == "roster_error" %>
               <div class="error" id="flash_error">
@@ -75,8 +79,7 @@
                             locals: {roster_errors: msg} %>
               </div>
             <% else %>
-              <%# msg is escaped by default %>
-              <%# if you must output raw html, set flash[:html_safe] = true in controller %>
+              <% msg = msg.html_safe if html_safe %>
               <%= content_tag :div, msg, id: "flash_#{name}",
                   class: "#{name}" %>
             <% end %>

--- a/app/views/layouts/home.html.erb
+++ b/app/views/layouts/home.html.erb
@@ -45,7 +45,8 @@
 
         <!-- Flashes -->
         <div id="flashes">
-          <!-- Ruby escapes msg by default, no need for sanitization -->
+          <%# msg is escaped by default %>
+          <%# if you must output raw html, set flash[:html_safe] = true in controller %>
           <% flash.each do |name, msg| %>
             <%= content_tag :div, msg, id: "flash_#{name}",
                 class: "#{name}" %>

--- a/app/views/layouts/home.html.erb
+++ b/app/views/layouts/home.html.erb
@@ -47,7 +47,10 @@
         <div id="flashes">
           <%# msg is escaped by default %>
           <%# if you must output raw html, set flash[:html_safe] = true in controller %>
+          <% html_safe = flash[:html_safe] %>
+          <% flash.delete(:html_safe) %>
           <% flash.each do |name, msg| %>
+            <% msg = msg.html_safe if html_safe %>
             <%= content_tag :div, msg, id: "flash_#{name}",
                 class: "#{name}" %>
           <% end %>


### PR DESCRIPTION
## Description
- Pluralize some strings using `pluralize`
- Add `flash[:html_safe] = true` whenever the flash should be displayed verbatim (if we know the whole string is safe and have a link that we want to display)
- Add logic on frontend to set `html_safe` whenever `flash[:html_safe]` is set, hence not escaping `msg`

## Motivation and Context
Currently, there appears to be some attempts to mark flashes as `html_safe` in the controllers (from ~2015)
- In the past, marking a string as `html_safe` in the controller would ensure the flash message would not be escaped in the view
- However, since Rails 4.1, the serialization method was changed, so HTML safety was no longer preserved ([source](https://groups.google.com/g/rubyonrails-core/c/z52zgDgUmbs))
- That said, this seems redundant given the view code of the time, which marked everything as `html_safe` (a terrible idea)

Since #216, `sanitize(msg)` was used as an alternate way to mark messages as `html_safe`. This prevents XSS attacks, but can lead to unexpected styling since tags are stripped but not escaped. This led to the removal of `sanitize` in #1532 altogether, to ensure that emails always appeared as expected.

However, this meant that some legitimate uses of links in flashes would not show up properly. To counteract this, I am proposing the use of a "flag" via `flash[:html_safe]` that we can set to `true` should we need a string to display verbatim. Otherwise, by default, Rails will escape the flash message as usual.

## How Has This Been Tested?
- Batch regrade submissions, observe that link appears as expected (`Regrading x submissions`) -- note "submission" is conditionally pluralized
- Regrade all submissions, observe that link appears as expected (`Regrading the most recent submissions from x students`) -- note "student" is conditionally pluralized
- Make a submission, observe that link appears as expected (`Submitted file <user>_<ver>_<file>.c (Job ID = xx) for autograding. Refresh the page to see the results.`)
- A variety of escaped flashes display as usual (e.g. sudo, unsudo)
- Also check that escaping works (e.g. sudo to a user whose email contains html -- requires inspect element to remove `type=email` from element)
  - For example, add user to course with email `<strong>name</strong>@bademail.com` (bypassing validation by removing type from email field)
  - Then, sudo to the user (also removing type from email field)
- The other code paths are analogous and do not require special testing

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR
