### PR TITLE
Remove facebook and logout buttons

### DIFF
--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -1,9 +1,7 @@
 <div id="footer">
-    <a href="http://autolabproject.com">Autolab Project</a>
+    <a href="https://autolabproject.com">Autolab Project</a>
     &middot; <a href="/contact">Contact</a>
     &middot; <a href="https://github.com/autolab/Autolab">GitHub</a>
-    &middot; <a href="https://www.facebook.com/autolabproject">Facebook</a>
-    &middot; <%= link_to "Logout", destroy_user_session_path, method: :delete %>
 
     <span class="site_version">v<%= Rails.configuration.site_version %></span>
 </div>


### PR DESCRIPTION
## Description
Remove facebook and logout button.

## Motivation and Context
There is no purpose in having these buttons, as the facebook page is unused and the logout button already exists via the navbar.

## How Has This Been Tested?
**Before**
<img width="983" alt="Screen Shot 2022-09-24 at 14 34 01" src="https://user-images.githubusercontent.com/9074856/192113501-2b872f23-7dbb-4368-9245-51be67c8624c.png">

**After**
<img width="988" alt="Screen Shot 2022-09-24 at 14 33 52" src="https://user-images.githubusercontent.com/9074856/192113506-fa07f06b-8b7b-4f0f-9e11-d7f9249c1eae.png">

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting