### PR TITLE
Hide view writeup button when no writeup exists

### DIFF
--- a/app/controllers/assessment/handout.rb
+++ b/app/controllers/assessment/handout.rb
@@ -31,6 +31,6 @@ module AssessmentHandout
       return
     end
 
-    flash[:error] = "There is no handout for this assessment."
+    flash.now[:error] = "There is no handout for this assessment."
   end
 end

--- a/app/controllers/assessments_controller.rb
+++ b/app/controllers/assessments_controller.rb
@@ -754,6 +754,7 @@ class AssessmentsController < ApplicationController
   action_auth_level :writeup, :student
 
   def writeup
+    # If the logic here changes, do update assessment#has_writeup?
     if @assessment.writeup_is_url?
       redirect_to @assessment.writeup
       return
@@ -768,7 +769,7 @@ class AssessmentsController < ApplicationController
       return
     end
 
-    @output = "There is no writeup for this assessment."
+    flash.now[:error] = "There is no writeup for this assessment."
   end
 
   # uninstall - uninstalls an assessment

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -325,6 +325,10 @@ class Assessment < ApplicationRecord
     scoreboard != nil
   end
 
+  def has_writeup?
+    writeup_is_url? || writeup_is_file?
+  end
+
   def groups
     Group.joins(:assessment_user_data).where(assessment_user_data: { assessment_id: id }).distinct
   end

--- a/app/views/assessments/show.html.erb
+++ b/app/views/assessments/show.html.erb
@@ -126,7 +126,7 @@
             <li><%= link_to "View handin history", {:action => 'history'}, {:title=> "View your submissions, scores, and feedback from the course staff" } %> </li>
 
             <% if @assessment.has_writeup? %>
-            <li><%= link_to "View writeup", {:action => 'writeup'}, {:title=> "View the assessment writeup", :class=>""}%> </li>
+              <li><%= link_to "View writeup", {:action => 'writeup'}, {:title=> "View the assessment writeup", :class=>""}%> </li>
             <% end %>
 
             <li><%= link_to "Download handout", {:action => 'handout'}, {:title=> "Download handout materials and starter code" } %> </li>
@@ -138,7 +138,7 @@
               <% end %>
             <% end %>
             <% if @assessment.has_scoreboard? %>
-                <li><%= link_to "View scoreboard", [@course, @assessment, :scoreboard], title: "View the assessment scoreboard" %></li>
+              <li><%= link_to "View scoreboard", [@course, @assessment, :scoreboard], title: "View the assessment scoreboard" %></li>
             <% end %>
 
           <% @list.sort { |a,b| a[1] <=> b[1] }.each { |key, value| %>

--- a/app/views/assessments/show.html.erb
+++ b/app/views/assessments/show.html.erb
@@ -124,7 +124,11 @@
         <div class="collapsible-body">
           <ul class="options">
             <li><%= link_to "View handin history", {:action => 'history'}, {:title=> "View your submissions, scores, and feedback from the course staff" } %> </li>
+
+            <% if @assessment.has_writeup? %>
             <li><%= link_to "View writeup", {:action => 'writeup'}, {:title=> "View the assessment writeup", :class=>""}%> </li>
+            <% end %>
+
             <li><%= link_to "Download handout", {:action => 'handout'}, {:title=> "Download handout materials and starter code" } %> </li>
             <% if @assessment.has_groups? %>
               <% if @aud.membership_status != AssessmentUserDatum::UNCONFIRMED then %>


### PR DESCRIPTION
## Description
* Hide view writeup button when writeup does not exist
* Use flash instead of text to report when writeup does not exist

Note: Defining an analogous check for handouts is harder because the config file might override the default handout behavior

Also note: `flash.now` is necessary because we are rendering directly rather than redirecting (as otherwise the flash would persist for an additional page load). I have updated handout's code to use `flash.now`, but it appears that `flash` works too because the route is defined in a different file and that somehow makes a difference.

## Motivation and Context
Currently, the view writeup button is visible to students even if no writeup exists. Furthermore, the error text is unnecessarily large.

## How Has This Been Tested?
**Before**

Error Text
![Screen Shot 2022-09-28 at 16 49 32](https://user-images.githubusercontent.com/9074856/192887276-751ea5c4-2f05-421e-b0dc-1ced372abd85.png)

Button visible
![Screen Shot 2022-09-28 at 16 49 48](https://user-images.githubusercontent.com/9074856/192887278-f0ce3ba0-9674-4647-910e-e4ab9a244d69.png)

**After**

Error Flash
![Screen Shot 2022-09-28 at 16 49 58](https://user-images.githubusercontent.com/9074856/192887286-00f97f27-5997-4549-b679-019a9e9889f9.png)

Button not visible
![Screen Shot 2022-09-28 at 16 49 55](https://user-images.githubusercontent.com/9074856/192887285-36de2c09-f28f-4fbd-8c87-bde82cc2fad1.png)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting