### PR TITLE
Standardize roster upload tables

### DIFF
--- a/app/views/courses/_uploadError.html.erb
+++ b/app/views/courses/_uploadError.html.erb
@@ -6,41 +6,30 @@
     <thead>
       <tr>
         <th>&#8470;</th>
+        <th>Email</th>
         <th>First Name</th>
         <th>Last Name</th>
-        <th>Email</th>
         <th>Lecture</th>
-        <th>section</th>
+        <th>Section</th>
         <th>School</th>
         <th>Major</th>
         <th>Year</th>
-        <th>Nickname</th>
-        <th>Dropped?</th>
-        <th>Type</th>
+        <th>Grading Policy</th>
       </tr>
     </thead>
     <!-- Row index is set using CSS. -->
     <% rowList.each do |errorRow| %>
       <tr class="user-row">
         <td><%= errorRow["row_num"] %></td>
+        <td><%= errorRow["email"] %></td>
         <td><%= errorRow["first_name"] %></td>
         <td><%= errorRow["last_name"] %></td>
-        <td><%= errorRow["email"] %></td>
         <td><%= errorRow["lecture"] %></td>
         <td><%= errorRow["section"] %></td>
         <td><%= errorRow["school"] %></td>
         <td><%= errorRow["major"] %></td>
         <td><%= errorRow["year"] %></td>
-        <td><%= errorRow["nickname"] %></td>
-        <td><%= errorRow["dropped"] %></td>
-        <td><%= if errorRow["instructor"] then
-          "Instructor"
-        elsif errorRow["instructor"] then
-          "Course Assistant"
-        else
-          "Student"
-        end
-        %></td>
+        <td><%= errorRow["grade_policy"] %></td>
       </tr>
     <% end %>
   </table>

--- a/app/views/courses/_uploadTable.html.erb
+++ b/app/views/courses/_uploadTable.html.erb
@@ -1,9 +1,15 @@
 <table class='prettyBorder sortable' id="<%= sort_status %>" >
   <thead>
   <tr>
-    <th>email</th><th>first_name</th><th>last_name</th>
-    <th>lecture</th><th>section</th><th>school</th><th>major</th><th>year</th>
-    <th>grading_policy</th>
+    <th>Email</th>
+    <th>First Name</th>
+    <th>Last Name</th>
+    <th>Lecture</th>
+    <th>Section</th>
+    <th>School</th>
+    <th>Major</th>
+    <th>Year</th>
+    <th>Grading Policy</th>
   </tr>
   </thead>
   <% rowNum = 0 %>


### PR DESCRIPTION
## Description
- Remove underscores from success table's table header (`first_name`, `last_name`, `grading_policy`)
- Make error table's table header match that of the success table

## Motivation and Context
Currently, the headers of the roster upload error table is different from the success table. Furthermore, the success table's table header contains unnecessary underscores. This PR remedies both issues by removing the underscores and standardizing the table headers.

## How Has This Been Tested?
**Before changes**
![Screen Shot 2022-09-12 at 10 45 20](https://user-images.githubusercontent.com/9074856/189686774-93c384e8-0ce3-4d70-8deb-7746aa90ba3d.png)
![Screen Shot 2022-09-12 at 10 45 29](https://user-images.githubusercontent.com/9074856/189686775-67431005-7615-4868-a86c-a4249756fa4b.png)

**After changes**
![Screen Shot 2022-09-12 at 10 52 55](https://user-images.githubusercontent.com/9074856/189686820-a716dab3-989a-4cfc-b1af-e5e7424d5d29.png)
![Screen Shot 2022-09-12 at 10 52 34](https://user-images.githubusercontent.com/9074856/189686826-b9af2ac6-6254-4536-a84c-bc3d69216074.png)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR