### PR TITLE
[hotfix] In Assessment Submission Summary, only show one download option

### DIFF
--- a/app/controllers/assessments_controller.rb
+++ b/app/controllers/assessments_controller.rb
@@ -426,8 +426,6 @@ class AssessmentsController < ApplicationController
     rescue StandardError => e
       flash[:error] = "Unable to generate tarball -- #{e.message}"
       redirect_to action: "index"
-    else
-      flash[:success] = "Successfully exported the assessment."
     end
   end
 

--- a/app/views/assessments/_downloadSubmission.html.erb
+++ b/app/views/assessments/_downloadSubmission.html.erb
@@ -1,15 +1,17 @@
 <div class="history-download-pane" style="margin-right: 30px;">
   <% if can_always_download or not (sub.assessment.exam or sub.assessment.course.exam_in_progress) then %>
     <% mime_type = sub.detected_mime_type %>
-    <%= link_to download_course_assessment_submission_path(@course, @assessment, sub),
-                data: {toggle: "tooltip", placement:"top"}, title: "Download Submission", style:"white-space: nowrap" do %>
-      <span style="margin-right:3px;"><i class="material-icons">file_download</i></span>
-      Download Submission
-    <% end %>
     <% if mime_type =~ /text\/.*/ then %>
       <%= link_to download_course_assessment_submission_path(@course, @assessment, sub, forceMime: 'text/plain'),
                   data: {toggle: "tooltip", placement: "top"}, title: "Download as text/plain", style:"white-space: nowrap" do %>
         <span style="margin-right:3px;"><i class="material-icons">file_download</i></span>
+        Download Submission
+      <% end %>
+    <% else %>
+      <%= link_to download_course_assessment_submission_path(@course, @assessment, sub),
+                  data: {toggle: "tooltip", placement:"top"}, title: "Download Submission", style:"white-space: nowrap" do %>
+        <span style="margin-right:3px;"><i class="material-icons">file_download</i></span>
+        Download Submission
       <% end %>
     <% end %>
     <br>

--- a/app/views/assessments/_downloadSubmission.html.erb
+++ b/app/views/assessments/_downloadSubmission.html.erb
@@ -14,7 +14,9 @@
         Download Submission
       <% end %>
     <% end %>
-    <br>
+    <div style="height: 4px">
+      <br>
+    </div>
     <% if link = view_course_assessment_submission_path(@course, @assessment, sub) then %>
       <%= link_to link, data: {toggle: "tooltip", placement: "top"}, title: "View Source", aria: {label: "Justify"}, style: "margin-right:3px; white-space: nowrap" do %>
         <span><i class="material-icons">zoom_in</i></span>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
#1609 brought changes to the submission summary in the Assessments page, especially to removing the file name and displaying a "Download Submission" button. However, in the case that the submitted file is a text file, two download icons appear but the icon for downloading as text doesn't appear:
<img width="1147" alt="Screen Shot 2022-09-28 at 12 27 20" src="https://user-images.githubusercontent.com/25730111/192839212-bca9181c-d921-4072-a1f5-70734c49ee52.png">

Now, if a file is plaintext, only one Download Submission button will appear:
<img width="1066" alt="Screen Shot 2022-09-28 at 12 28 30" src="https://user-images.githubusercontent.com/25730111/192839312-c1440207-82f4-4367-a552-b720d5463eb9.png">

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- upload a submission of a plaintext file to an assessment
- go to submission summary and see only one option to download, hover over and see tooltip
- 
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR
