### PR TITLE
[hotfix] Removes possiblility to have a submission time in the future when bul…

### DIFF
--- a/app/controllers/assessment/grading.rb
+++ b/app/controllers/assessment/grading.rb
@@ -113,7 +113,7 @@ private
               course_user_datum_id: user.id,
               assessment_id: asmt.id,
               submitted_by_id: @cud.id,
-              created_at: asmt.due_at
+              created_at: [Time.current, asmt.due_at].min
             )
           end
 


### PR DESCRIPTION
…k importing grades

<!--- Provide a general summary of your changes in the Title above -->

## Description
Changed the logic for setting the `created_at` time when bulk importing grades. New logic sets `created_at` to the minimum of the current time, and the assignment due date. 

## Motivation and Context
Previously, when bulk importing grades, `created_at` was set to the assignment due date. If the assignment due date was then moved to be earlier (e.g. to release grades earlier), the grades imported would incur penalty late days. With this change, moving the due date to an earlier time (not in the past), will not cause grades uploaded using bulk import to incur penalty late days.

## How Has This Been Tested?
Verify that bulk importing before the due date sets the submission time to the current time.
- Creating an assignment with a future due date.
- Bulk import grades
- Verify that the submission time of imported grades is equal the current time

Verify that bulk importing after the due date sets the submission time to the due date.
- Creating an assignment with a past due date.
- Bulk import grades
- Verify that the submission time of imported grades is equal the due date

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR
