### PR TITLE
Disable version switching feature when displaying autograder output

### DIFF
--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -303,6 +303,10 @@ class SubmissionsController < ApplicationController
       }]
     end
 
+    viewing_autograder_output = params.include?(:header_position) &&
+                                (params[:header_position].to_i == -1) &&
+                                !@submission.autograde_file.nil?
+
     # Adds autograded file as first option if it exist
     # We are mapping Autograder to header_position -1
     unless @submission.autograde_file.nil?
@@ -312,10 +316,7 @@ class SubmissionsController < ApplicationController
                        directory: false })
     end
 
-    if params.include?(:header_position) &&
-       (params[:header_position].to_i == -1) &&
-       !@submission.autograde_file.nil?
-
+    if viewing_autograder_output
       file = @submission.autograde_file.read || "Empty Autograder Output"
       @displayFilename = "Autograder Output"
     elsif params.include?(:header_position) && Archive.archive?(@submission.handin_file_path)
@@ -492,12 +493,9 @@ class SubmissionsController < ApplicationController
                                .order("version DESC")
 
     # Autograder Output is a dummy file
-    # If we are displaying autograder output, don't attempt to match pathname
-    is_autograder_output = params.include?(:header_position) &&
-                           (params[:header_position].to_i == -1) &&
-                           !@submission.autograde_file.nil?
-
-    unless is_autograder_output
+    # If we are viewing autograder output, don't attempt to match versions
+    # and let @prevVersion = @nextVersion = nil
+    unless viewing_autograder_output
       # Find user submissions that contain the same pathname
       matchedVersions = []
       @userVersions.each do |submission|

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -317,7 +317,6 @@ class SubmissionsController < ApplicationController
        !@submission.autograde_file.nil?
 
       file = @submission.autograde_file.read || "Empty Autograder Output"
-      is_autograder_output = true
       @displayFilename = "Autograder Output"
     elsif params.include?(:header_position) && Archive.archive?(@submission.handin_file_path)
       file, pathname = Archive.get_nth_file(@submission.handin_file_path,
@@ -494,6 +493,10 @@ class SubmissionsController < ApplicationController
 
     # Autograder Output is a dummy file
     # If we are displaying autograder output, don't attempt to match pathname
+    is_autograder_output = params.include?(:header_position) &&
+                           (params[:header_position].to_i == -1) &&
+                           !@submission.autograde_file.nil?
+
     unless is_autograder_output
       # Find user submissions that contain the same pathname
       matchedVersions = []


### PR DESCRIPTION
## Description
When displaying autograder output, do not attempt to match pathname for version switching purposes

## Motivation and Context
Currently, when displaying the autograder output for autograded archives,
* `@displayFilename` is `Autograder Output`
* However, this is not an actual file in the archive, so we are likely to fail to find any matches (even for the current version) -- unless it happens to be an actual file
* This can lead to `matchedVersions` being empty and `@curVersionIndex` being `nil`, resulting in errors when we attempt to define `@prevVersion` and `@nextVersion`

Hence, this PR skips the matching in such cases, letting `@prevVersion` and `@nextVersion` stay as `nil`

## How Has This Been Tested?
* Created a modified Hello assessment which accepts a tar-ed `hello.c` file (unzip this: [hello.tar.zip](https://github.com/autolab/Autolab/files/9384321/hello.tar.zip))
* Make several submissions of the solution (unzip this: [hello.tar.zip](https://github.com/autolab/Autolab/files/9384326/hello.tar.zip))

Ensure that Autograder Output now displays correctly (note that the arrows will always be grayed out)

<img width="1440" alt="Screen Shot 2022-08-20 at 01 34 23" src="https://user-images.githubusercontent.com/9074856/185677023-81dd098b-b502-4c0f-ba73-333b6124307d.png">

Ensure that normal files still display correctly

<img width="1440" alt="Screen Shot 2022-08-20 at 01 34 18" src="https://user-images.githubusercontent.com/9074856/185677035-1671f28f-1955-4e74-a3d1-1722d78815a8.png">

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR