### PR TITLE
Include CSRF token for Git submissions

### DIFF
--- a/app/assets/javascripts/git_submission.js
+++ b/app/assets/javascripts/git_submission.js
@@ -65,7 +65,8 @@ $(document).on("click", "input[type='submit']", function (e) {
     e.preventDefault();
     var repo_name = $("#repo-dropdown input[name='repo']").val();
     var branch_name = $("#branch-dropdown input[name='branch']").val();
-    var params = {repo: repo_name, branch: branch_name};
+    var token = $("meta[name=csrf-token]").attr("content");
+    var params = {repo: repo_name, branch: branch_name, authenticity_token: token};
     var assessment_nav = $(".sub-navigation").find(".item").last();
     var assessment_url = assessment_nav.find("a").attr("href");
     var url = assessment_url + "/handin"


### PR DESCRIPTION
## Description
- Retrieve CSRF token and set it for Git submissions

## Motivation and Context
Currently, Git submissions do not set the CSRF token when submitting, resulting in an authentication error. This only became an issue after #1524 properly fixed CSRF protection. This PR retrieves the CSRF token from the meta tag (set because of `csrf_meta_tag` in `application.html.erb`) and includes it for Git submissions.

## How Has This Been Tested?
- Set up GitHub integration
- Connect GitHub account
- Make a Git submission, observe that it succeeds

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR