### PR TITLE
Do not run :log_entry on :destroy

### DIFF
--- a/app/models/score.rb
+++ b/app/models/score.rb
@@ -22,7 +22,7 @@ class Score < ApplicationRecord
   validates(:problem_id, uniqueness: { scope: :submission_id })
   validates :grader_id, presence: true
 
-  after_commit :log_entry
+  after_commit :log_entry, on: [:create, :update]
 
   def self.find_with_feedback(*args)
     with_exclusive_scope { find(*args) }

--- a/app/models/score.rb
+++ b/app/models/score.rb
@@ -23,7 +23,6 @@ class Score < ApplicationRecord
   validates :grader_id, presence: true
 
   after_commit :log_entry, on: [:create, :update]
-  after_commit :log_delete, on: [:destroy]
 
   def self.find_with_feedback(*args)
     with_exclusive_scope { find(*args) }
@@ -58,10 +57,6 @@ class Score < ApplicationRecord
     "#{submission.course_user_datum.user.email} set to " \
     "#{score} on #{submission.assessment.name}:#{problem.name} by" \
     " #{setter}")
-  end
-
-  def log_delete
-    COURSE_LOGGER.log("Score #{id} DESTROYED for #{submission.course_user_datum.user.email}")
   end
 
 private

--- a/app/models/score.rb
+++ b/app/models/score.rb
@@ -23,6 +23,7 @@ class Score < ApplicationRecord
   validates :grader_id, presence: true
 
   after_commit :log_entry, on: [:create, :update]
+  after_commit :log_delete, on: [:destroy]
 
   def self.find_with_feedback(*args)
     with_exclusive_scope { find(*args) }
@@ -57,6 +58,10 @@ class Score < ApplicationRecord
     "#{submission.course_user_datum.user.email} set to " \
     "#{score} on #{submission.assessment.name}:#{problem.name} by" \
     " #{setter}")
+  end
+
+  def log_delete
+    COURSE_LOGGER.log("Score #{id} DESTROYED for #{submission.course_user_datum.user.email}")
   end
 
 private


### PR DESCRIPTION
## Description
Inside `score.rb`, restrict `:log_entry` to run only on `:create` and `:update`

## Motivation and Context

In #1411, several `after_save` hooks were changed to `after_commit`. Notably, `after_commit` hooks run when a record has been destroyed.

Hence, when destroying a course, `:log_entry` is called when `Score` records are eventually destroyed. However, `:log_entry` includes a logging statement which prints `problem.name` -- but the corresponding `Problem` record has already been destroyed. This results in an exception (although the course seems to be destroyed regardless).

Thus, this PR restricts `:log_entry` to run only on `:create` and `:update` (which was the behavior in the past anyway).

## How Has This Been Tested?
- Create a new course and create a new assessment by importing `hello.tar`
- Make a submission
- Delete the course successfully
- Also, use `byebug` to check that `:log_entry` is called when creating a submission / regrading a submission.

**Before PR**

<img width="1440" alt="Screen Shot 2022-07-12 at 01 48 37" src="https://user-images.githubusercontent.com/9074856/178328201-d6c50265-7e5f-434f-848b-3e1e6d06be66.png">

**After PR**

Course deletes successfully.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR
