### PR TITLE
Fix Autograder Output on View Submission Page

### DIFF
--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -314,7 +314,7 @@ class SubmissionsController < ApplicationController
 
     if params.include?(:header_position) &&
        (params[:header_position].to_i == -1) &&
-       @submission.autograde_file.nil?
+       !@submission.autograde_file.nil?
 
       file = @submission.autograde_file.read || "Empty Autograder Output"
       @displayFilename = "Autograder Output"


### PR DESCRIPTION
## Description
- Add missing `!`

## Motivation and Context
During linting in #1465, a `!` was accidentally deleted, making it impossible to view the Autograder output on the view submission page.

## How Has This Been Tested?
- Import `hello.tar` and make a submission
- Check that Autograder output can be viewed

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR