### PR TITLE
Fix remarks for annotations on autograder output

### DIFF
--- a/app/views/assessments/viewFeedback.html.erb
+++ b/app/views/assessments/viewFeedback.html.erb
@@ -16,19 +16,26 @@ Graded by: <%= if @score.grader && @score.grader.user then @score.grader.user.em
 
 <% end %>
 <!--
-Yes, feedback if per problem but we show all annotations for this submission anyway. While this is not semantically correct, it offers a better UX than we had before. If we just show annotations attached to this problem, then where would we show annotations not attached to a problem at all?
+Yes, feedback is per problem but we show all annotations for this submission anyway. While this is not semantically correct, it offers a better UX than we had before. If we just show annotations attached to this problem, then where would we show annotations not attached to a problem at all?
 -->
 
 <% if @submission.annotations.count > 0 and @problemReleased %>
   <h2 style="margin-top: 1em">Remarks</h2>
 
   <ul>
+  <!-- TODO: Make order of annotations consistent with order of file list  -->
   <% @submission.annotations.each do |annotation| %>
     <li>
       <%= link_to annotation.as_text, [:view, @course, @assessment, @submission, header_position: annotation.position] %>
       <% 
-        # if the submission is an archive, use filename in archive; otherwise, use submission filename
-        filename = @files && annotation.position ? Archive.get_nth_filename(@files, annotation.position) : @submission.filename
+
+        filename = if annotation.position == -1
+                     # position -1 maps to the Autograder Output
+                     "Autograder Output"
+                   else
+                     # if the submission is an archive, use filename in archive; otherwise, use submission filename
+                     @files && annotation.position ? Archive.get_nth_filename(@files, annotation.position) : @submission.filename
+                   end
       %>
       (<%= filename %>: <%= annotation.line %>)
     </li>

--- a/app/views/assessments/viewFeedback.html.erb
+++ b/app/views/assessments/viewFeedback.html.erb
@@ -27,9 +27,7 @@ Yes, feedback is per problem but we show all annotations for this submission any
   <% @submission.annotations.each do |annotation| %>
     <li>
       <%= link_to annotation.as_text, [:view, @course, @assessment, @submission, header_position: annotation.position] %>
-      <% 
-
-        filename = if annotation.position == -1
+      <% filename = if annotation.position == -1
                      # position -1 maps to the Autograder Output
                      "Autograder Output"
                    else


### PR DESCRIPTION
## Description
When `annotation.position = -1`, set `filename` to `Autograder Output` instead.

## Motivation and Context
A bug noted by the 122 team is that annotations on the autograder output (when `annotation.position = -1`) appear to reference the last file in the file tree instead.

Looking at `viewFeedback.html.erb`, the current logic for choosing `filename` is `@files && annotation.position ? Archive.get_nth_filename(@files, annotation.position) : @submission.filename`.

When we have a single file submission, `@files` is `nil` and so `filename` is `@submission.filename` (i.e. the last file).

Similarly, with an archive submission, `filename` is `Archive.get_nth_filename(@files, annotation.position)`, which evaluates to `@files[annotation.position][:pathname]` where `annotation.position = -1`. In particular, we are accessing index `-1`, i.e. the last file.

This PR remedies the logic by explicitly handling the `annotation.position = -1` case.

## How Has This Been Tested?
- Create an autograded assessment that accepts archives (for simplicity, use the assessment from #1578).
- Add an additional `Style` problem.
- Make a submission, annotate the autograder output, and release grades.
- View feedback page (by clicking on the autograded score on the view assessment page)

**Before changes**
<img width="220" alt="Screen Shot 2022-08-24 at 00 13 17" src="https://user-images.githubusercontent.com/9074856/186208849-5395808d-4f51-4de4-b4aa-bf978e5bfb85.png">

**After changes**
<img width="279" alt="Screen Shot 2022-08-24 at 00 07 04" src="https://user-images.githubusercontent.com/9074856/186208860-24deda4b-69e7-41ea-bc3f-c4a13f265282.png">

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR
