### PR TITLE
Trim prerenders

### DIFF
--- a/app/views/submissions/_version_links.html.erb
+++ b/app/views/submissions/_version_links.html.erb
@@ -3,7 +3,6 @@
     <%= link_to(url_for([:view, @course, @assessment, @prevVersion[:submission], header_position: @prevVersion[:header_position]]), class: "btn small", title: "Previous version containing this file (shortcut: [)", id: "prev_version_link") do %>
       <i class="material-icons">south</i>
     <% end %>
-    <link rel="prerender" href=<%= url_for([:view, @course, @assessment, @prevVersion[:submission], header_position: @prevVersion[:header_position]]) %> />
   <% else %>
     <a class="btn disabled"><i class="material-icons">south</i></a>
   <% end %>
@@ -11,7 +10,6 @@
     <%= link_to(url_for([:view, @course, @assessment, @nextVersion[:submission], header_position: @nextVersion[:header_position]]), class: "btn small", title: "Next version containing this file (shortcut: ])", id: "next_version_link") do %>
       <i class="material-icons">north</i>
     <% end %>
-    <link rel="prerender" href=<%= url_for([:view, @course, @assessment, @nextVersion[:submission], header_position: @nextVersion[:header_position]]) %> />
   <% else %>
     <a class="btn disabled"><i class="material-icons">north</i></a>
   <% end %>

--- a/app/views/submissions/view.html.erb
+++ b/app/views/submissions/view.html.erb
@@ -64,7 +64,6 @@
         <%= link_to(url_for([:view, @course, @assessment, @prevSubmission]), class: "valign-wrapper", title: "Previous student (shortcut: ←)", id: "prev_submission_link") do %>
           <i class="material-icons" style="margin-right: 3px">arrow_back</i> <%= @prevSubmission.course_user_datum.user.email %>
         <% end %>
-         <link rel="prerender" href= <%= url_for([:view, @course, @assessment, @prevSubmission])%> />
       <% end %>
     </div>
     <div class="col s8 center-align valign-wrapper submission-controls">


### PR DESCRIPTION
## Description
- Remove prerender for version links
- Remove prerender for previous student

## Motivation and Context
In #1415 and #1503, `prerender` was used with the goal of loading likely pages in advance to reduce loading times.

However, through testing, it turns out that only one link (previous student) was prerendered (actually [NoState Prefetch](https://developer.chrome.com/blog/nostate-prefetch/)). Given that TAs are most likely to go to the next student, this PR removes all prerenders except for the link to the next student.

## How Has This Been Tested?
1. Use Chrome incognito
2. Start logging with `chrome://net-export/`
3. Load a page with prev / next version / student available and wait for a few seconds
4. Stop logging
5. Import log file to [netlog viewer](https://netlog-viewer.appspot.com/)

**Before changes**: Only previous student prerendered (1908). Previous version (1906), next version (1910), next student (1895) links encounter a Rate Limit Exceeded.

<img width="1440" alt="Screen Shot 2022-07-29 at 00 29 35" src="https://user-images.githubusercontent.com/9074856/181595448-e56fe467-a050-4d84-8634-92de258b3b78.png">

**After changes**: Next student prerendered (1895).

<img width="1439" alt="Screen Shot 2022-07-29 at 01 01 59" src="https://user-images.githubusercontent.com/9074856/181595981-392aa524-5cad-4a78-bd96-eadcdc7935c1.png">

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR
