### PR TITLE
Fix roster format

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -730,19 +730,19 @@ private
     case parsedRoster[0].length
     when ROSTER_COLUMNS_F20
       # In CMU S3 roster. Columns are:
-      # Semester(0), Course(1), Section(2), (Lecture)(3), (Mini-skip)(4),
+      # Semester(0), Course(1), Section(2), Lecture(3), (Mini-skip)(4),
       # Last Name(5), Preferred/First Name(6), (MI-skip)(7), Andrew ID(8),
       # (Email-skip)(9), College(10), (Department-skip)(11), Major(12),
       # Class(13), Graduation Semester(skip)(14), Units(skip)(15), Grade Option(16), ...
-      map = [0, 8, 5, 6, 10, 12, 13, 16, -1, 1, 2]
+      map = [0, 8, 5, 6, 10, 12, 13, 16, -1, 3, 2]
       select_columns = ROSTER_COLUMNS_F20
     when ROSTER_COLUMNS_F16
       # In CMU S3 roster. Columns are:
-      # Semester(0), Course(1), Section(2), (Lecture-skip)(3), (Mini-skip)(4),
+      # Semester(0), Course(1), Section(2), Lecture(3), (Mini-skip)(4),
       # Last Name(5), First Name(6), (MI-skip)(7), Andrew ID(8),
       # (Email-skip)(9), School(10), (Department-skip)(11), Major(12),
       # Year(13), (skip)(14), Grade Policy(15), ...
-      map = [0, 8, 5, 6, 10, 12, 13, 15, -1, 1, 2]
+      map = [0, 8, 5, 6, 10, 12, 13, 15, -1, 3, 2]
       select_columns = ROSTER_COLUMNS_F16
     when ROSTER_COLUMNS_S15
       # In CMU S3 roster. Columns are:

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -278,8 +278,9 @@ class CoursesController < ApplicationController
     @cuds.each do |cud|
       user = cud.user
       # to_csv avoids issues with commas
-      output += [@course.semester, cud.user.email, user.last_name, user.first_name, cud.school,
-                 cud.major, cud.year, cud.grade_policy, cud.lecture, cud.section].to_csv
+      output += [@course.semester, cud.user.email, user.last_name, user.first_name,
+                 cud.school, cud.major, cud.year, cud.grade_policy,
+                 @course.name, cud.lecture, cud.section].to_csv
     end
     send_data output, filename: "roster.csv", type: "text/csv", disposition: "inline"
   end
@@ -644,6 +645,7 @@ private
                     major: row[5].to_s.chomp(" "),
                     year: row[6].to_s.chomp(" "),
                     grade_policy: row[7].to_s.chomp(" "),
+                    # Ignore courseNumber (row[8])
                     lecture: row[9].to_s.chomp(" "),
                     section: row[10].to_s.chomp(" ") }
         cud = @currentCUDs.find do |current|

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -638,16 +638,18 @@ private
     begin
       csv = detect_and_convert_roster(params["upload"]["file"].read)
       csv.each do |row|
-        new_cud = { email: row[1].to_s,
-                    last_name: row[2].to_s.chomp(" "),
-                    first_name: row[3].to_s.chomp(" "),
-                    school: row[4].to_s.chomp(" "),
-                    major: row[5].to_s.chomp(" "),
-                    year: row[6].to_s.chomp(" "),
-                    grade_policy: row[7].to_s.chomp(" "),
-                    # Ignore courseNumber (row[8])
-                    lecture: row[9].to_s.chomp(" "),
-                    section: row[10].to_s.chomp(" ") }
+        new_cud = { # Ignore Semester (row[0])
+          email: row[1].to_s,
+          last_name: row[2].to_s.chomp(" "),
+          first_name: row[3].to_s.chomp(" "),
+          school: row[4].to_s.chomp(" "),
+          major: row[5].to_s.chomp(" "),
+          year: row[6].to_s.chomp(" "),
+          grade_policy: row[7].to_s.chomp(" "),
+          # Ignore courseNumber (row[8])
+          lecture: row[9].to_s.chomp(" "),
+          section: row[10].to_s.chomp(" ")
+        }
         cud = @currentCUDs.find do |current|
           current.user && current.user.email.downcase == new_cud[:email].downcase
         end
@@ -709,7 +711,7 @@ private
   # column matching and convert to default roster
 
   # map fields:
-  # map[0]: semester
+  # map[0]: semester (unused)
   # map[1]: email
   # map[2]: last_name
   # map[3]: first_name
@@ -717,7 +719,7 @@ private
   # map[5]: major
   # map[6]: year
   # map[7]: grade_policy
-  # map[8]: unused
+  # map[8]: course (unused)
   # map[9]: lecture
   # map[10]: section
   # rubocop:disable Lint/UselessAssignment
@@ -728,34 +730,44 @@ private
     raise "Roster cannot be recognized" if parsedRoster[0][0].nil?
 
     case parsedRoster[0].length
-    when ROSTER_COLUMNS_F20
+    when ROSTER_COLUMNS_F20 # 34 fields
       # In CMU S3 roster. Columns are:
-      # Semester(0), Course(1), Section(2), Lecture(3), (Mini-skip)(4),
-      # Last Name(5), Preferred/First Name(6), (MI-skip)(7), Andrew ID(8),
-      # (Email-skip)(9), College(10), (Department-skip)(11), Major(12),
-      # Class(13), Graduation Semester(skip)(14), Units(skip)(15), Grade Option(16), ...
-      map = [0, 8, 5, 6, 10, 12, 13, 16, -1, 3, 2]
+      # Semester(0 - skip), Course(1 - skip), Section(2), Lecture(3), Mini(4 - skip),
+      # Last Name(5), Preferred/First Name(6), MI(7 - skip), Andrew ID(8),
+      # Email(9 - skip), College(10), Department(11 - skip), Major(12),
+      # Class(13), Graduation Semester(14 - skip), Units(15 - skip), Grade Option(16)
+      # ... the remaining fields are all skipped but shown for completeness
+      # QPA Scale(17), Mid-Semester Grade(18), Primary Advisor(19), Final Grade(20),
+      # Default Grade(21), Time Zone Code(22), Time Zone Description(23), Added By(24),
+      # Added On(25), Confirmed(26), Waitlist Position(27), Units Carried/Max Units(28),
+      # Waitlisted By(29), Waitlisted On(30), Dropped By(31), Dropped On(32), Roster As Of Date(33)
+      map = [-1, 8, 5, 6, 10, 12, 13, 16, -1, 3, 2]
       select_columns = ROSTER_COLUMNS_F20
-    when ROSTER_COLUMNS_F16
+    when ROSTER_COLUMNS_F16 # 32 fields
       # In CMU S3 roster. Columns are:
-      # Semester(0), Course(1), Section(2), Lecture(3), (Mini-skip)(4),
-      # Last Name(5), First Name(6), (MI-skip)(7), Andrew ID(8),
-      # (Email-skip)(9), School(10), (Department-skip)(11), Major(12),
-      # Year(13), (skip)(14), Grade Policy(15), ...
-      map = [0, 8, 5, 6, 10, 12, 13, 15, -1, 3, 2]
+      # Semester(0 - skip), Course(1 - skip), Section(2), Lecture(3), Mini(4 - skip),
+      # Last Name(5), Preferred/First Name(6), MI(7 - skip), Andrew ID(8),
+      # Email(9 - skip), College(10), Department(11), Major(12),
+      # Class(13), Graduation Semester(14 - skip), Units(15 - skip), Grade Option(16)
+      # ... the remaining fields are all skipped but shown for completeness
+      # QPA Scale(17), Mid-Semester Grade(18), Primary Advisor(19), Final Grade(20),
+      # Default Grade(21), Added By(22), Added On(23), Confirmed(24), Waitlist Position(25),
+      # Units Carried/Max Units(26), Waitlisted By(27), Waitlisted On(28), Dropped By(29),
+      # Dropped On(30), Roster As Of Date(31)
+      map = [-1, 8, 5, 6, 10, 12, 13, 16, -1, 3, 2]
       select_columns = ROSTER_COLUMNS_F16
-    when ROSTER_COLUMNS_S15
+    when ROSTER_COLUMNS_S15 # 29 fields
       # In CMU S3 roster. Columns are:
-      # Semester(0), Lecture(1), Section(2), (skip)(3), (skip)(4), Last Name(5),
+      # Semester(0 - skip), Lecture(1), Section(2), (skip)(3), (skip)(4), Last Name(5),
       # First Name(6), (skip)(7), Andrew ID(8), (skip)(9), School(10),
-      # Major(11), Year(12), (skip)(13), Grade Policy(14), ...
-      map = [0, 8, 5, 6, 10, 11, 12, 14, -1, 1, 2]
+      # Major(11), Year(12), (skip)(13), Grade Policy(14), ... [elided]
+      map = [-1, 8, 5, 6, 10, 11, 12, 14, -1, 1, 2]
       select_columns = ROSTER_COLUMNS_S15
     else
       # No header row. Columns are:
-      # Semester(0), Email(1), Last Name(2), First Name(3), School(4),
-      # Major(5), Year(6), Grade Policy(7), (skip)(8), Lecture(9),
-      # Section(10), ...
+      # Semester(0 - skip), Email(1), Last Name(2), First Name(3), School(4),
+      # Major(5), Year(6), Grade Policy(7), Course(8 - skip), Lecture(9),
+      # Section(10)
       return parsedRoster
     end
     # rubocop:enable Lint/UselessAssignment


### PR DESCRIPTION
## Description
- When exporting roster, use `@course.name` for the missing `courseNumber` column
- Make `ROSTER_COLUMNS_F16` and `ROSTER_COLUMNS_F20` use `Lecture` (rather than `Course`) for `courseLecture` field.
- Added entire `ROSTER_COLUMNS_F16` and `ROSTER_COLUMNS_F20` formats in comments
- Map `map[0]` (`Semester`) to `-1` since it is not used
- Fix mapping for `grading_policy` in `ROSTER_COLUMNS_F16` format

## Motivation and Context

The "General Autolab Format" is described by `Semester,email,last_name,first_name,school,major,year,grading_policy,courseNumber,courseLecture,section`.

Inside `parse_roster_csv`, the corresponding fields are extracted (except for `Semester` and `courseNumber`, since the data is stored in `@course`). However, when exporting a roster, the `courseNumber` column is not outputted,  which causes the columns to shift if we reimport the data (`courseLecture` will now take on the value of `section`, and `section` will be blank). This PR fixes this by using `@course.name` for the `courseNumber` column.

Furthermore, when processing Roster formats `ROSTER_COLUMNS_F16` and `ROSTER_COLUMNS_F20`, the `Course` field, instead of the `Lecture` field, is mapped to `courseLecture`, meaning that we are recording the Course name (e.g. `15122`) as the Lecture number (which should be `1`, `2`, etc.). In older format `ROSTER_COLUMNS_S15`, the `courseLecture` was correctly mapped to the `Lecture` field.

Fixes #997.

## How Has This Been Tested?

### Test 1: Ensure General Autolab Format still works correctly

**Roster**

`M22,xho@foo.bar,Ho,Damian,SCS,CS,2025,L,15122,1,A`

<img width="997" alt="Screen Shot 2022-07-12 at 12 42 06" src="https://user-images.githubusercontent.com/9074856/178410109-64939e46-3079-4416-a181-f0b4e090c654.png">

### Test 2: Check that Export + Import works correctly

**Roster (Note the 4 undropped students)**

<img width="999" alt="Screen Shot 2022-07-11 at 14 30 45" src="https://user-images.githubusercontent.com/9074856/178202632-8157dd63-8bcb-418d-80bb-9ecc16cfc2dd.png">

**Before PR: Export + Import**

Observe that the section letter shifted into the lecture column.

<img width="1008" alt="Screen Shot 2022-07-11 at 14 31 42" src="https://user-images.githubusercontent.com/9074856/178202755-46cee5a7-2e76-48b7-8c9b-e23b5020cfec.png">

**After PR: Export + Import**

<img width="1001" alt="Screen Shot 2022-07-11 at 14 32 03" src="https://user-images.githubusercontent.com/9074856/178202775-13cad208-d007-42ef-a9bb-f320a3ef711b.png">

### Test 3: Check that CMU Roster Format works correctly

**Roster**

```
Semester,Course,Section,Lecture,Mini,Last Name,Preferred/First Name,MI,Andrew ID,Email,College,Department,Major,Class,Graduation Semester,Units,Grade Option,QPA Scale,Mid-Semester Grade,Primary Advisor,Final Grade,Default Grade,Time Zone Code,Time Zone Description,Added By,Added On,Confirmed,Waitlist Position,Units Carried/Max Units,Waitlisted By,Waitlisted On,Dropped By,Dropped On,Roster As Of Date
M22,15122,A,1,N,Ho,Damian,,xho,xho@andrew.cmu.edu,SCS,CS,CS,3,F25,0,L,4+,,Test Advisor,,,EST,Eastern Standard Time (GMT-5:00),fake_andrewid,11 Jul 2022,Y,,,,,,,11 Jul 2022 12:00 AM
```

**Before PR**

Observe that Course number appears in the lecture field.

<img width="1003" alt="Screen Shot 2022-07-11 at 14 39 39" src="https://user-images.githubusercontent.com/9074856/178203646-c6728f7e-63e8-4dc1-9df1-1dcb30e1f8bb.png">

**After PR**

<img width="996" alt="Screen Shot 2022-07-11 at 14 39 14" src="https://user-images.githubusercontent.com/9074856/178203617-8ed018c6-6e95-49d6-a077-327045dcfa04.png">

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR