### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ Since 2010, Autolab has had a transformative impact on education at CMU. Each se
 </a>
 </p>
 
-[![Build Status](https://travis-ci.org/autolab/Autolab.svg)](https://travis-ci.org/autolab/Autolab)
+[![Build Status](http://autolab-d01.club.cc.cmu.edu:8080/buildStatus/icon?job=autolab+demosite)](http://autolab-d01.club.cc.cmu.edu:8080/job/autolab%20demosite/)
+[![Better Uptime Badge](https://betteruptime.com/status-badges/v1/monitor/95ro.svg)](https://betteruptime.com/?utm_source=status_badge)
 ![GitHub last commit](https://img.shields.io/github/last-commit/autolab/Autolab)
 
 Subscribe to our [mailing list](https://groups.google.com/g/autolabproject) to receive announcements about major releases and updates to the Autolab Project.

--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ mkdocs gh-deploy
 
 This will build the site using the branch you are currently in (hopefully `master`), place the built HTML files into the `gh-pages` branch, and push to GitHub. GitHub will then automatically deploy the new content in `gh-pages`.
 
+**Note**: Jenkins will automatically deploy the documentation whenever a new commit is pushed to `master`, so there is generally no need to manually execute this step. 
+
 ## Contributing
 
 We encourage you to contribute to Autolab! Please check out the

--- a/README.md
+++ b/README.md
@@ -64,9 +64,9 @@ After setting up the test environment, simply run spec by:
 bundle exec rails spec
 ```
 
-## Rails 4 Support
-Autolab is now running on Rails 5. The Rails 4 branch can be found on `master-rails-4`. 
-We will not be backporting any new features from `master` to `master-rails-4`, and we have discontinued Rails 4 support.
+## Rails 5 Support
+Autolab is now running on Rails 6. The Rails 5 branch can be found on `master-rails-5`. 
+We will not be backporting any new features from `master` to `master-rails-5`, and we have discontinued Rails 5 support.
 
 ## Updating Docs
 To install mkdocs, run

--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ Since 2010, Autolab has had a transformative impact on education at CMU. Each se
 <a href="https://groups.google.com/g/autolabproject" style="float:left">
  <img src="public/images/mailing_list.svg" width="170px" height="44px">
 </a>
-
 </p>
 
 [![Build Status](https://travis-ci.org/autolab/Autolab.svg)](https://travis-ci.org/autolab/Autolab)
@@ -31,7 +30,6 @@ Subscribe to our [mailing list](https://groups.google.com/g/autolabproject) to r
 
 ## Try It Out
 We have a demo site running at https://nightly.autolabproject.com/. See the [docs](https://docs.autolabproject.com/#demonstration-site) for more information on how to login and suggestions on things to try.
-
 
 ## Installation
 
@@ -129,7 +127,7 @@ Please feel free to use Autolab at your school/organization. If you run into any
 ### (2021/10/12) Moved from Uglifier to Terser
 - Autolab has migrated from Uglifier to Terser for our Javascript compressor in order to support the latest Javascript syntax. Please change `Uglifier.new(harmony: true)` to `:terser` in your `production.rb`
 
-### v2.5.0 (2020/02/22) Upgrade from Rails 4 Rails 5
+### v2.5.0 (2020/02/22) Upgrade from Rails 4 to Rails 5
 - Autolab has been upgraded from Rails 4 to Rails 5 after almost a year of effort! There are still some small
 bugs to be fixed, but it should not affect the core functionality of Autolab. Please file an issue if you believe
 you have found a bug.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<a href="http://autolabproject.com">
+<a href="https://autolabproject.com">
   <img src="public/images/autolab_banner.svg" width="380px" height="100px">
 </a>
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Since 2010, Autolab has had a transformative impact on education at CMU. Each se
 Subscribe to our [mailing list](https://groups.google.com/g/autolabproject) to receive announcements about major releases and updates to the Autolab Project.
 
 ## Try It Out
-We have a demo site running at https://nightly.autolabproject.com/. See the [docs](https://docs.autolabproject.com/#demonstration-site) for more information on how to login and suggestions on things to try.
+We have a demo site running at https://nightly.autolabproject.com/. See the [docs](https://docs.autolabproject.com/#demonstration-site) for more information on how to log in and suggestions on things to try.
 
 ## Installation
 
@@ -90,12 +90,12 @@ Once your updated documentation is in `master`, Jenkins will automatically run a
 mkdocs gh-deploy
 ```
 
-This will build the site using the branch you are currently in (hopefully `master`), place the built HTML files into the `gh-pages` branch, and push to GitHub. GitHub will then automatically deploy the new content in `gh-pages`.
+This will build the site using the branch you are currently in (hopefully `master`), place the built HTML files into the `gh-pages` branch, and push them to GitHub. GitHub will then automatically deploy the new content in `gh-pages`.
 
 ## Contributing
 
 We encourage you to contribute to Autolab! Please check out the
-[Contributing to Autolab Guide](https://github.com/autolab/Autolab/blob/master/CONTRIBUTING.md) for guidelines about how to proceed. You can also reach out to us on [Slack](https://autolab-slack.herokuapp.com) as well.
+[Contributing to Autolab Guide](https://github.com/autolab/Autolab/blob/master/CONTRIBUTING.md) for guidelines about how to proceed. You can reach out to us on [Slack](https://autolab-slack.herokuapp.com) as well.
 
 ## License
 
@@ -103,7 +103,7 @@ Autolab is released under the [Apache License 2.0](http://opensource.org/license
 
 ## Using Autolab
 
-Please feel free to use Autolab at your school/organization. If you run into any problems, you can reach the core developers at `autolab-dev@andrew.cmu.edu` and we would be happy to help. On a case by case basis, we also provide servers for free. (Especially if you are an NGO or small high-school classroom)
+Please feel free to use Autolab at your school/organization. If you run into any problems, you can reach the core developers at `autolab-dev@andrew.cmu.edu` and we would be happy to help. On a case-by-case basis, we also provide servers for free. (Especially if you are an NGO or small high-school classroom)
 
 
 ## Changelog
@@ -114,7 +114,7 @@ Please feel free to use Autolab at your school/organization. If you run into any
 
 ### [v2.7.0](https://github.com/autolab/Autolab/releases/tag/v2.7.0) (2021/05/29) Autolab Docker Compose, Student Metrics, Redesigned Documentation
 - Integration with new Docker Compose [installation method](https://github.com/autolab/docker)
-- Student Metrics Feature, which allows instructors to identify students who may be in need of attention
+- Student Metrics Feature, which allows instructors to identify students who may require attention
 - Redesigned Autolab documentation
 - Numerous bug fixes
 
@@ -124,31 +124,31 @@ Please feel free to use Autolab at your school/organization. If you run into any
 - Numerous bug fixes
 
 ### (2021/10/12) Moved from Uglifier to Terser
-- Autolab has migrated from Uglifier to Terser for our Javascript compressor in order to support the latest Javascript syntax. Please change `Uglifier.new(harmony: true)` to `:terser` in your `production.rb`
+- Autolab has migrated from Uglifier to Terser for our Javascript compressor to support the latest Javascript syntax. Please change `Uglifier.new(harmony: true)` to `:terser` in your `production.rb`
 
 ### v2.5.0 (2020/02/22) Upgrade from Rails 4 to Rails 5
 - Autolab has been upgraded from Rails 4 to Rails 5 after almost a year of effort! There are still some small
-bugs to be fixed, but it should not affect the core functionality of Autolab. Please file an issue if you believe
+bugs to be fixed, but they should not affect the core functionality of Autolab. Please file an issue if you believe
 you have found a bug.
 
 
 ### [v2.4.0](https://github.com/autolab/Autolab/releases/tag/v2.4.0) (2020/02/08) Speedgrader - The new code viewer 
-- The File Tree shows file hierarchy of student’s submission 
+- The File Tree shows the file hierarchy of student’s submission 
   - Click on a file to open 
   - Click on a folder to expand 
 - The Symbol Tree allows you to jump quickly to functions in the student’s code 
   - Click on a function to jump 
 - You can easily switch between submissions and files 
-  - Up/down arrow keys change file 
-  - Right/left arrow keys change submission 
-- How to use new annotation system: 
+  - Up/down arrow keys change the file 
+  - Right/left arrow keys change the submission 
+- How to use the new annotation system: 
   - Make annotations with grade adjustments 
   - Important: annotations can only be made for non-autograded problems (to preserve the original autograded score of the autograded problem) 
-  - Annotations grade changes summarized by the Annotations table on the right 
+  - Annotations grade changes are summarized by the Annotations table on the right 
 - New: Score for problem automatically updates after annotation score changes based on the following formula (this no longer has to be done manually on the Gradebook): 
 
  `score = max_score + ∑(annotation score changes) `
-- For example, a way to grade style in a deductive manner would be to set the max score for the Style problem, and make annotations with negative score for style violations and zero score for good style 
+- For example, a way to grade style in a deductive manner would be to set the max score for the Style problem, and make annotations with a negative score for style violations and a zero score for good style 
 
 UI Enhancements 
 - Tables are more standardized 

--- a/README.md
+++ b/README.md
@@ -84,15 +84,13 @@ To run and preview this locally, run:
 mkdocs serve
 ```
 
-Once your updated documentation is in `master`, run:
+Once your updated documentation is in `master`, Jenkins will automatically run a job to update the docs. You can trigger a manual update with
 
 ```bash
 mkdocs gh-deploy
 ```
 
 This will build the site using the branch you are currently in (hopefully `master`), place the built HTML files into the `gh-pages` branch, and push to GitHub. GitHub will then automatically deploy the new content in `gh-pages`.
-
-**Note**: Jenkins will automatically deploy the documentation whenever a new commit is pushed to `master`, so there is generally no need to manually execute this step. 
 
 ## Contributing
 


### PR DESCRIPTION
## Description
- Replace Travis Build Status with Jenkins Build Status since Travis is no longer used
- Add Better Uptime Badge to track uptime of Nightly
- Update documentation deployment section to reflect that this step is now automated by Jenkins
- Update Rails support section to reflect that Autolab is now using Rails 6
- Use https for link to autolabproject website
- Fix typo in v2.5.0 changelog title

## Motivation and Context
General maintenance of `README.md`.

## How Has This Been Tested?
Ensured that newly added badges display correctly (using my IDE, but one can also check by manually accessing the links).

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR