### PR TITLE
Improve flash styles

### DIFF
--- a/app/assets/stylesheets/style.css.scss
+++ b/app/assets/stylesheets/style.css.scss
@@ -1156,16 +1156,19 @@ div.center {
   margin-top: 8px;
 }
 
-#flash_alert.alert,
-#flash_error.error,
-#flash_notice {
-  color: #ce4844;
+#flash_error,
+#flash_notice,
+#flash_success {
   padding: 10px;
   margin-bottom: 0px;
   border-radius: 3px;
   border: 1px solid #eee;
-  border-left: 5px solid #ce4844;
   font-weight: 500;
+}
+
+#flash_error {
+  color: #ce4844;
+  border-left: 5px solid #ce4844;
 }
 
 #flash_error table {
@@ -1177,21 +1180,14 @@ div.center {
   margin: 0px;
 }
 
-#flash_alert.success,
-#flash_success.success,
-#flash_notice.success {
-  color: green;
-  padding: 10px;
-  margin-bottom: 0px;
-  border-radius: 3px;
-  border: 1px solid #eee;
-  border-left: 5px solid green;
-  font-weight: 500;
-}
-
 #flash_notice {
   color: #1b809e;
   border-left: 5px solid #1b809e;
+}
+
+#flash_success {
+  color: green;
+  border-left: 5px solid green;
 }
 
 .attachments,

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -179,7 +179,7 @@ protected
 
     when :admin_created
       @cud = cud
-      flash[:info] = "Administrator user added to course"
+      flash[:notice] = "Administrator user added to course"
 
     when :admin_creation_error
       flash[:error] = "Error adding administrator #{current_user.email} to course"

--- a/app/controllers/assessment/autograde.rb
+++ b/app/controllers/assessment/autograde.rb
@@ -59,7 +59,7 @@ module AssessmentAutograde
 
     unless @assessment.has_autograder?
       # Not an error, this behavior was specified!
-      flash[:info] = "This submission is not autogradable"
+      flash[:notice] = "This submission is not autogradable"
       redirect_to([:history, @course, @assessment, cud_id: @effective_cud.id]) && return
     end
 

--- a/app/controllers/assessment/svn.rb
+++ b/app/controllers/assessment/svn.rb
@@ -37,7 +37,7 @@ module AssessmentSVN
       aud.save!
     end
 
-    flash[:info] = "Repositories were imported successfully"
+    flash[:notice] = "Repositories were imported successfully"
     redirect_to(action: :admin_svn) && return
   end
 

--- a/app/controllers/scoreboards_controller.rb
+++ b/app/controllers/scoreboards_controller.rb
@@ -18,7 +18,7 @@ class ScoreboardsController < ApplicationController
     end
     begin
       @scoreboard.save!
-      flash[:info] = "Scoreboard Created"
+      flash[:notice] = "Scoreboard Created"
     rescue ActiveRecord::RecordInvalid => e
       flash[:error] = "Unable to create scoreboard: #{e.message}"
     end
@@ -151,7 +151,7 @@ class ScoreboardsController < ApplicationController
   action_auth_level :destroy, :instructor
   def destroy
     if @scoreboard.destroy
-      flash[:info] = "Destroyed!"
+      flash[:notice] = "Destroyed!"
     else
       flash[:error] = "Unable to destroy scoreboard"
     end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -275,7 +275,7 @@ class UsersController < ApplicationController
       gh_integration.destroy
       flash[:success] = "Successfully disconnected from Github"
     else
-      flash[:info] = "Github not connected, revocation unnecessary"
+      flash[:notice] = "Github not connected, revocation unnecessary"
     end
     (redirect_to user_path(id: @user.id)) && return
   end


### PR DESCRIPTION
## Description
- Change all occurrences of `:info` to `:notice`
- Remove unused `#flash_alert.alert` style
- Removed unused `#flash_alert.success` and `#flash_notice.success` styles
- Made flash style code DRY-er

## Motivation and Context
Currently, `flash[:info]` is used in several locations throughout the codebase despite there being no style for `:info`, but only `:notice`. Hence, this PR migrates all uses of `:info` to `:notice`.

Additionally, some style code is unused, such as `#flash_alert.alert` (`:alert` is not used anywhere), and `#flash_alert.success` + `#flash_notice.success` (with the current flash code, the class always mirrors the id). Hence such styles are removed in this PR.

This PR also extracts the styling common to the different flash types to improve DRY-ness of code.

## How Has This Been Tested?
- Grepped codebase to ensure only `:error`, `:notice`, `:success` are used (and not `:alert` nor `:info`). Note that `:roster_error` and `:html_safe` are used for custom logic.
- In `application.html.erb`, added the following code under `div#flashes` and opened home page to observe that flashes were correctly rendered.
```erb
<%= content_tag :div, "success", id: "flash_success", class: "success" %>
<%= content_tag :div, "error", id: "flash_error", class: "error" %>
<%= content_tag :div, "notice", id: "flash_notice", class: "notice" %>
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR