### PR TITLE
Fix statistics page for problemless assessment

### DIFF
--- a/app/controllers/assessment/grading.rb
+++ b/app/controllers/assessment/grading.rb
@@ -426,12 +426,12 @@ private
       problem_stats = {}
       # seems like we always index with 1
       @assessment.problems.each do |problem|
-        problem_stats[problem.name] =  stats.stats(problem_scores[problem.id])
+        problem_stats[problem.name] = stats.stats(problem_scores[problem.id])
       end
       problem_stats[:Total] = stats.stats(problem_scores[:total])
       result[group] = {}
       result[group][:data] = problem_stats
-      result[group][:total_students] =problem_scores[ problem_scores.keys[1]].length
+      result[group][:total_students] = problem_scores[:total].length
     end
     # raise result.inspect
     result


### PR DESCRIPTION
## Description
- When calculating total students, index `problem_scores` via `:total` rather than 1st problem (0-indexed).

## Motivation and Context

Currently, when loading the statistics page for an assessment, the total number of students for a certain grouping is calculated by finding the number of scores associated with the 1st problem (0-indexed) by indexing `problem_scores` with its 1st key. Note that `problem_scores` includes the key `:total`, so we are guaranteed at least one "problem".

However, when an assessment has no problems, and we make a submission, the `problem_scores` hash has only one key (`:total`), and so we get nil when indexing with the 1st key. This leads to an exception when we subsequently call `.length` on it.

Although very unlikely, it is also possible for different problems to have a different number of scores associated with them, depending on whether a submission was created before the problem was defined. This can lead to erroneous student counts (e.g. if a particular grader grades submissions that were all created before a second problem was defined, then it would show the grader as having marked 0 students).

Hence, this PR changes the logic to use the length of `problem_scores[:total]` instead.

## How Has This Been Tested?
1. Create a new assessment and make a submission without defining any problems.
2. Open the statistics page

**Before PR**

<img width="1440" alt="Screen Shot 2022-07-11 at 18 28 29" src="https://user-images.githubusercontent.com/9074856/178248895-fa2e4776-9a24-4dde-8670-55479602f18a.png">

**After PR**

<img width="1008" alt="Screen Shot 2022-07-11 at 18 28 11" src="https://user-images.githubusercontent.com/9074856/178248915-537d7ac9-1dea-414f-9a0b-62d6a3f5bbb6.png">

Also test that the statistics page displays correctly under normal circumstances (i.e. with at least one problem defined).

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR