### PR TITLE
Add mononym support

### DIFF
--- a/app/assets/javascripts/watchlist.js
+++ b/app/assets/javascripts/watchlist.js
@@ -373,7 +373,8 @@ function get_watchlist_function(){
           var id = _.get(watchlist_instance,'id');
           var course_id = _.get(watchlist_instance,'course_id');
           var user_id = _.get(watchlist_instance,'course_user_datum_id');
-          var user_name = _.get(data,`["users"][${user_id}].first_name`) + " " + _.get(data,`["users"][${user_id}].last_name`); 
+          // https://stackoverflow.com/questions/19902860/join-strings-with-a-delimiter-only-if-strings-are-not-null-or-empty
+          var user_name = [_.get(data,`["users"][${user_id}].first_name`), _.get(data,`["users"][${user_id}].last_name`)].filter(Boolean).join(' ');
           var user_email = _.get(data,`["users"][${user_id}].email`);
           var risk_condition_id = _.get(watchlist_instance,'risk_condition_id');
           var watchlist_status = _.get(watchlist_instance,'status');

--- a/app/controllers/assessment/grading.rb
+++ b/app/controllers/assessment/grading.rb
@@ -293,11 +293,11 @@ end
     grader = (if score then score.grader else nil end)
     grader_info = ""
     if grader
-      grader_info = "#{grader.first_name} #{grader.last_name} (#{grader.email})"
+      grader_info = grader.full_name_with_email
     end
 
     feedback = score.feedback
-    response = {"grader" => grader_info, "feedback" => feedback, "score" => score.score}
+    response = { "grader" => grader_info, "feedback" => feedback, "score" => score.score }
     render json: response
   end
 

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -258,7 +258,7 @@ class CoursesController < ApplicationController
     if params[:doIt]
       begin
         save_uploaded_roster
-        flash[:success] = "Success!"
+        flash.now[:success] = "Successfully updated roster!"
       rescue StandardError => e
         if e != "Roster validation error"
           flash[:error] = e

--- a/app/controllers/scoreboards_controller.rb
+++ b/app/controllers/scoreboards_controller.rb
@@ -51,7 +51,7 @@ class ScoreboardsController < ApplicationController
         @grades[uid] = {}
         @grades[uid][:nickname] = user.nickname
         @grades[uid][:andrewID] = user.email
-        @grades[uid][:fullName] = "#{user.first_name} #{user.last_name}"
+        @grades[uid][:fullName] = user.full_name
         @grades[uid][:problems] = {}
       end
       if @grades[uid][:version] != row["version"]

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,7 +17,8 @@ class User < ApplicationRecord
   has_one :github_integration
 
   trim_field :school
-  validates :first_name, :last_name, :email, presence: true
+  validates :email, presence: true
+  validate :first_or_last_name
 
   # check if user is instructor in any course
   def instructor?
@@ -260,5 +261,13 @@ class User < ApplicationRecord
     result[:school] ||= user[:edupersonschoolcollegename][0]
 
     result
+  end
+
+private
+
+  def first_or_last_name
+    return if first_name.present? || last_name.present?
+
+    errors.add(:base, "Student first name and last name can't both be blank")
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -42,7 +42,7 @@ class User < ApplicationRecord
   end
 
   def full_name
-    "#{first_name} #{last_name}"
+    [first_name, last_name].reject(&:empty?).join(' ')
   end
 
   def full_name_with_email
@@ -50,7 +50,7 @@ class User < ApplicationRecord
   end
 
   def display_name
-    first_name && last_name ? full_name : email
+    first_name.present? && last_name.present? ? full_name : email
   end
 
   def after_create

--- a/app/views/assessments/viewGradesheet.html.erb
+++ b/app/views/assessments/viewGradesheet.html.erb
@@ -46,7 +46,7 @@
       <% for s in @submissions do %>
           { "id": "",
             "name": {
-              name: "<%= s.course_user_datum.last_name %>, <%= s.course_user_datum.first_name %>",
+              name: "<%= [s.course_user_datum.last_name, s.course_user_datum.first_name].reject(&:blank?).join(', ') %>",
               email: "<%= s.course_user_datum.email %>"
             },
             "lec": "<%= s.course_user_datum.lecture %>",

--- a/app/views/course_user_data/index.html.erb
+++ b/app/views/course_user_data/index.html.erb
@@ -1,6 +1,6 @@
 <h3>Account Details for <%= @user.andrewID %></h3>
 <table class="noStyle" >
-<tr><td>Name</td><td><td> <%= @user.first_name %> <%= @user.last_name %> </td></tr>
+<tr><td>Name</td><td><td> <%= @user.full_name %> </td></tr>
 <tr><td class="noStyle" >First Name</td><td class="noStyle"><%= @user.first_name %></td></tr>
 <tr><td class="noStyle" >Last Name</td><td class="noStyle"><%= @user.last_name %></td></tr>
 <tr><td class="noStyle" >andrewID</td><td class="noStyle"><%= @user.andrewID %></td></tr>

--- a/app/views/course_user_data/show.html.erb
+++ b/app/views/course_user_data/show.html.erb
@@ -1,8 +1,8 @@
-<h2><%= @requestedUser.first_name %> <%= @requestedUser.last_name %> (<%= @requestedUser.nickname %>)</h2>
+<h2><%= @requestedUser.full_name %> (<%= @requestedUser.nickname %>)</h2>
 <ul class="gray-box">
   <li><b>Contact</b><br>
     <a href="mailto:<%= @requestedUser.email %>"><%= @requestedUser.email %></a></li>
-  <li> <b>About</b><br>
+  <li><b>About</b><br>
     Lecture <strong><%= @requestedUser.lecture %></strong><br>
     Section <strong><%= @requestedUser.section %></strong><br>
     Course <strong><%= @requestedUser.course.full_name %></strong><br>

--- a/app/views/course_user_data/user.html.erb
+++ b/app/views/course_user_data/user.html.erb
@@ -1,9 +1,9 @@
-<h2><%= @requestedUser.first_name %> <%= @requestedUser.last_name %> (<%= @requestedUser.nickname %>)</h2>
+<h2><%= @requestedUser.full_name %> (<%= @requestedUser.nickname %>)</h2>
 <ul class="gray-box">
   <li><b>Contact</b><br>
     <%= @requestedUser.andrewID %> (andrewid)<br>
     <a href="mailto:<%= @requestedUser.email %>"><%= @requestedUser.email %></a></li>
-  <li> <b>About</b><br>
+  <li><b>About</b><br>
     Lecture <strong><%= @requestedUser.lecture %></strong><br>
     Section <strong><%= @requestedUser.section %></strong><br>
     Course <strong><%= @requestedUser.course.display_name %></strong><br>

--- a/app/views/submissions/index.html.erb
+++ b/app/views/submissions/index.html.erb
@@ -99,7 +99,7 @@
           </label>
         </p>
       </td>
-      <td><%= "#{submission.course_user_datum.last_name}, #{submission.course_user_datum.first_name}" %>
+      <td><%= [submission.course_user_datum.last_name, submission.course_user_datum.first_name].reject(&:blank?).join(', ') %>
       <%= link_to submission.course_user_datum.email,
                       history_course_assessment_path(@course, @assessment, cud_id: submission.course_user_datum_id, partial: true),
                       {remote: true, class: :trigger}

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -5,8 +5,18 @@
     <a href="mailto:<%= @user.email %>"><%= @user.email %></a>
   </li>
   <li> <b>About</b><br>
-    First name <strong><%= @user.first_name %></strong><br>
-    Last name <strong><%= @user.last_name %></strong><br>
+    <% if @user.first_name.present? %>
+      First name: <strong><%= @user.first_name %></strong>
+    <% else %>
+      First name: (student has no first name)
+    <% end %>
+    <br>
+    <% if @user.last_name.present? %>
+      Last name: <strong><%= @user.last_name %></strong>
+    <% else %>
+      Last name: (student has no last name)
+    <% end %>
+    <br>
     Courses 
     <% if @cuds.empty? %>
       <strong> None </strong>


### PR DESCRIPTION
## Description
Initial attempt to add mononym support, by updating user validation to only require at least one of `first_name` and `last_name`.

Pages with style changes for mononyms
- Assessment Gradesheet
- Course view student CUD
- Assessment Manage submissions
- User Account
- Assessment Scoreboard
- Course Metrics Watchlist
- Assessment Gradesheet grader information
- (course_user_data `index` and `user` pages -- they seemed unused as `show` is used instead)

A good litmus test is to run `grep -nr "\.first_name.*\.last_name" .` and look at the results

Other changes
- Use `flash.now` for roster update success flash as otherwise the flash persists for one additional page load
- Update `user.rb#full_name` method to handle mononyms
- Update `user.rb#display_name` method to correctly use `.present?` to check for presence, since empty strings are truthy. Note: this method seems pretty redundant, and is mainly used in the navbar and Account page; we could probably delete this method and use `full_name` directly instead

## Motivation and Context

To support students who do not have first names or last names.

Fixes #1536 

## How Has This Been Tested?

### Import roster containing mononyms

Supports Mononyms
![Screen Shot 2022-08-28 at 15 11 26](https://user-images.githubusercontent.com/9074856/187092014-032623f7-f55d-407d-8635-cb5b1bda80ac.png)

Correctly validates against completely blank names
![Screen Shot 2022-08-28 at 15 11 12](https://user-images.githubusercontent.com/9074856/187092013-b4d39b49-cbff-4279-89c7-3579f155c9bf.png)

### Check miscellaneous styling

**Gradesheet**
![Screen Shot 2022-08-28 at 15 58 29](https://user-images.githubusercontent.com/9074856/187092247-25bfac23-6794-4492-8372-f6b6c740e28e.png)

**View student CUD**
![Screen Shot 2022-08-28 at 15 54 34](https://user-images.githubusercontent.com/9074856/187092103-240606ee-cb7e-4d67-834b-68c2dadd172e.png)

**Manage submissions**
![Screen Shot 2022-08-28 at 15 52 41](https://user-images.githubusercontent.com/9074856/187092037-2792bf8e-40a2-4a5d-9516-3468d4c7bdf8.png)

**Account**
![Screen Shot 2022-08-28 at 15 55 11](https://user-images.githubusercontent.com/9074856/187092143-75ddcb84-0781-4a52-b320-62dc84844011.png)

**Scoreboard**
![Screen Shot 2022-08-28 at 16 46 27](https://user-images.githubusercontent.com/9074856/187093916-d8c7ea69-c6c5-42a0-a4c4-129bfe240816.png)

**Watchlist**
![Screen Shot 2022-08-28 at 16 47 20](https://user-images.githubusercontent.com/9074856/187093920-59ec430a-c5f2-47f8-a73e-ec89f2114bc5.png)

**Grader information**
![Screen Shot 2022-08-28 at 16 55 45](https://user-images.githubusercontent.com/9074856/187094188-4a391e7e-61ed-489e-aff9-5ec9134d98e2.png)

**Also, check that various functionality such as sudo, extensions, create submissions still work**

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR
