### PR TITLE
Fix order of annotations on feedback view and file view to be consistent

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -331,6 +331,22 @@ protected
     emails.join(",")
   end
 
+  # gets a filename string to be able to sort files properly
+  # by changing the filename if it's the autograded output
+  # or it's an archived file
+  def get_correct_filename(annotation, files, submission)
+    if annotation.position == -1
+      # position -1 maps to the Autograder Output
+      "Autograder Output"
+    elsif files && annotation.position != 0
+      # if the submission is an archive, use filename in archive;
+      # otherwise, use submission filename
+      Archive.get_nth_filename(files, annotation.position)
+    else
+      submission.filename
+    end
+  end
+
 private
 
   # called on Exceptions.  Shows a stack trace to course assistants, and above.

--- a/app/controllers/assessments_controller.rb
+++ b/app/controllers/assessments_controller.rb
@@ -582,18 +582,9 @@ class AssessmentsController < ApplicationController
       @files = Archive.get_files @submission.handin_file_path
     end
     @problemReleased = @submission.scores.pluck(:released).all?
+    # get_correct_filename is protected, so we wrap around controller-specific call
     @get_correct_filename = ->(annotation) {
-      filename = if annotation.position == -1
-                   # position -1 maps to the Autograder Output
-                   "Autograder Output"
-                 elsif @files && annotation.position
-                   # if the submission is an archive, use filename in archive;
-                   # otherwise, use submission filename
-                   Archive.get_nth_filename(@files, annotation.position)
-                 else
-                   @submission.filename
-                 end
-      return filename
+      get_correct_filename(annotation, @files, @submission)
     }
   end
 

--- a/app/controllers/assessments_controller.rb
+++ b/app/controllers/assessments_controller.rb
@@ -582,6 +582,19 @@ class AssessmentsController < ApplicationController
       @files = Archive.get_files @submission.handin_file_path
     end
     @problemReleased = @submission.scores.pluck(:released).all?
+    @get_correct_filename = ->(annotation) {
+      filename = if annotation.position == -1
+                   # position -1 maps to the Autograder Output
+                   "Autograder Output"
+                 elsif @files && annotation.position
+                   # if the submission is an archive, use filename in archive;
+                   # otherwise, use submission filename
+                   Archive.get_nth_filename(@files, annotation.position)
+                 else
+                   @submission.filename
+                 end
+      return filename
+    }
   end
 
   def parseScore(feedback)

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -461,10 +461,19 @@ class SubmissionsController < ApplicationController
       value = annotation.value || 0
       line = annotation.line
       problem = annotation.problem ? annotation.problem.name : "General"
-
+      filename = if annotation.position == -1
+                   # position -1 maps to the Autograder Output
+                   "Autograder Output"
+                 elsif @files && annotation.position != 0
+                   # if the submission is an archive, use filename in archive;
+                   # otherwise, use submission filename
+                   Archive.get_nth_filename(@files, annotation.position)
+                 else
+                   @submission.filename
+                 end
       @problemSummaries[problem] ||= []
       @problemSummaries[problem] << [description, value, line, annotation.submitted_by,
-                                     annotation.id, annotation.position]
+                                     annotation.id, annotation.position, filename]
 
       @problemGrades[problem] ||= 0
       @problemGrades[problem] += value

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -461,16 +461,7 @@ class SubmissionsController < ApplicationController
       value = annotation.value || 0
       line = annotation.line
       problem = annotation.problem ? annotation.problem.name : "General"
-      filename = if annotation.position == -1
-                   # position -1 maps to the Autograder Output
-                   "Autograder Output"
-                 elsif @files && annotation.position != 0
-                   # if the submission is an archive, use filename in archive;
-                   # otherwise, use submission filename
-                   Archive.get_nth_filename(@files, annotation.position)
-                 else
-                   @submission.filename
-                 end
+      filename = get_correct_filename(annotation, @files, @submission)
       @problemSummaries[problem] ||= []
       @problemSummaries[problem] << [description, value, line, annotation.submitted_by,
                                      annotation.id, annotation.position, filename]

--- a/app/views/assessments/viewFeedback.html.erb
+++ b/app/views/assessments/viewFeedback.html.erb
@@ -23,18 +23,23 @@ Yes, feedback is per problem but we show all annotations for this submission any
   <h2 style="margin-top: 1em">Remarks</h2>
 
   <ul>
-  <!-- TODO: Make order of annotations consistent with order of file list  -->
-  <% @submission.annotations.each do |annotation| %>
+  <!-- use custom sort b/c using ordering doesn't work with autograder output, archived files -->
+  <% @subs = @submission.annotations.sort do |a,b|
+     aFilename = @get_correct_filename.call(a)
+     bFilename = @get_correct_filename.call(b)
+     case
+       when aFilename< bFilename
+         -1
+       when aFilename > bFilename
+          1
+       else
+          a.line <=> b.line
+       end
+     end
+     @subs.each do |annotation| %>
     <li>
       <%= link_to annotation.as_text, [:view, @course, @assessment, @submission, header_position: annotation.position] %>
-      <% filename = if annotation.position == -1
-                     # position -1 maps to the Autograder Output
-                     "Autograder Output"
-                   else
-                     # if the submission is an archive, use filename in archive; otherwise, use submission filename
-                     @files && annotation.position ? Archive.get_nth_filename(@files, annotation.position) : @submission.filename
-                   end
-      %>
+      <% filename = @get_correct_filename.call(annotation) %>
       (<%= filename %>: <%= annotation.line %>)
     </li>
   <% end %>

--- a/app/views/assessments/viewFeedback.html.erb
+++ b/app/views/assessments/viewFeedback.html.erb
@@ -28,7 +28,7 @@ Yes, feedback is per problem but we show all annotations for this submission any
      aFilename = @get_correct_filename.call(a)
      bFilename = @get_correct_filename.call(b)
      case
-       when aFilename< bFilename
+       when aFilename < bFilename
          -1
        when aFilename > bFilename
           1

--- a/app/views/submissions/_annotation_pane.html.erb
+++ b/app/views/submissions/_annotation_pane.html.erb
@@ -15,7 +15,8 @@
             </div>
             <div class="collapsible-body">
               <% if @cud.instructor? or @cud.course_assistant? or @problemReleased%>
-                <% descriptTuples.each do |description, value, line, user, id, position| %>
+                <% puts(descriptTuples) %>
+                <% descriptTuples.sort_by{|a| [a[6], a[2]]}.each do |description, value, line, user, id, position, filename| %>
                   <div class="descript" id="li-annotation-<%= id %>"> <!-- Line + 1 because the code line numbers starts with 1 not 0. -->
                     <%= link_to(
                         url_for([:view, @course, @assessment, @submission, header_position: position.nil? ? 0 : position, line: line.nil? ? 1 : line+1]),
@@ -24,7 +25,7 @@
                         "data-line": line.nil? ? 1 : line+1,
                         remote: true,
                       ) do %>
-                        <span class="point_badge <%= value > 0 ? "positive" : value < 0 ? "negative" : "neutral" %>"><%= plus_fix(value) %></span> <%= description %>
+                        <span class="point_badge <%= value > 0 ? "positive" : value < 0 ? "negative" : "neutral" %>"><%= plus_fix(value) %></span> <%= description  %>
                     <% end %>
                   </div>
                 <% end %>

--- a/app/views/submissions/_annotation_pane.html.erb
+++ b/app/views/submissions/_annotation_pane.html.erb
@@ -15,7 +15,7 @@
             </div>
             <div class="collapsible-body">
               <% if @cud.instructor? or @cud.course_assistant? or @problemReleased%>
-                <% puts(descriptTuples) %>
+                <!-- a[6] = filename, a[2] = line-->
                 <% descriptTuples.sort_by{|a| [a[6], a[2]]}.each do |description, value, line, user, id, position, filename| %>
                   <div class="descript" id="li-annotation-<%= id %>"> <!-- Line + 1 because the code line numbers starts with 1 not 0. -->
                     <%= link_to(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Previously, the annotations on the "viewFeedback" page were sorted by creation date of the annotation, while the annotations on the file view were sorted by line number, which meant order wasn't maintained among the two views.

Previous feedback and file view:
![Screen Shot 2022-09-17 at 15 39 09](https://user-images.githubusercontent.com/25730111/190873922-a79019fb-3fa4-4e29-bfb9-470019013e23.png)
![Screen Shot 2022-09-17 at 15 38 45](https://user-images.githubusercontent.com/25730111/190873928-2419ae24-2583-4425-82f8-48e4e8360938.png)

I added sorting to both `viewFeedback.html.erb` and `_annotation_pane.html.erb` to first sort by the filename the annotation was added to, and then to sort by the line number.  The lambda function `get_correct_filename` was added to `assessments_controller.rb` since in multiple instances, we need to get the proper filename / change the filename if it's the autograded output or it's an archived file, in `viewFeedback.html.erb`. `submissions_controller.rb` also received similar code to append the proper filename to `problemSummaries`.

Revised annotation ordering for feedback and file view:
![Screen Shot 2022-09-17 at 15 38 18](https://user-images.githubusercontent.com/25730111/190874214-f509d6e1-ffae-4f4f-800a-d93cbf467ae3.png)
![Screen Shot 2022-09-17 at 15 38 30](https://user-images.githubusercontent.com/25730111/190874215-aabf1107-62f5-4fdd-a3e6-a61827b8fc46.png)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This issue was brought up by the 122 team, as they saw that "the order of annotations in the student feedback when they click on the score is not the same as the order when you look at the file page." There was also a TODO in `viewFeedback.html.erb` to make order of annotations consistent with the order of the file list.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- create / use an assessment that has multiple files (an autograded lab with additional problems is preferred)
- as a student account, submit a solution to the assessment, make sure it gets properly autograded
- as instructor, go to "grade submission" and click on the student submission, 
- add multiple annotations to multiple files in the student submission, and try adding some annotations in a random order with regards to line number (for example, add one annotation to the bottom of autograder output, and then add one annotation to the middle of the main submission file, then another at the bottom of the main submission file)
- make sure to add feedback for the problem in "viewGradesheet" for the student
- as a student, go to the assessment, and under the handin with the problem with annotations click on the score like so:
  - ![Screen Shot 2022-09-17 at 16 08 56](https://user-images.githubusercontent.com/25730111/190874789-dcad97b2-c053-4c4b-9ed6-0172b917d956.png)
- Verify that the order of the annotations is by file name and then by line number
- Go to the file view, verify that the order of the annotations is the same

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting



