### PR TITLE
[hotfix] Fix PDF viewer on autograded assignments

### DIFF
--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -506,11 +506,10 @@ class SubmissionsController < ApplicationController
 
                           matched_file[:header_position]
                         end
-      # If not an archive, header_position = nil
-      # This ensures that in _version_links.html.erb, header_position is not set in the querystring
+      # If not an archive, we have header_position = nil
+      # This means that in _version_links.html.erb, header_position is not set in the querystring
       # for the prev / next button urls
-      # Otherwise, pure PDF submissions would not load as #download sees the header_position
-      # and treats the file as an archive
+      # This is fine since #download ignores header_position for non-archives
 
       matchedVersions << {
         version: submission.version,

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -203,7 +203,7 @@ class SubmissionsController < ApplicationController
   # try to send the file at that position in the archive.
   action_auth_level :download, :student
   def download
-    if params[:header_position]
+    if Archive.archive?(@submission.handin_file_path) && params[:header_position]
       file, pathname = Archive.get_nth_file(@filename, params[:header_position].to_i)
       unless file && pathname
         flash[:error] = "Could not read archive."

--- a/app/views/submissions/_annotations_js.html.erb
+++ b/app/views/submissions/_annotations_js.html.erb
@@ -13,8 +13,8 @@
 
   <% if @is_pdf %>
   newFile.pdf = true;
-  newFile.pdfUrl = "<%= url_for [:download, @course, @assessment, @submission, header_position: params[:header_position]] %>";
-  newFile.annotatedPdfUrl = "<%= url_for [:download, @course, @assessment, @submission, header_position: params[:header_position], annotated: true] %>";
+  newFile.pdfUrl = "<%= url_for [:download, @course, @assessment, @submission, header_position: @header_position] %>";
+  newFile.annotatedPdfUrl = "<%= url_for [:download, @course, @assessment, @submission, header_position: @header_position, annotated: true] %>";
   newFile.previewMode = false;
   <% if @preview_mode %>
       newFile.previewMode = true;

--- a/app/views/submissions/_code_symbol_tree.html.erb
+++ b/app/views/submissions/_code_symbol_tree.html.erb
@@ -1,5 +1,5 @@
 <div id="symbol-tree-container">
-<% unless @is_pdf %>
+<% unless (@is_pdf || @ctag_obj.nil?) %>
     <div id="symbol-tree-box">
         <h5>Symbol Tree</h5>
         <ul>


### PR DESCRIPTION
## Description
Fixes bug where PDFs were not rendering correctly on assignments that have an autograder.

## How Has This Been Tested?
Check that speedgrader loads PDFs and that downloads work in all cases:
1. Upload PDF to auto-graded assignment
2. Upload PDF to non-auto-graded assignment
3. Upload tar file containing multiple PDFs
4. Upload tar file containing mix of PDFs and code

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR
