### PR TITLE
Add reset layout button to student view

### DIFF
--- a/app/views/submissions/view.html.erb
+++ b/app/views/submissions/view.html.erb
@@ -91,6 +91,13 @@
       <% end %>
     </div>
   </div>
+<% else %>
+  <div class="row">
+    <div class="col s12 center-align valign-wrapper">
+      <button class="btn small" onclick="resetLayout()">Reset Layout</button>
+    </div>
+  </div>
+
 <% end %>
 
 <div class="row" id="speedgrader">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added the reset layout button to the student view of the speedgrader, so that students are now able to reset their Golden Layout configuration.
![Screen Shot 2022-09-17 at 2 30 27 PM](https://user-images.githubusercontent.com/50491000/190871643-20888246-b414-4897-b7c7-cb1d57351f3d.jpg)


## Motivation and Context
Currently, the only way for students to get back the default Golden Layout configuration is to clear localStorage.

## How Has This Been Tested?
* Reset layout button shows up on Speedgrader page in the student view & works when clicked
* Reset layout button shows up properly on Speedgrader page in the instructor view & works when clicked

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR

