### PR TITLE
[hotfix] Parameterize category names for allowlist

### DIFF
--- a/app/assets/javascripts/metrics_config.js
+++ b/app/assets/javascripts/metrics_config.js
@@ -2,13 +2,6 @@
 //= require semantic-ui
 
 // metrics api endpoints
-const parameterize = (str) => {
-  return str.trim().toLowerCase()
-          .replace(/[^a-z0-9\-_]+/g, "_")
-          .replace(/_{2,}/g, "_")
-          .replace(/^_|_$/g, "");
-}
-
 const metrics_config_endpoints = {
 	get_category: 'get_watchlist_category_blocklist',
 	update: 'update_watchlist_configuration',
@@ -23,7 +16,7 @@ $.getJSON(metrics_config_endpoints['get_category'],function(data, status){
 		if (status=='success') {
       data.forEach(category => {
         excluded_categories.push(category);
-				$(`#excluded_${parameterize(category)}`).css('visibility', 'visible');
+				$(`[id='excluded_${category}']`).css('visibility', 'visible');
 			});
 
 			$('#included_categories').children("div").each(function () {
@@ -37,8 +30,8 @@ $.getJSON(metrics_config_endpoints['get_category'],function(data, status){
 
 $('.exchange.icon').click(function(){
 	var category = $(this).attr("data-value");
-	var included_category = $(`#included_${category}`);
-	var excluded_category = $(`#excluded_${category}`);
+	var included_category = $(`[id='included_${category}']`);
+	var excluded_category = $(`[id='excluded_${category}']`);
 	if(included_category.css('visibility') == 'hidden') {
 		included_category.css('visibility', 'visible');
 		excluded_category.css('visibility', 'hidden');

--- a/app/assets/javascripts/metrics_config.js
+++ b/app/assets/javascripts/metrics_config.js
@@ -2,6 +2,13 @@
 //= require semantic-ui
 
 // metrics api endpoints
+const parameterize = (str) => {
+  return str.trim().toLowerCase()
+          .replace(/[^a-z0-9\-_]+/, "_")
+          .replace(/_{2,}/g, "_")
+          .replace(/^_|_$/g, "");
+}
+
 const metrics_config_endpoints = {
 	get_category: 'get_watchlist_category_blocklist',
 	update: 'update_watchlist_configuration',
@@ -12,11 +19,11 @@ Object.freeze(metrics_config_endpoints);
 
 $.getJSON(metrics_config_endpoints['get_category'],function(data, status){
 		excluded_categories = [];
-
+    
 		if (status=='success') {
-			data.forEach(category => {
-				excluded_categories.push(category);
-				$(`#excluded_${category}`).css('visibility', 'visible');
+      data.forEach(category => {
+        excluded_categories.push(category);
+				$(`#excluded_${parameterize(category)}`).css('visibility', 'visible');
 			});
 
 			$('#included_categories').children("div").each(function () {

--- a/app/assets/javascripts/metrics_config.js
+++ b/app/assets/javascripts/metrics_config.js
@@ -4,7 +4,7 @@
 // metrics api endpoints
 const parameterize = (str) => {
   return str.trim().toLowerCase()
-          .replace(/[^a-z0-9\-_]+/, "_")
+          .replace(/[^a-z0-9\-_]+/g, "_")
           .replace(/_{2,}/g, "_")
           .replace(/^_|_$/g, "");
 }
@@ -19,7 +19,7 @@ Object.freeze(metrics_config_endpoints);
 
 $.getJSON(metrics_config_endpoints['get_category'],function(data, status){
 		excluded_categories = [];
-    
+
 		if (status=='success') {
       data.forEach(category => {
         excluded_categories.push(category);

--- a/app/assets/javascripts/metrics_config.js
+++ b/app/assets/javascripts/metrics_config.js
@@ -14,8 +14,8 @@ $.getJSON(metrics_config_endpoints['get_category'],function(data, status){
 		excluded_categories = [];
 
 		if (status=='success') {
-      data.forEach(category => {
-        excluded_categories.push(category);
+			data.forEach(category => {
+				excluded_categories.push(category);
 				$(`[id='excluded_${category}']`).css('visibility', 'visible');
 			});
 

--- a/app/views/metrics/index.html.erb
+++ b/app/views/metrics/index.html.erb
@@ -228,21 +228,21 @@
       <h3> Included </h3>
       <div id="included_categories">
         <% for category in @course_assessment_categories do%>
-          <div class="item" id="included_<%=category.parameterize.underscore%>" style="visibility: hidden;"><%=category%></div><br />
+          <div class="item" id="included_<%=category%>" style="visibility: hidden;"><%=category%></div><br />
         <% end %>
       </div>
     </div>
     <div class="four wide column">
       <h3><br /></h3>
       <% for category in @course_assessment_categories do%>
-        <i class="exchange alternate icon" data-value="<%=category.parameterize.underscore%>"></i><br /><br />
+        <i class="exchange alternate icon" data-value="<%=category%>"></i><br /><br />
       <% end %>
     </div>
     <div class="five wide column">
       <h3> Excluded </h3>
       <div id="excluded_categories">
         <% for category in @course_assessment_categories do%>
-          <div class="item" id="excluded_<%=category.parameterize.underscore%>" style="visibility: hidden;"><%=category%></div><br />
+          <div class="item" id="excluded_<%=category%>" style="visibility: hidden;"><%=category%></div><br />
         <% end %>
       </div>
     </div>

--- a/app/views/metrics/index.html.erb
+++ b/app/views/metrics/index.html.erb
@@ -228,21 +228,21 @@
       <h3> Included </h3>
       <div id="included_categories">
         <% for category in @course_assessment_categories do%>
-          <div class="item" id="included_<%=category%>" style="visibility: hidden;"><%=category%></div><br />
+          <div class="item" id="included_<%=category.parameterize.underscore%>" style="visibility: hidden;"><%=category%></div><br />
         <% end %>
       </div>
     </div>
     <div class="four wide column">
       <h3><br /></h3>
       <% for category in @course_assessment_categories do%>
-        <i class="exchange alternate icon" data-value="<%=category%>"></i><br /><br />
+        <i class="exchange alternate icon" data-value="<%=category.parameterize.underscore%>"></i><br /><br />
       <% end %>
     </div>
     <div class="five wide column">
       <h3> Excluded </h3>
       <div id="excluded_categories">
         <% for category in @course_assessment_categories do%>
-          <div class="item" id="excluded_<%=category%>" style="visibility: hidden;"><%=category%></div><br />
+          <div class="item" id="excluded_<%=category.parameterize.underscore%>" style="visibility: hidden;"><%=category%></div><br />
         <% end %>
       </div>
     </div>


### PR DESCRIPTION
## Description
Previously, nothing would happen when a user clicked on the switch icon between the "Included" and "Excluded" list for assignment categories that have spaces in the names (e.g. "Optional Assignments"). This was caused because the category names were being used as ID's, which caused the jQuery to return undefined for categories with spaces. This was fixed by altering the jQuery to look for `[id='included_${category}']`, rather than individual id tags (which looks for id's separated by spaces separately, causing nothing to be returned).

## How Has This Been Tested?
* Toggled included/excluded for both categories with and without spaces and made sure it saved properly.
* Category names with other non-alphanumeric characters (e.g. $, %, etc.)
* Category names with trailing whitespaces or multiple non-alphanumeric characters in a row

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR

