### PR TITLE
Add CNAME to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,8 +93,6 @@ mkdocs gh-deploy
 
 This will build the site using the branch you are currently in (hopefully `master`), place the built HTML files into the `gh-pages` branch, and push to GitHub. GitHub will then automatically deploy the new content in `gh-pages`.
 
-Finally, go to the repository Settings page, and set `docs.autolabproject.com` under the `Custom domain` field.
-
 ## Contributing
 
 We encourage you to contribute to Autolab! Please check out the

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+docs.autolabproject.com


### PR DESCRIPTION
## Description
- Add CNAME file to docs folder
- Remove instruction to set custom domain

## Motivation and Context
Previously, deploying Autolab docs required setting the custom domain field afterward, which was error-prone. By adding the CNAME file to the docs folder (as noted in https://www.mkdocs.org/user-guide/deploying-your-docs/ under "Custom Domains"), the CNAME file will now be automatically created upon deployment. Hence, the README has also been updated to reflect this.

## How Has This Been Tested?
Redeployed docs with `--no-history` flag set (to force a "refresh") and ensured that CNAME file was created as desired. 

Noted that output of command includes: `INFO     -  Based on your CNAME file, your documentation should be available shortly at: http://docs.autolabproject.com`

Checked that online docs loads as usual.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [x] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [x] I have updated the documentation accordingly, included in this PR