### PR TITLE
[hotfix] Use correct files list for sorting annotations when viewing an archive

### DIFF
--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -455,13 +455,16 @@ class SubmissionsController < ApplicationController
       @annotations = []
     end
 
+    if Archive.archive? @filename
+      files = Archive.get_files(@submission.handin_file_path)
+    end
     # extract information from annotations
     @annotations.each do |annotation|
       description = annotation.comment
       value = annotation.value || 0
       line = annotation.line
       problem = annotation.problem ? annotation.problem.name : "General"
-      filename = get_correct_filename(annotation, @files, @submission)
+      filename = get_correct_filename(annotation, files, @submission)
       @problemSummaries[problem] ||= []
       @problemSummaries[problem] << [description, value, line, annotation.submitted_by,
                                      annotation.id, annotation.position, filename]

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -456,7 +456,7 @@ class SubmissionsController < ApplicationController
     end
 
     if Archive.archive? @filename
-      files = Archive.get_files(@submission.handin_file_path)
+      files = Archive.get_files(@filename)
     end
     # extract information from annotations
     @annotations.each do |annotation|


### PR DESCRIPTION
## Description
Use result from `Archive.get_files`, rather than `@files`, when calling `get_correct_filename` in `view`.

Hotfix for #1590

## Motivation and Context
Currently, we are using `@files` when finding the filenames for annotations.

The problem with this is that `@files` is the result of `Archive.get_file_hierarchy`, whose length does not correspond directly to the number of files (subfiles are recursively nested). Rather its length is the number of "top level" files / directories.
<img width="539" alt="Screen Shot 2022-09-28 at 17 46 10" src="https://user-images.githubusercontent.com/9074856/192894456-2c84b5ae-a9d5-457b-a62a-3dcad2853c4a.png">

This further results in an error when `get_correct_filename` calls `Archive.get_nth_filename`, potentially on an out of bounds index.

However, `viewFeedback` handles this correctly since `@files` is only set for Archives, and is set to the result of `Archive.get_files`.
<img width="682" alt="Screen Shot 2022-09-28 at 17 48 20" src="https://user-images.githubusercontent.com/9074856/192894794-3c7eaef5-5f41-4a70-81dd-6b2ed9d19f5b.png">

## How Has This Been Tested?
* Create an assessment that accepts tar files
* Upload [hello.tar.zip](https://github.com/autolab/Autolab/files/9669116/hello.tar.zip) (unzip this first)
* Create a problem and annotate a nested file

**Before**
![Screen Shot 2022-09-28 at 17 49 31](https://user-images.githubusercontent.com/9074856/192894935-5d01a925-f29d-46ae-a056-9647e931a98c.png)

**After**
![Screen Shot 2022-09-28 at 17 49 52](https://user-images.githubusercontent.com/9074856/192894986-d349569a-8b57-41b8-abac-4925c1c8d742.png)


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting