### PR TITLE
Fix CA redirection when downloadAll called with no submissions

### DIFF
--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -160,7 +160,12 @@ class SubmissionsController < ApplicationController
 
     if @assessment.disable_handins
       flash[:error] = "There are no submissions to download."
-      redirect_to([@course, @assessment, :submissions]) && return
+      if @cud.course_assistant
+        redirect_to([@course, @assessment])
+      else
+        redirect_to([@course, @assessment, :submissions])
+      end
+      return
     end
 
     submissions = if params[:final]
@@ -177,7 +182,12 @@ class SubmissionsController < ApplicationController
 
     if result.nil?
       flash[:error] = "There are no submissions to download."
-      redirect_to([@course, @assessment, :submissions]) && return
+      if @cud.course_assistant
+        redirect_to([@course, @assessment])
+      else
+        redirect_to([@course, @assessment, :submissions])
+      end
+      return
     end
 
     send_data(result.read, # to read from stringIO object returned by create_zip


### PR DESCRIPTION
## Description
- When an assessment has no submissions, redirect CAs that attempt to `downloadAll` to the assessment page rather than the manage submissions page

## Motivation and Context
Currently, when `downloadAll` is called for an assessment (or section) with no submissions, the user is redirected to the manage submissions page (i.e. `index`). However, `downloadAll` has permission level `:course_assistant`while `index` has permission level `:instructor`. That is, Course Assistants who are redirected will face an authentication error.

## How Has This Been Tested?
- Create a new assessment
- Create a CA for section A
- Act as CA, attempt to download section A submissions, ensure that we are redirected to the assessment page with the appropriate error
- As instructor, attempt to download all submissions (from manage submissions page), ensure that we are redirected to the manage submissions page with the appropriate error

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR