### PR TITLE
Metrics hotfix

### DIFF
--- a/app/controllers/metrics_controller.rb
+++ b/app/controllers/metrics_controller.rb
@@ -10,7 +10,7 @@ class MetricsController < ApplicationController
     @max_consecutive_assessments = if course_max.nil?
                                      0
                                    else
-                                     course_max[1] - 1
+                                     course_max[1]
                                    end
   end
 

--- a/app/models/watchlist_instance.rb
+++ b/app/models/watchlist_instance.rb
@@ -360,8 +360,8 @@ class WatchlistInstance < ApplicationRecord
         case condition.condition_type
 
         when "grace_day_usage"
-          grace_day_threshold = condition.parameters[:grace_day_threshold].to_i
-          date = condition.parameters[:date]
+          grace_day_threshold = condition.parameters["grace_day_threshold"].to_i
+          date = condition.parameters["date"]
           asmts_before_date = course.asmts_before_date(date)
           asmts_before_date = asmts_before_date.reject do |asmt|
             category_blocklist.include?(asmt.category_name)
@@ -377,8 +377,8 @@ class WatchlistInstance < ApplicationRecord
           cur_instances << new_instance unless new_instance.nil?
 
         when "grade_drop"
-          percentage_drop = condition.parameters[:percentage_drop].to_f
-          consecutive_counts = condition.parameters[:consecutive_counts].to_i
+          percentage_drop = condition.parameters["percentage_drop"].to_f
+          consecutive_counts = condition.parameters["consecutive_counts"].to_i
 
           categories = course.assessment_categories - category_blocklist
           asmt_arrs = categories.map do |category|
@@ -391,7 +391,7 @@ class WatchlistInstance < ApplicationRecord
           cur_instances << new_instance unless new_instance.nil?
 
         when "no_submissions"
-          no_submissions_threshold = condition.parameters[:no_submissions_threshold].to_i
+          no_submissions_threshold = condition.parameters["no_submissions_threshold"].to_i
 
           new_instance = add_new_instance_for_cud_no_submissions(course, category_blocklist,
                                                                  condition.id, cud,
@@ -399,8 +399,8 @@ class WatchlistInstance < ApplicationRecord
           cur_instances << new_instance unless new_instance.nil?
 
         when "low_grades"
-          grade_threshold = condition.parameters[:grade_threshold].to_f
-          count_threshold = condition.parameters[:count_threshold].to_i
+          grade_threshold = condition.parameters["grade_threshold"].to_f
+          count_threshold = condition.parameters["count_threshold"].to_i
 
           new_instance = add_new_instance_for_cud_low_grades(course, category_blocklist,
                                                              condition.id, cud,


### PR DESCRIPTION
## Description
- Don't subtract one when calculating `@max_consecutive_assessments`
- Use string instead of symbol to access hash

## Motivation and Context
With the recent Rails upgrade, in `risk_condition#get_current_for_course`, `RiskCondition.where(course_id: course_id, version: max_version)` now returns a `Hash` instead of `HashWithIndifferentAccess`. Hence, we can no longer use symbols interchangeably with strings as keys. This PR modifies the Hash accesses to use string keys.

Furthermore, since consecutive assessments are inclusive, we should not subtract one when calculating  `@max_consecutive_assessments`, else we can't set the grades dropping metric to cover all assignments.

## How Has This Been Tested?
Tested workflow for metrics improvement.

Essentially, define categories of 2 assignments to test the following metrics (and considered categories feature)
- 1 grace day used
- 50% drop over 2 assignments
- Did not submit 1 assignment
- 1 assignment below 51%

Tips and reminders
- Remember to set max grace days for assignments where you're making a student use grace days
- Use annotations to award marks (after creating a problem)
- For drop metric, order is by `due_date ASC`

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR
