### PR TITLE
Fixed annotation switching problems not updating score

### DIFF
--- a/app/controllers/annotations_controller.rb
+++ b/app/controllers/annotations_controller.rb
@@ -34,6 +34,10 @@ class AnnotationsController < ApplicationController
     tweaked_params.delete(:submission_id)
     tweaked_params.delete(:filename)
     ActiveRecord::Base.transaction do
+      # Remove effect of annotation to handle updating annotation problem
+      @annotation.update({ "value" => "0" })
+      @annotation.update_non_autograded_score
+
       @annotation.update(tweaked_params)
       @annotation.update_non_autograded_score
     end


### PR DESCRIPTION
## Motivation and Context
Previously, if an annotation was moved from one problem to another, the effect of the annotation's score would remain on the original problem as well as be applied to the new problem. With this fix, when an annotation moves problems, its impact on the score of the original problem is removed and appropriately applied to the new problem.

## How Has This Been Tested?
Set up an assessment with two problems, create an annotation for problem 1 with nonzero score, then update the annotation to apply to problem 2. Confirm that the total scores for problem 1 and problem 2 are correct.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR
