### PR TITLE
Revert "Alphabetically sort extracted archive files"

### DIFF
--- a/lib/archive.rb
+++ b/lib/archive.rb
@@ -15,14 +15,11 @@ module Archive
 
     files = []
 
-    pathnames = archive_extract.map do |entry|
+    # Parse archive header
+    archive_extract.each_with_index do |entry, i|
       # Obtain path name depending for tar/zip entry
-      get_entry_name(entry)
-    end
+      pathname = get_entry_name(entry)
 
-    pathnames.sort!
-
-    pathnames.each_with_index do |pathname, i|
       files << {
         pathname: pathname,
         header_position: i,


### PR DESCRIPTION
## Description
- Revert #1568

## Motivation and Context
#1568 sorted extracted archive files for display in the speedgrader file outline. However, the files are not sorted when obtained via other functions, such as `Archive.get_nth_file`, causing the wrong files to be loaded.

## How Has This Been Tested?
- Create a new assessment
- Set handin filename to `handin.zip`
- Hand in [hello_changed.zip](https://github.com/autolab/Autolab/files/9126390/hello_changed.zip)
- Ensure that clicking on files in the file outline loads the correct file as expected

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds
 functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR