### PR TITLE
Fix creation of missing submissions

### DIFF
--- a/app/views/components/_autocomplete.html.erb
+++ b/app/views/components/_autocomplete.html.erb
@@ -1,5 +1,5 @@
 <script type="application/javascript">
-  /* requires @usersEncoded and @users to be set, i.e. via retrieve_autocompletion_data! */
+  /* requires @usersEncoded and @users to be set, i.e. via Course.get_autocomplete_data */
   jQuery(function() {
     /* match user name/email with cud_id */
     /* escape_javascript prevents issues with backslashes in names, etc. */

--- a/app/views/submissions/new.html.erb
+++ b/app/views/submissions/new.html.erb
@@ -1,7 +1,3 @@
-<% content_for :javascripts do %>
-  <%= render partial: "components/autocomplete", locals: { hiddenCUDField: "#submission_course_user_datum_id" } %>
-<% end %>
-
 <h2>Create Submission for <%= link_to @assessment.display_name, [@course, @assessment] %> </h2>
 
 <p>
@@ -25,6 +21,10 @@
   <th>User:</th>
   <td>
   <% if params[:course_user_datum_id].nil? then %>
+
+  <% content_for :javascripts do %>
+    <%= render partial: "components/autocomplete", locals: { hiddenCUDField: "#submission_course_user_datum_id" } %>
+  <% end %>
 
   <div class="input-field">
     <input type="text" size="3" id="student_autocomplete" class="autocomplete" autocomplete="off"/>


### PR DESCRIPTION
## Description
- Only run autocomplete code on create submissions page when CUD is `nil`.

## Motivation and Context
As reported in `INC1029200`, an internal server error occurs when one attempts to fill in blank submissions for missing submissions.

This is because the autocomplete js code attempts to run even when CUD is set (so there's no need to autocomplete anything). However, the required data is not initialized in such a case, so we attempt to iterate over `nil`.

**Fill in Empty Submissions feature**
![Screen Shot 2022-09-10 at 20 10 02](https://user-images.githubusercontent.com/9074856/189505992-3299c194-c05e-4c82-a10b-e9b3b80d598a.png)

**Server only initializes autocomplete data when CUD is not nil**
![Screen Shot 2022-09-10 at 20 08 08](https://user-images.githubusercontent.com/9074856/189506006-88162735-855c-4b4b-a2b2-9758490ebcf0.png)

To remedy this, don't run autocomplete js code unless there is a need to.

## How Has This Been Tested?
- On an assessment with missing submissions, attempt to fill in empty submissions

**Before changes**
![Screen Shot 2022-09-10 at 20 12 49](https://user-images.githubusercontent.com/9074856/189506022-68ff435a-92ac-4613-a03f-7ee54e5da496.png)

**After changes**
![Screen Shot 2022-09-10 at 20 12 39](https://user-images.githubusercontent.com/9074856/189506025-b468cbcf-2184-4edc-adef-24f9399bb6e7.png)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR