### PR TITLE
Add Update Extension functionality

### DIFF
--- a/app/controllers/extensions_controller.rb
+++ b/app/controllers/extensions_controller.rb
@@ -28,7 +28,7 @@ class ExtensionsController < ApplicationController
       redirect_to(action: :index) && return
     end
 
-    cud = @course.course_user_data.find_by(id: cud_id)
+    cud = @course.course_user_data.find(cud_id)
     unless cud
       flash[:error] = "No student with id #{cud_id} was found for this course."
       redirect_to(action: :index) && return

--- a/app/controllers/extensions_controller.rb
+++ b/app/controllers/extensions_controller.rb
@@ -33,6 +33,22 @@ class ExtensionsController < ApplicationController
       flash[:error] = "No student with id #{cud_id} was found for this course."
       redirect_to(action: :index) && return
     end
+
+    # Check for existing extension, and if so, update
+    existing_ext = @assessment.extensions.find_by(course_user_datum_id: cud_id)
+    if existing_ext
+      existing_ext.days = params[:extension][:days]
+      existing_ext.infinite = params[:extension][:infinite]
+      existing_ext.save
+      if !existing_ext.errors.empty?
+        flash[:error] = existing_ext.errors.full_messages[0]
+      else
+        flash[:success] = "Extension updated successfully for user #{cud.email}."
+      end
+      redirect_to(action: :index) && return
+    end
+
+    # Create new extension instead
     ext = @assessment.extensions.create(extension_params)
     if !ext.errors.empty?
       flash[:error] = ext.errors.full_messages[0]

--- a/app/models/extension.rb
+++ b/app/models/extension.rb
@@ -10,9 +10,9 @@ class Extension < ApplicationRecord
   after_destroy :invalidate_cgdubs_for_assessments_after
 
   def days_or_infinite
-    return unless days.blank? && !infinite?
+    return unless (days.blank? || days < 0) && !infinite?
 
-    errors.add(:base, "Please enter days of extension, or mark as infinite.")
+    errors.add(:base, "Please enter (≥ 0) days of extension, or mark as infinite.")
   end
 
   def invalidate_cgdubs_for_assessments_after

--- a/app/views/components/_autocomplete.html.erb
+++ b/app/views/components/_autocomplete.html.erb
@@ -26,7 +26,7 @@
     /* track changes in student autocomplete field */
     $studentAutocompleteField.on('change', function() {
       /* $studentAutocompleteField.val() unescapes a second time */
-      const encoded = window.btoa($studentAutocompleteField.val())
+      const encoded = window.btoa($studentAutocompleteField.val());
       // Trigger 'change' event for any code that might be listening
       $hiddenCUDField.val(userData[encoded]).trigger('change');
     });

--- a/app/views/components/_autocomplete.html.erb
+++ b/app/views/components/_autocomplete.html.erb
@@ -27,7 +27,8 @@
     $studentAutocompleteField.on('change', function() {
       /* $studentAutocompleteField.val() unescapes a second time */
       const encoded = window.btoa($studentAutocompleteField.val())
-      $hiddenCUDField.val(userData[encoded]);
+      // Trigger 'change' event for any code that might be listening
+      $hiddenCUDField.val(userData[encoded]).trigger('change');
     });
   });
 </script>

--- a/app/views/components/_autocomplete.html.erb
+++ b/app/views/components/_autocomplete.html.erb
@@ -3,15 +3,15 @@
   jQuery(function() {
     /* match user name/email with cud_id */
     /* escape_javascript prevents issues with backslashes in names, etc. */
-    userData = {
+    const userData = {
       <% @usersEncoded.each do |k,v| %>
         "<%= j k %>": "<%= v %>",
       <% end %>
     };
 
     /* user autocomplete */
-    $studentAutocompleteField = $('#student_autocomplete');
-    $hiddenCUDField = $('<%= hiddenCUDField %>');
+    const $studentAutocompleteField = $('#student_autocomplete');
+    const $hiddenCUDField = $('<%= hiddenCUDField %>');
     /* note that the names were already escaped once in retrieve_autocompletion_data! */
     /* and now, each name (k) is implicitly escaped a second time */
     /* this is desired behavior since autocomplete unescapes once */
@@ -26,7 +26,7 @@
     /* track changes in student autocomplete field */
     $studentAutocompleteField.on('change', function() {
       /* $studentAutocompleteField.val() unescapes a second time */
-      encoded = window.btoa($studentAutocompleteField.val())
+      const encoded = window.btoa($studentAutocompleteField.val())
       $hiddenCUDField.val(userData[encoded]);
     });
   });

--- a/app/views/extensions/index.html.erb
+++ b/app/views/extensions/index.html.erb
@@ -5,22 +5,23 @@
   <script type="application/javascript">
     jQuery(function() {
       /* set up dates */
-      $dueDate = moment("<%= @assessment.due_at.to_s %>", "YYYY-MM-DD hh:mm:ss ZZ").startOf('day');
+      const $dueDate = moment("<%= @assessment.due_at.to_s %>", "YYYY-MM-DD hh:mm:ss ZZ").startOf('day');
 
-      $extensionDaysField = $('#extension_days');
-      $extensionNewDayField = $('#extension_due_at');
-      $extensionDaysLabel = $('label[for="extension_days"]');
+      const $extensionDaysField = $('#extension_days');
+      const $extensionNewDayField = $('#extension_due_at');
+      const $extensionDaysLabel = $('label[for="extension_days"]');
+      const $studentAutocompleteField = $('#student_autocomplete');
 
       /* set up flatpickr (not using initialize_datetimepickers script since
       * it seems to be causing trouble with setting minDate). */
-      $extensionNewDayFlatpickr = flatpickr($extensionNewDayField, {
+      const $extensionNewDayFlatpickr = flatpickr($extensionNewDayField, {
           altInput: true,
           defaultDate: $dueDate.valueOf(),
           minDate: $dueDate.valueOf()
       });
 
       /* Enable/disable extension days options */
-      $enableInfiniteExtension = $('#extension_infinite');
+      const $enableInfiniteExtension = $('#extension_infinite');
       if ($enableInfiniteExtension.is(':checked')) {
         $extensionDaysField.prop('disabled',true);
         $extensionNewDayField.prop('disabled',true);
@@ -37,13 +38,13 @@
 
       /* two-way-bind newDayField with daysField */
       $extensionDaysField.on('change', function() {
-        $newDate = moment($dueDate);
+        const $newDate = moment($dueDate);
         $newDate.add($extensionDaysField.val(), 'days').startOf('day');
         $extensionNewDayFlatpickr.setDate($newDate.toDate());
       });
       $extensionNewDayField.on('change', function() {
-        $newDate = moment($extensionNewDayField.val()).startOf('day');
-        $extendBy = $newDate.diff($dueDate, 'days');
+        const $newDate = moment($extensionNewDayField.val()).startOf('day');
+        const $extendBy = $newDate.diff($dueDate, 'days');
         $extensionDaysField.val($extendBy);
         $extensionDaysLabel.addClass("active");
       });

--- a/app/views/extensions/index.html.erb
+++ b/app/views/extensions/index.html.erb
@@ -146,7 +146,9 @@
         <% end %>
       </tbody>
     </table>
-    <p>Click on an email above to update the extension.</p>
+    <% if !@extensions.empty? %>
+      <p>Click on an email above to update the extension.</p>
+    <% end %>
   </div>
 
   <div class="col s12 m6">

--- a/app/views/extensions/index.html.erb
+++ b/app/views/extensions/index.html.erb
@@ -10,7 +10,6 @@
       const $extensionDaysField = $('#extension_days');
       const $extensionNewDayField = $('#extension_due_at');
       const $extensionDaysLabel = $('label[for="extension_days"]');
-      const $hiddenCUDField = $('#extension_course_user_datum_id');
 
       /* set up flatpickr (not using initialize_datetimepickers script since
       * it seems to be causing trouble with setting minDate). */
@@ -22,7 +21,7 @@
 
       /* Enable/disable extension days options */
       const $enableInfiniteExtension = $('#extension_infinite');
-      function checkInfiniteExtension () {
+      function checkInfiniteExtension() {
         if ($enableInfiniteExtension.is(':checked')) {
           $extensionDaysField.prop('disabled',true);
           $extensionNewDayField.prop('disabled',true);
@@ -32,7 +31,7 @@
         }
       }
 
-      $enableInfiniteExtension.click(() => checkInfiniteExtension());
+      $enableInfiniteExtension.click(checkInfiniteExtension);
 
       /* two-way-bind newDayField with daysField */
       $extensionDaysField.on('change', function() {
@@ -48,30 +47,42 @@
       });
 
       /* Automatically display details of existing extensions */
-
+      const $studentAutocompleteField = $('#student_autocomplete');
+      const $studentAutocompleteLabel = $('label[for=\'student_autocomplete\']');
+      const $hiddenCUDField = $('#extension_course_user_datum_id');
       const $updateWarning = $('#update-warning');
-      // Map CUD to days / infinite details
-      const CUDMap = {
-          <% @extensions.each do |ext| %>
-            "<%= ext.course_user_datum_id %>": {
-                days: "<%= ext.days %>",
-                infinite: <%= ext.infinite %>
-            },
-          <% end %>
+      const $studentSelect = $('.student-select');
+      const $autocomplete = M.Autocomplete.getInstance($studentAutocompleteField);
+      /* Map CUD to days / infinite details */
+      const CUDToExtensionsMap = {
+        <% @extensions.each do |ext| %>
+          "<%= ext.course_user_datum_id %>": {
+            days: "<%= ext.days %>",
+            infinite: <%= ext.infinite %>
+          },
+        <% end %>
       };
+      const CUDToFullnameMap = {
+        <% @users.each do |k,v| %>
+          "<%= v %>": "<%= j k %>",
+        <% end %>
+      }
 
       $hiddenCUDField.on('change', function() {
         const cud = $hiddenCUDField.val();
-        if (cud === '') return;
+        if (cud === '' && $studentAutocompleteField.val() !== '') {
+          // Don't update, cud is just temporarily blank while the option is being selected
+          return;
+        }
 
-        const extensionExists = cud in CUDMap;
+        const extensionExists = cud in CUDToExtensionsMap;
 
         let extensionDays = '0';
         let infiniteExtension = false;
         if (extensionExists) {
-            const extensionData = CUDMap[cud];
-            extensionDays = extensionData.days || '0';
-            infiniteExtension = extensionData.infinite;
+          const extensionData = CUDToExtensionsMap[cud];
+          extensionDays = extensionData.days || '0';
+          infiniteExtension = extensionData.infinite;
         }
         /* Populate fields */
         $extensionDaysField.val(extensionDays);
@@ -80,7 +91,20 @@
         checkInfiniteExtension();
       });
 
-      // Initialization
+      // https://stackoverflow.com/questions/69317948/how-to-use-selectoption-in-autocomplete
+      function selectStudent(e) {
+        const $student = $(e.target);
+        const cud = $student.data('cud');
+        const fullName = CUDToFullnameMap[cud];
+        console.log(cud, fullName);
+        $studentAutocompleteField.val(fullName);
+        $studentAutocompleteLabel.addClass('active');
+        $studentAutocompleteField.trigger('change');
+      }
+
+      $studentSelect.click((e) => selectStudent(e));
+
+      /* Initialization */
       checkInfiniteExtension();
       $updateWarning.hide();
     });
@@ -90,7 +114,7 @@
 
 <div class="row">
   <div class="col s12 m6">
-    <p><b>Current Extensions (<%= @extensions.size %>)</b></p>
+    <h4>Current Extensions (<%= @extensions.size %>)</h4>
     <table class="verticalTable">
       <thead>
         <tr>
@@ -107,7 +131,7 @@
         <% else %>
           <% @extensions.each do |ext| %>
             <tr>
-              <td><%= ext.course_user_datum.email %></td>
+              <td><a class="clickable student-select" data-cud=<%= ext.course_user_datum_id %>><%= ext.course_user_datum.email %></a></td>
               <td style="padding: 0 5px"><%= ext.infinite? ? "Infinite" : "#{pluralize(ext.days, "day")}" %></td>
               <td><%= link_to '<i class="material-icons">delete</i>'.html_safe, [@course, @assessment, ext],
                               data: { confirm: 'Are you sure you want to delete the extension for user ' + ext.course_user_datum.email + '?' },
@@ -120,23 +144,23 @@
   </div>
 
   <div class="col s12 m6">
-    <p><b>Create/Update Extension</b></p>
-      <%= form_for @new_extension, :as=>"extension", :url=>{:action=>"create"}, builder: FormBuilderWithDateTimeInput do |f| %>
-        <div class="input-field">
-          <input type="text" size="3" id="student_autocomplete" class="autocomplete" autocomplete="off"/>
-          <label for="student_autocomplete">Start typing student name or email</label>
-        </div>
-        <p>Select a new due date (Currently due at: <span class="moment-date-time"><%= @assessment.due_at.to_s %></span>)</p>
-        <%= f.date_select :due_at, greater_than: @assessment.due_at, id: "extension_due_at" %>
-        <p>-OR- Specify number of days to extend:</p>
-        <%= f.number_field :days, :size=>3, :placeholder=>0, :value=>0, :min=>0, :id=>"extension_days" %>
-        <p>-OR- Infinite Extension?</p>
-        <%= f.check_box :infinite, id: "extension_infinite" %>
-        <%= f.hidden_field(:course_user_datum_id)%>
-        <%= f.hidden_field(:assessment_id)%>
-        <p id="update-warning" class="red-text">This student has a current extension. Submitting will override it!</p>
-        <%= f.submit "Create/Update" , {:class=>"btn primary"} %>
-      <% end %>
+    <h4>Create/Update Extension</h4>
+    <%= form_for @new_extension, :as=>"extension", :url=>{:action=>"create"}, builder: FormBuilderWithDateTimeInput do |f| %>
+      <div class="input-field">
+        <input type="text" size="3" id="student_autocomplete" class="autocomplete" autocomplete="off"/>
+        <label for="student_autocomplete">Start typing student name or email</label>
+      </div>
+      <p>Select a new due date (Currently due at: <span class="moment-date-time"><%= @assessment.due_at.to_s %></span>)</p>
+      <%= f.date_select :due_at, greater_than: @assessment.due_at, id: "extension_due_at" %>
+      <p>-OR- Specify number of days to extend:</p>
+      <%= f.number_field :days, :size=>3, :placeholder=>0, :value=>0, :min=>0, :id=>"extension_days" %>
+      <p>-OR- Infinite Extension?</p>
+      <%= f.check_box :infinite, id: "extension_infinite" %>
+      <%= f.hidden_field(:course_user_datum_id)%>
+      <%= f.hidden_field(:assessment_id)%>
+      <p id="update-warning" class="red-text">This student has a current extension. Submitting will override it!</p>
+      <%= f.submit "Create/Update" , {:class=>"btn primary"} %>
+    <% end %>
   </div>
 
 </div>

--- a/app/views/extensions/index.html.erb
+++ b/app/views/extensions/index.html.erb
@@ -65,19 +65,27 @@
       </thead>
 
       <tbody>
-        <% for ext in @extensions do %>
+        <% if @extensions.empty? %>
           <tr>
-            <th><%= ext.course_user_datum.email %></th>
-            <td style="padding: 0 5px"><%= ext.infinite? ? "Infinite" : "#{ext.days} days" %></td>
-            <td><%= link_to '<i class="material-icons">delete</i>'.html_safe, [@course, @assessment, ext], method: :delete %></td>
+            <td colspan=3>There are currently no extensions for this assessment</td>
           </tr>
+        <% else %>
+          <% for ext in @extensions do %>
+            <tr>
+              <td><%= ext.course_user_datum.email %></td>
+              <td style="padding: 0 5px"><%= ext.infinite? ? "Infinite" : "#{pluralize(ext.days, "day")}" %></td>
+              <td><%= link_to '<i class="material-icons">delete</i>'.html_safe, [@course, @assessment, ext],
+                              data: { confirm: 'Are you sure you want to delete the extension for user ' + ext.course_user_datum.email + '?' },
+                              method: :delete %></td>
+            </tr>
+          <% end %>
         <% end %>
       </tbody>
     </table>
   </div>
 
   <div class="col s12 m6">
-    <p><b>Create New Extension</b></p>
+    <p><b>Create/Update Extension</b></p>
       <%= form_for @new_extension, :as=>"extension", :url=>{:action=>"create"}, builder: FormBuilderWithDateTimeInput do |f| %>
         <div class="input-field">
           <input type="text" size="3" id="student_autocomplete" class="autocomplete" autocomplete="off"/>
@@ -91,7 +99,7 @@
         <%= f.check_box :infinite, id: "extension_infinite" %>
         <%= f.hidden_field(:course_user_datum_id)%>
         <%= f.hidden_field(:assessment_id)%>
-        <%= f.submit "Create" , {:class=>"btn primary"} %>
+        <%= f.submit "Create/Update" , {:class=>"btn primary"} %>
       <% end %>
   </div>
 

--- a/app/views/extensions/index.html.erb
+++ b/app/views/extensions/index.html.erb
@@ -65,7 +65,7 @@
         <% @users.each do |k,v| %>
           "<%= v %>": "<%= j k %>",
         <% end %>
-      }
+      };
 
       $hiddenCUDField.on('change', function() {
         const cud = $hiddenCUDField.val();
@@ -98,7 +98,6 @@
         const $student = $(e.target);
         const cud = $student.data('cud');
         const fullName = CUDToFullNameMap[cud];
-        console.log(cud, fullName);
         $studentAutocompleteField.val(fullName);
         // To prevent overlap
         $studentAutocompleteLabel.addClass('active');

--- a/app/views/extensions/index.html.erb
+++ b/app/views/extensions/index.html.erb
@@ -88,6 +88,9 @@
         $extensionDaysField.val(extensionDays);
         $enableInfiniteExtension.prop('checked', infiniteExtension);
         $updateWarning.toggle(extensionExists);
+        // To update calendar picker
+        $extensionDaysField.trigger('change');
+        // To disable extension days field as necessary
         checkInfiniteExtension();
       });
 
@@ -98,7 +101,9 @@
         const fullName = CUDToFullnameMap[cud];
         console.log(cud, fullName);
         $studentAutocompleteField.val(fullName);
+        // To prevent overlap
         $studentAutocompleteLabel.addClass('active');
+        // To trigger CUD change, etc.
         $studentAutocompleteField.trigger('change');
       }
 
@@ -141,6 +146,7 @@
         <% end %>
       </tbody>
     </table>
+    <p>Click on an email above to update the extension.</p>
   </div>
 
   <div class="col s12 m6">
@@ -158,7 +164,7 @@
       <%= f.check_box :infinite, id: "extension_infinite" %>
       <%= f.hidden_field(:course_user_datum_id)%>
       <%= f.hidden_field(:assessment_id)%>
-      <p id="update-warning" class="red-text">This student has a current extension. Submitting will override it!</p>
+      <p id="update-warning" class="red-text">This student has a current extension. Submitting will update it!</p>
       <%= f.submit "Create/Update" , {:class=>"btn primary"} %>
     <% end %>
   </div>

--- a/app/views/extensions/index.html.erb
+++ b/app/views/extensions/index.html.erb
@@ -11,6 +11,14 @@
       $extensionNewDayField = $('#extension_due_at');
       $extensionDaysLabel = $('label[for="extension_days"]');
 
+      /* set up flatpickr (not using initialize_datetimepickers script since
+      * it seems to be causing trouble with setting minDate). */
+      $extensionNewDayFlatpickr = flatpickr($extensionNewDayField, {
+          altInput: true,
+          defaultDate: $dueDate.valueOf(),
+          minDate: $dueDate.valueOf()
+      });
+
       /* Enable/disable extension days options */
       $enableInfiniteExtension = $('#extension_infinite');
       if ($enableInfiniteExtension.is(':checked')) {
@@ -31,21 +39,13 @@
       $extensionDaysField.on('change', function() {
         $newDate = moment($dueDate);
         $newDate.add($extensionDaysField.val(), 'days').startOf('day');
-        $extensionNewDayField.flatpickr().setDate($newDate.toDate());
+        $extensionNewDayFlatpickr.setDate($newDate.toDate());
       });
       $extensionNewDayField.on('change', function() {
         $newDate = moment($extensionNewDayField.val()).startOf('day');
         $extendBy = $newDate.diff($dueDate, 'days');
         $extensionDaysField.val($extendBy);
         $extensionDaysLabel.addClass("active");
-      });
-
-      /* set up flatpickr (not using initialize_datetimepickers script since
-       * it seems to be causing trouble with setting minDate). */
-      $extensionNewDayField.flatpickr({
-        altInput: true,
-        defaultDate: $dueDate.valueOf(),
-        minDate: $dueDate.valueOf()
       });
     });
   </script>
@@ -85,7 +85,7 @@
         <p>Select a new due date (Currently due at: <span class="moment-date-time"><%= @assessment.due_at.to_s %></span>)</p>
         <%= f.date_select :due_at, greater_than: @assessment.due_at, id: "extension_due_at" %><br>
         <p>-OR- Specify number of days to extend:</p>
-        <%= f.text_field :days, :size=>3, :id => "extension_days" %>
+        <%= f.number_field :days, :size=>3, :placeholder=>0, :value=>0, :min=>0, :id=>"extension_days" %>
         <p>-OR- Infinite Extension?</p>
         <%= f.check_box :infinite, id: "extension_infinite" %>
         <%= f.hidden_field(:course_user_datum_id)%>

--- a/app/views/extensions/index.html.erb
+++ b/app/views/extensions/index.html.erb
@@ -10,7 +10,7 @@
       const $extensionDaysField = $('#extension_days');
       const $extensionNewDayField = $('#extension_due_at');
       const $extensionDaysLabel = $('label[for="extension_days"]');
-      const $studentAutocompleteField = $('#student_autocomplete');
+      const $hiddenCUDField = $('#extension_course_user_datum_id');
 
       /* set up flatpickr (not using initialize_datetimepickers script since
       * it seems to be causing trouble with setting minDate). */
@@ -22,11 +22,7 @@
 
       /* Enable/disable extension days options */
       const $enableInfiniteExtension = $('#extension_infinite');
-      if ($enableInfiniteExtension.is(':checked')) {
-        $extensionDaysField.prop('disabled',true);
-        $extensionNewDayField.prop('disabled',true);
-      }
-      $enableInfiniteExtension.click(function() {
+      function checkInfiniteExtension () {
         if ($enableInfiniteExtension.is(':checked')) {
           $extensionDaysField.prop('disabled',true);
           $extensionNewDayField.prop('disabled',true);
@@ -34,7 +30,11 @@
           $extensionDaysField.prop('disabled',false);
           $extensionNewDayField.prop('disabled',false);
         }
-      });
+      }
+
+      $enableInfiniteExtension.click(() => checkInfiniteExtension());
+      // Run once at the start
+      checkInfiniteExtension();
 
       /* two-way-bind newDayField with daysField */
       $extensionDaysField.on('change', function() {
@@ -47,6 +47,35 @@
         const $extendBy = $newDate.diff($dueDate, 'days');
         $extensionDaysField.val($extendBy);
         $extensionDaysLabel.addClass("active");
+      });
+
+      /* Automatically display details of existing extensions */
+
+      // Map CUD to days / infinite details
+      const CUDMap = {
+          <% @extensions.each do |ext| %>
+            "<%= ext.course_user_datum_id %>": {
+                days: "<%= ext.days %>",
+                infinite: <%= ext.infinite %>
+            },
+          <% end %>
+      };
+
+      $hiddenCUDField.on('change', function() {
+        const cud = $hiddenCUDField.val();
+        if (cud === '') return;
+
+        let extensionDays = '0';
+        let infiniteExtension = false;
+        if (cud in CUDMap) {
+            const extensionData = CUDMap[cud];
+            extensionDays = extensionData.days || '0';
+            infiniteExtension = extensionData.infinite;
+        }
+        /* Populate fields */
+        $extensionDaysField.val(extensionDays);
+        $enableInfiniteExtension.prop('checked', infiniteExtension);
+        checkInfiniteExtension();
       });
     });
   </script>
@@ -70,7 +99,7 @@
             <td colspan=3>There are currently no extensions for this assessment</td>
           </tr>
         <% else %>
-          <% for ext in @extensions do %>
+          <% @extensions.each do |ext| %>
             <tr>
               <td><%= ext.course_user_datum.email %></td>
               <td style="padding: 0 5px"><%= ext.infinite? ? "Infinite" : "#{pluralize(ext.days, "day")}" %></td>

--- a/app/views/extensions/index.html.erb
+++ b/app/views/extensions/index.html.erb
@@ -52,7 +52,6 @@
       const $hiddenCUDField = $('#extension_course_user_datum_id');
       const $updateWarning = $('#update-warning');
       const $studentSelect = $('.student-select');
-      const $autocomplete = M.Autocomplete.getInstance($studentAutocompleteField);
       /* Map CUD to days / infinite details */
       const CUDToExtensionsMap = {
         <% @extensions.each do |ext| %>
@@ -62,7 +61,7 @@
           },
         <% end %>
       };
-      const CUDToFullnameMap = {
+      const CUDToFullNameMap = {
         <% @users.each do |k,v| %>
           "<%= v %>": "<%= j k %>",
         <% end %>
@@ -98,7 +97,7 @@
       function selectStudent(e) {
         const $student = $(e.target);
         const cud = $student.data('cud');
-        const fullName = CUDToFullnameMap[cud];
+        const fullName = CUDToFullNameMap[cud];
         console.log(cud, fullName);
         $studentAutocompleteField.val(fullName);
         // To prevent overlap

--- a/app/views/extensions/index.html.erb
+++ b/app/views/extensions/index.html.erb
@@ -33,8 +33,6 @@
       }
 
       $enableInfiniteExtension.click(() => checkInfiniteExtension());
-      // Run once at the start
-      checkInfiniteExtension();
 
       /* two-way-bind newDayField with daysField */
       $extensionDaysField.on('change', function() {
@@ -51,6 +49,7 @@
 
       /* Automatically display details of existing extensions */
 
+      const $updateWarning = $('#update-warning');
       // Map CUD to days / infinite details
       const CUDMap = {
           <% @extensions.each do |ext| %>
@@ -65,9 +64,11 @@
         const cud = $hiddenCUDField.val();
         if (cud === '') return;
 
+        const extensionExists = cud in CUDMap;
+
         let extensionDays = '0';
         let infiniteExtension = false;
-        if (cud in CUDMap) {
+        if (extensionExists) {
             const extensionData = CUDMap[cud];
             extensionDays = extensionData.days || '0';
             infiniteExtension = extensionData.infinite;
@@ -75,8 +76,13 @@
         /* Populate fields */
         $extensionDaysField.val(extensionDays);
         $enableInfiniteExtension.prop('checked', infiniteExtension);
+        $updateWarning.toggle(extensionExists);
         checkInfiniteExtension();
       });
+
+      // Initialization
+      checkInfiniteExtension();
+      $updateWarning.hide();
     });
   </script>
 
@@ -121,13 +127,14 @@
           <label for="student_autocomplete">Start typing student name or email</label>
         </div>
         <p>Select a new due date (Currently due at: <span class="moment-date-time"><%= @assessment.due_at.to_s %></span>)</p>
-        <%= f.date_select :due_at, greater_than: @assessment.due_at, id: "extension_due_at" %><br>
+        <%= f.date_select :due_at, greater_than: @assessment.due_at, id: "extension_due_at" %>
         <p>-OR- Specify number of days to extend:</p>
         <%= f.number_field :days, :size=>3, :placeholder=>0, :value=>0, :min=>0, :id=>"extension_days" %>
         <p>-OR- Infinite Extension?</p>
         <%= f.check_box :infinite, id: "extension_infinite" %>
         <%= f.hidden_field(:course_user_datum_id)%>
         <%= f.hidden_field(:assessment_id)%>
+        <p id="update-warning" class="red-text">This student has a current extension. Submitting will override it!</p>
         <%= f.submit "Create/Update" , {:class=>"btn primary"} %>
       <% end %>
   </div>


### PR DESCRIPTION
## Description
Adds update functionality to extensions, alongside several improvements
- More meaningful flashes
- Improved validation against creation of extensions with < 0 days (change days field to type number with min 0, add validation on backend)
- Increase size of titles
- Add message when no extensions exist
- Add confirmation message for deletion of extensions
- Prevent flatpickr from losing `minDate` after any changes (due to re-initialization of component)

To update extensions, instructors can either click on a student's email in the sidebar, or input the student's name/email as usual. Then,
- The fields will auto-populate with the current extension details (will reset if we empty the name/email field)
- A warning will appear

## Motivation and Context
Currently, the only way to update an extension is to delete and re-create it, which can be error-prone. This PR adds the functionality to directly update an extension.

## How Has This Been Tested?
- Successfully create an extension
- Successfully delete an extension (after acknowledging popup)
- Input name of student with existing extension; fields autopopulate
- Click email of student with existing extension in sidebar; fields autopopulate
- Submitting updates an existing extension
- Clearing name field also clears the other fields

No extensions screen
![Screen Shot 2022-09-17 at 23 38 40](https://user-images.githubusercontent.com/9074856/190884644-cb5ab289-5025-44dc-b5b1-2e7f140ea507.png)

Deletion confirmation
![Screen Shot 2022-09-17 at 23 39 08](https://user-images.githubusercontent.com/9074856/190884651-6c12b1f8-eb21-46c9-a2a8-a5852e388312.png)

Clicking on email / inputting name automatically populates fields and displays warning
![Screen Shot 2022-09-17 at 23 39 23](https://user-images.githubusercontent.com/9074856/190884666-2aa5a1b1-82c1-4a1a-b807-9c91a8515109.png)

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting