### PR TITLE
Update ctags installation instructions

### DIFF
--- a/docs/installation/one-click.md
+++ b/docs/installation/one-click.md
@@ -101,11 +101,11 @@ You can run Autolab with or without HTTPS encryption. We strongly recommend you 
 
 Here are a few options to get the SSL certificate and key:
 
-1.  Go through your school/organization
+1. Go through your school/organization
 
     Many universities have a program whereby they'll grant SSL certificates to students and faculty for free. Some of these programs require you to be using a school-related domain name, but some don't. You should be able to find out more information from your school's IT department.
 
-2.  Use paid service: SSLmate
+2. Use paid service: SSLmate
 
     You can follow this [simple guide](https://sslmate.com/help/getting_started) to get your paid SSL with [SSLMate](https://sslmate.com/) in the simplest way.
 
@@ -125,17 +125,17 @@ Autolab uses email for various features, include sending out user confirmation e
 
 ### 2. Download and Configuration
 
-1.  Use root to install Autolab
+1. Use root to install Autolab
 
         :::bash
         sudo -i
 
-2.  Clone the installation package
+2. Clone the installation package
 
         :::bash
         git clone https://github.com/autolab/autolab-oneclick.git; cd autolab-oneclick
 
-3.  Generate a new secret key for Devise Auth Configuration:
+3. Generate a new secret key for Devise Auth Configuration:
 
         :::bash
         python -c "import random; print hex(random.getrandbits(512))[2:-1]"
@@ -167,18 +167,18 @@ Autolab uses email for various features, include sending out user confirmation e
         :::ruby
         # config.middleware.use Rack::SslEnforcer, :except => [ /log_submit/, /local_submit/ ]
 
-6.  Configure Nginx in `server/configs/nginx.conf`
+6. Configure Nginx in `server/configs/nginx.conf`
 
         :::ruby
         server_name <YOUR_SERVER_DOMAIN>
         ssl_certificate /path/to/ssl_certificate/file
         ssl_certificate_key /path/to/ssl_certificate_key/file
 
-7.  Configure Email in `server/configs/production.rb`. Update the address, port, user_name, password and domain with your email service information. For Mandrill, go to "SMTP & API Info" to see the information.
+7. Configure Email in `server/configs/production.rb`. Update the address, port, user_name, password and domain with your email service information. For Mandrill, go to "SMTP & API Info" to see the information.
 
 ### 3. Installation
 
-1.  Start Installation
+1. Start Installation
 
         ::bash
         cd autolab-oneclick
@@ -186,7 +186,7 @@ Autolab uses email for various features, include sending out user confirmation e
 
     Answer the prompts and wait until you see `Autolab Installation Finished`.
 
-2.  Ensure docker containers are running
+2. Ensure docker containers are running
 
         :::bash
         docker ps

--- a/docs/installation/osx.md
+++ b/docs/installation/osx.md
@@ -56,7 +56,15 @@ Follow the step-by-step instructions below:
     -   <a href="https://www.tutorialspoint.com/sqlite/sqlite_installation.htm" target="_blank">SQLite</a> should **only** be used in development
     -   <a href="https://dev.mysql.com/doc/refman/5.7/en/osx-installation-pkg.html" target="_blank">MySQL</a> can be used in development or production
 
-8.  Initialize Autolab Configs
+8. Install <a href="https://brew.sh/" target="_blank">homebrew</a>, as well as the <a href="https://github.com/universal-ctags/homebrew-universal-ctags" target="_blank">universal-ctags</a> package:
+
+        :::bash
+        /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+        brew install --HEAD universal-ctags/universal-ctags/universal-ctags
+
+    Afterward, run `which ctags` to ensure that the package lies on your `PATH` and can be found.
+
+9.  Initialize Autolab Configs
 
         :::bash
         cp config/database.yml.template config/database.yml
@@ -66,19 +74,19 @@ Follow the step-by-step instructions below:
     Edit `school.yml` with your school/organization specific names and emails
     Edit `database.yml` with the correct credentials for your chosen database. Refer to [Troubleshooting](/installation/troubleshoot) for any issues and suggested development [configurations](/installation/troubleshoot/#suggested-development-configuration-for-configdatabaseyml).
 
-9.  Create a .env file to store Autolab configuration constants. 
+10.  Create a .env file to store Autolab configuration constants. 
 
         :::bash
         cp .env.template .env
 
     If you have not installed Tango yet, you do not need to do anything else in this stage. If you have already installed Tango, you should make sure to fill in the `.env` file with values consistent with Tango's `config.py`
 
-10. Initialize application secrets.
+11. Initialize application secrets.
 
         :::bash
         ./bin/initialize_secrets.sh
 
-11. Create and initialize the database tables:
+12. Create and initialize the database tables:
 
         :::bash
         bundle exec rails db:create
@@ -86,7 +94,7 @@ Follow the step-by-step instructions below:
 
     Do not forget to use `bundle exec` in front of every rake/rails command.
 
-12. Create initial root user, pass the `-d` flag for developmental deployments:
+13. Create initial root user, pass the `-d` flag for developmental deployments:
 
         :::bash
         # For production:
@@ -95,24 +103,24 @@ Follow the step-by-step instructions below:
         # For development:
         ./bin/initialize_user.sh -d
 
-13. Populate dummy data (for development only):
+14. Populate dummy data (for development only):
 
         :::bash
         bundle exec rails autolab:populate
 
-14. Start the rails server:
+15. Start the rails server:
 
         :::bash
         bundle exec rails s -p 3000
 
-15. Go to localhost:3000 and login with either the credentials of the root user you just created, or choose `Developer Login` with:
+16. Go to localhost:3000 and login with either the credentials of the root user you just created, or choose `Developer Login` with:
 
         :::bash
         Email: "admin@foo.bar".
 
-16. Install [Tango](/installation/tango), the backend autograding service. Information on linking Autolab to Tango can be found on this page
+17. Install [Tango](/installation/tango), the backend autograding service. Information on linking Autolab to Tango can be found on this page
 as well.
 
-17. If you would like to configure Github integration to allow students to submit via Github, please follow the [Github integration setup instructions](/installation/github_integration).
+18. If you would like to configure Github integration to allow students to submit via Github, please follow the [Github integration setup instructions](/installation/github_integration).
 
-18. Now you are all set to start using Autolab! Visit the [Guide for Instructors](/instructors) and [Guide for Lab Authors](/lab) pages for more info.
+19. Now you are all set to start using Autolab! Visit the [Guide for Instructors](/instructors) and [Guide for Lab Authors](/lab) pages for more info.

--- a/docs/installation/osx.md
+++ b/docs/installation/osx.md
@@ -2,22 +2,22 @@ This page provides instructions on installing Autolab for development on Mac OSX
 
 Follow the step-by-step instructions below:
 
-1.  Install <a href="https://github.com/sstephenson/rbenv" target="_blank">rbenv</a> (use the Basic GitHub Checkout method)
+1. Install <a href="https://github.com/sstephenson/rbenv" target="_blank">rbenv</a> (use the Basic GitHub Checkout method)
 
-2.  Install <a href="https://github.com/sstephenson/ruby-build" target="_blank">ruby-build</a> as an rbenv plugin:
+2. Install <a href="https://github.com/sstephenson/ruby-build" target="_blank">ruby-build</a> as an rbenv plugin:
 
         :::bash
         git clone https://github.com/sstephenson/ruby-build.git ~/.rbenv/plugins/ruby-build
 
     Restart your shell at this point in order to start using your newly installed rbenv
 
-3.  Clone the Autolab repo into home directory and enter it:
+3. Clone the Autolab repo into home directory and enter it:
 
         :::bash
         cd ~/
         git clone https://github.com/autolab/Autolab.git && cd Autolab
 
-4.  Install the correct version of ruby:
+4. Install the correct version of ruby:
 
         :::bash
         rbenv install $(cat .ruby-version)
@@ -37,13 +37,13 @@ Follow the step-by-step instructions below:
         export RBENV_ROOT=<rbenv folder path on your local machine>
         eval "$(rbenv init -)"
 
-5.  Install `bundler`:
+5. Install `bundler`:
 
         :::bash
         gem install bundler
         rbenv rehash
 
-6.  Install the required gems (run the following commands in the cloned Autolab repo):
+6. Install the required gems (run the following commands in the cloned Autolab repo):
 
         :::bash
         cd bin
@@ -51,7 +51,7 @@ Follow the step-by-step instructions below:
 
     Refer to [Troubleshooting](/installation/troubleshoot) for issues installing gems
 
-7.  Install one of two database options
+7. Install one of two database options
 
     -   <a href="https://www.tutorialspoint.com/sqlite/sqlite_installation.htm" target="_blank">SQLite</a> should **only** be used in development
     -   <a href="https://dev.mysql.com/doc/refman/5.7/en/osx-installation-pkg.html" target="_blank">MySQL</a> can be used in development or production
@@ -64,7 +64,7 @@ Follow the step-by-step instructions below:
 
     Afterward, run `which ctags` to ensure that the package lies on your `PATH` and can be found.
 
-9.  Initialize Autolab Configs
+9. Initialize Autolab Configs
 
         :::bash
         cp config/database.yml.template config/database.yml
@@ -74,7 +74,7 @@ Follow the step-by-step instructions below:
     Edit `school.yml` with your school/organization specific names and emails
     Edit `database.yml` with the correct credentials for your chosen database. Refer to [Troubleshooting](/installation/troubleshoot) for any issues and suggested development [configurations](/installation/troubleshoot/#suggested-development-configuration-for-configdatabaseyml).
 
-10.  Create a .env file to store Autolab configuration constants. 
+10. Create a .env file to store Autolab configuration constants. 
 
         :::bash
         cp .env.template .env

--- a/docs/installation/tango.md
+++ b/docs/installation/tango.md
@@ -5,19 +5,19 @@ This guide provides instructions for installing Tango on either a [development e
 
 This guide shows how to setup Tango in a **development environment**. Use the [production installation](#production-installation) guide for installing in a **production environment**.
 
-1.  Obtain the source code.
+1. Obtain the source code.
 
         :::bash
         git clone https://github.com/autolab/Tango.git; cd Tango
 
-2.  Install Redis following <a href="http://redis.io/topics/quickstart" target="_blank">this guide</a>. By default, Tango uses Redis as a stateless job queue. Learn more <a href="https://autolab.github.io/2015/04/making-backend-scalable/" target="_blank">here</a>.
+2. Install Redis following <a href="http://redis.io/topics/quickstart" target="_blank">this guide</a>. By default, Tango uses Redis as a stateless job queue. Learn more <a href="https://autolab.github.io/2015/04/making-backend-scalable/" target="_blank">here</a>.
 
-3.  Create a `config.py` file from the given template.
+3. Create a `config.py` file from the given template.
 
         :::bash
         cp config.template.py config.py
 
-4.  Create the course labs directory where job's output files will go, organized by key and lab name:
+4. Create the course labs directory where job's output files will go, organized by key and lab name:
 
         :::bash
         mkdir courselabs
@@ -25,14 +25,14 @@ This guide shows how to setup Tango in a **development environment**. Use the [p
     By default the `COURSELABS` option in `config.py` points to the `courselabs` directory in the Tango directory.
     Change this to specify another path if you wish.
 
-5.  Set up a VMMS for Tango to use.
+5. Set up a VMMS for Tango to use.
 
     -   [Docker](#docker-vmms-setup) (**recommended**)
     -   [Amazon EC2](#amazon-ec2-vmms-setup)
     -   TashiVMMS (deprecated)
 
 
-6.  Run the following commands to setup the Tango dev environment inside the Tango directory. <a href="https://pip.pypa.io/en/stable/installing/" target="_blank">Install pip</a> if needed.
+6. Run the following commands to setup the Tango dev environment inside the Tango directory. <a href="https://pip.pypa.io/en/stable/installing/" target="_blank">Install pip</a> if needed.
 
         :::bash
         $ pip install virtualenv
@@ -41,18 +41,18 @@ This guide shows how to setup Tango in a **development environment**. Use the [p
         $ pip install -r requirements.txt
         $ mkdir volumes
 
-7.  If you are using Docker, set `DOCKER_VOLUME_PATH` in `config.py` to be the path to the `volumes` directory you just created.
+7. If you are using Docker, set `DOCKER_VOLUME_PATH` in `config.py` to be the path to the `volumes` directory you just created.
 
         :::bash
         DOCKER_VOLUME_PATH = "/path/to/Tango/volumes/"
 
 
-8.  Start Redis by running the following command:
+8. Start Redis by running the following command:
 
         :::bash
         $ redis-server
 
-9.  Run the following command to start the server (producer). If no port is given, the server will run on the port specified in `config.py` (default: 3000):
+9. Run the following command to start the server (producer). If no port is given, the server will run on the port specified in `config.py` (default: 3000):
 
         :::bash
         python restful_tango/server.py <port>
@@ -64,7 +64,7 @@ This guide shows how to setup Tango in a **development environment**. Use the [p
 
     For more information on the job producer/consumer model check out our <a href="https://autolab.github.io/2015/04/making-backend-scalable/" target="_blank">blog post</a>.
 
-10.  Ensure Tango is running:
+10. Ensure Tango is running:
 
         :::bash
         $ curl localhost:<port>
@@ -106,33 +106,33 @@ This is a guide to setup a fully self-sufficient Tango deployment environment ou
 -   You can change any of these in the respective config files in `deployment/config/` before you build the `tango_deployment` image.
 
 ### Steps
-1.  Clone the Tango repo
+1. Clone the Tango repo
 
         :::sh
         $ git clone https://github.com/autolab/Tango.git; cd Tango
 
-2.  Create a `config.py` file from the given template.  
+2. Create a `config.py` file from the given template.  
       
         :::sh
         $ cp config.template.py config.py
 
-3.  Modify `DOCKER_VOLUME_PATH` in `config.py` as follows: 
+3. Modify `DOCKER_VOLUME_PATH` in `config.py` as follows: 
 	
         :::sh
         DOCKER_VOLUME_PATH = '/opt/TangoService/Tango/volumes/'
 
-4.  Install docker on the host machine by following instructions on the <a href="https://docs.docker.com/installation/" target="_blank">docker installation page</a>. Ensure docker is running:
+4. Install docker on the host machine by following instructions on the <a href="https://docs.docker.com/installation/" target="_blank">docker installation page</a>. Ensure docker is running:
 
         :::sh
         $ docker ps
         # CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS                    NAMES
 
-5.  Run the following command to build the Tango deployment image.
+5. Run the following command to build the Tango deployment image.
 
         :::sh
         $ docker build --tag="tango_deployment" .
 
-6.  Ensure the image was built by running.
+6. Ensure the image was built by running.
 
         :::sh
         $ docker images
@@ -140,22 +140,22 @@ This is a guide to setup a fully self-sufficient Tango deployment environment ou
         # tango_deployment    latest              3c0d4f4b4958        2 minutes ago       742.6 MB
         # ubuntu              15.04               d1b55fd07600        4 minutes ago       131.3 MB
 
-7.  Run the following command to access the image in a container with a bash shell. The `-p` flag will map `nginxPort` on the docker container to `localPort` (8610 recommended) on your local machine (or on the VM that docker is running in on the local machine) so that Tango is accessible from outside the docker container.
+7. Run the following command to access the image in a container with a bash shell. The `-p` flag will map `nginxPort` on the docker container to `localPort` (8610 recommended) on your local machine (or on the VM that docker is running in on the local machine) so that Tango is accessible from outside the docker container.
       
         :::sh
         $ docker run --privileged -p <localPort>:<nginxPort> -it tango_deployment /bin/bash
 
-8.  Set up a VMMS for Tango within the Docker container.
+8. Set up a VMMS for Tango within the Docker container.
 
     - [Docker](#docker-vmms-setup) (**recommended**)
     - [Amazon EC2](#amazon-ec2-vmms-setup)
 
-9.  Run the following command to start supervisor, which will then start Tango and all its dependencies.
+9. Run the following command to start supervisor, which will then start Tango and all its dependencies.
 
         :::sh
         $ service supervisor start
 
-10.  Check to see if Tango is responding to requests
+10. Check to see if Tango is responding to requests
       
         :::sh
         $ curl localhost:8610 # Hello, world! RESTful Tango here!
@@ -241,19 +241,19 @@ This is a guide to setup a fully self-sufficient Tango deployment environment ou
 
 This is a guide to set up Tango to run jobs inside Docker containers.
 
-1.  Install docker on host machine by following instructions on the <a href="https://docs.docker.com/installation/" target="_blank">docker installation page</a>. Ensure docker is running:
+1. Install docker on host machine by following instructions on the <a href="https://docs.docker.com/installation/" target="_blank">docker installation page</a>. Ensure docker is running:
       
         :::bash
         $ docker ps # CONTAINER ID IMAGE COMMAND CREATED STATUS PORTS NAMES
 
-2.  Build base Docker image from root Tango directory.
+2. Build base Docker image from root Tango directory.
 
         :::sh
         cd path/to/Tango
         docker build -t autograding_image vmms/
         docker images autograding_image    # Check if image built
 
-3.  Update `VMMS_NAME` in `config.py`.
+3. Update `VMMS_NAME` in `config.py`.
 
         :::python
         # in config.py
@@ -263,11 +263,11 @@ This is a guide to set up Tango to run jobs inside Docker containers.
 
 This is a guide to set up Tango to run jobs on an Amazon EC2 VM.
 
-1.  Create an <a href="https://aws.amazon.com/" target="_blank">AWS Account</a> or use an existing one.
+1. Create an <a href="https://aws.amazon.com/" target="_blank">AWS Account</a> or use an existing one.
 
-2.  Obtain your `access_key_id` and `secret_access_key` by following the instructions <a href="http://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys" target="_blank">here</a>.
+2. Obtain your `access_key_id` and `secret_access_key` by following the instructions <a href="http://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys" target="_blank">here</a>.
 
-3.  Add AWS Credentials to a file called `~/.boto` using the following format:
+3. Add AWS Credentials to a file called `~/.boto` using the following format:
 
         :::bash
         [Credentials]
@@ -276,9 +276,9 @@ This is a guide to set up Tango to run jobs on an Amazon EC2 VM.
 
     Tango uses the <a href="http://boto.cloudhackers.com/en/latest/" target="_blank">Boto</a> Python package to interface with Amazon Web Services
 
-4.  In the AWS EC2 console, create an Ubuntu 14.04+ EC2 instance and save the `.pem` file in a safe location.
+4. In the AWS EC2 console, create an Ubuntu 14.04+ EC2 instance and save the `.pem` file in a safe location.
 
-5.  Copy the directory and contents of `autodriver/` in the Tango repo into the EC2 VM. For more help connecting to the EC2 instance follow <a href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AccessingInstancesLinux.html#AccessingInstancesLinuxSCP" target="_blank">this guide</a>.
+5. Copy the directory and contents of `autodriver/` in the Tango repo into the EC2 VM. For more help connecting to the EC2 instance follow <a href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AccessingInstancesLinux.html#AccessingInstancesLinuxSCP" target="_blank">this guide</a>.
 
         :::bash
         chmod 400 /path/my-key-pair.pem
@@ -286,14 +286,14 @@ This is a guide to set up Tango to run jobs on an Amazon EC2 VM.
 
     The autodriver is used as a sandbox environment to run the job inside the VM. It limits Disk I/O, Disk Usage, monitors security, and controls other valuable `sudo` level resources.
 
-6.  In the EC2 VM, compile the autodriver.
+6. In the EC2 VM, compile the autodriver.
 
         :::bash
         $ cd autodriver/
         $ make clean; make
         $ cp -p autodriver /usr/bin/autodriver
 
-7.  Create the `autograde` Linux user and directory. All jobs will be run under this user.
+7. Create the `autograde` Linux user and directory. All jobs will be run under this user.
 
         :::bash
         $ useradd autograde
@@ -301,9 +301,9 @@ This is a guide to set up Tango to run jobs on an Amazon EC2 VM.
         $ chown autograde autograde
         $ chown :autograde autograde
 
-8.  In the AWS EC2 console, create an AMI image from your EC2 VM. Use <a href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/creating-an-ami-ebs.html#how-to-create-ebs-ami" target="_blank">this guide</a> to create a custom AMI.
+8. In the AWS EC2 console, create an AMI image from your EC2 VM. Use <a href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/creating-an-ami-ebs.html#how-to-create-ebs-ami" target="_blank">this guide</a> to create a custom AMI.
 
-9.  Exit the EC2 instance and edit the following values in `config.py` in the Tango directory.
+9. Exit the EC2 instance and edit the following values in `config.py` in the Tango directory.
 
         :::bash
         # VMMS to use. Must be set to a VMMS implemented in vmms/ before

--- a/docs/installation/ubuntu.md
+++ b/docs/installation/ubuntu.md
@@ -5,7 +5,7 @@ This page provides instructions on installing Autolab for development on Ubuntu 
         :::bash
         sudo apt-get update
         sudo apt-get upgrade
-        sudo apt-get install build-essential git libffi-dev zlib1g-dev autoconf bison build-essential libssl-dev libyaml-dev libreadline6-dev libncurses5-dev libgdbm5 libgdbm-dev libmysqlclient-dev libjansson-dev ctags
+        sudo apt-get install build-essential git libffi-dev zlib1g-dev autoconf bison build-essential libssl-dev libyaml-dev libreadline6-dev libncurses5-dev libgdbm5 libgdbm-dev libmysqlclient-dev libjansson-dev universal-ctags
 
 2. Cloning Autolab repo from Github to ~/Autolab
 

--- a/docs/installation/ubuntu.md
+++ b/docs/installation/ubuntu.md
@@ -76,7 +76,7 @@ Following instructions from <a href="https://www.digitalocean.com/community/tuto
         cp config/school.yml.template config/school.yml
         cp config/autogradeConfig.rb.template config/autogradeConfig.rb
 
-10.  Create a .env file to store Autolab configuration constants. 
+10. Create a .env file to store Autolab configuration constants. 
 
         :::bash
         cp .env.template .env

--- a/docs/tango-cli.md
+++ b/docs/tango-cli.md
@@ -22,12 +22,12 @@ The args are -P <port\>, -k <key\>, -l <unique_job_name\> --runJob <job_files_pa
 
 ### Individual Steps
 
-1.  Open a `courselab` on Tango. This will create a directory for tango to store the files for the job.
+1. Open a `courselab` on Tango. This will create a directory for tango to store the files for the job.
 
         :::bash
         $ python clients/tango-cli.py -P <port> -k <key> -l <courselab> --open
 
-2.  Upload files necessary for the job.
+2. Upload files necessary for the job.
 
         :::bash
         $ python clients/tango-cli.py -P <port> -k <key> -l <courselab> \
@@ -35,7 +35,7 @@ The args are -P <port\>, -k <key\>, -l <unique_job_name\> --runJob <job_files_pa
         $ python clients/tango-cli.py -P <port> -k <key> -l <courselab> \
             --upload --filename <clients/job1/autograde-Makefile>
 
-3.  Add the job to the queue. Note: `localFile` is the name of the file that was uploaded and `destFile` is the name of the file that will be on the VM. One of the `destFile` attributes must be `Makefile`. Furthermore, `image` references the name of the VM image you want the job to be run on. For Docker it is `autograding_image`.
+3. Add the job to the queue. Note: `localFile` is the name of the file that was uploaded and `destFile` is the name of the file that will be on the VM. One of the `destFile` attributes must be `Makefile`. Furthermore, `image` references the name of the VM image you want the job to be run on. For Docker it is `autograding_image`.
 
         :::bash
         $ python clients/tango-cli.py -P <port> -k <key> -l <courselab> \
@@ -45,7 +45,7 @@ The args are -P <port\>, -k <key\>, -l <unique_job_name\> --runJob <job_files_pa
             --image <image> --outputFile <outputFileName> \
             --jobname <jobname> --maxsize <maxOutputSize> --timeout <jobTimeout>
 
-4.  Get the job output.
+4. Get the job output.
 
         :::sh
         $ python clients/tango-cli.py -P <port> -k <key> -l <courselab> \


### PR DESCRIPTION
## Description
- For Autolab installation for Linux, change instructions to use `universal-ctags` instead of `ctags`
- For Autolab installation for Mac OSX, add instructions to use homebrew to install `universal-ctags`
- For consistency, use single space after numbers in bulleted lists

## Motivation and Context

For the symbol tree in submission view to function correctly, the `universal-ctags` package is required instead of the normal `ctags` package. However, the current instructions for Autolab installation on Linux instructs the user to install `ctags` instead of `universal-ctags`. Furthermore, Mac OSX comes installed with `ctags` by default, but not `universal-ctags`.

Fixes #1543.

## How Has This Been Tested?

Ran `mkdocs serve` to ensure visual correctness of the modified portions of the docs. Also checked that the links work as expected.

Tested on Mac OSX that following the new instructions fixes the symbol tree in submission view.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [x] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [x] I have updated the documentation accordingly, included in this PR