### PR TITLE
Show revised due date for manage extensions

### DIFF
--- a/app/views/extensions/index.html.erb
+++ b/app/views/extensions/index.html.erb
@@ -122,7 +122,8 @@
       <thead>
         <tr>
           <th>Email</th>
-          <th colspan=2>Length</th>
+          <th>Length</th>
+          <th colspan=2>New Due Date</th>
         </tr>
       </thead>
 
@@ -136,6 +137,7 @@
             <tr>
               <td><a class="clickable student-select" data-cud=<%= ext.course_user_datum_id %>><%= ext.course_user_datum.email %></a></td>
               <td style="padding: 0 5px"><%= ext.infinite? ? "Infinite" : "#{pluralize(ext.days, "day")}" %></td>
+              <td style="padding: 0 5px"><%= ext.infinite? ? "-" : "#{(@assessment.due_at + ext.days.days).strftime('%m-%d-%Y')}" %></td>
               <td><%= link_to '<i class="material-icons">delete</i>'.html_safe, [@course, @assessment, ext],
                               data: { confirm: 'Are you sure you want to delete the extension for user ' + ext.course_user_datum.email + '?' },
                               method: :delete %></td>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Created a column in the "manage extensions" table that shows the revised due date after accounting for the extensions.
![Screen Shot 2022-10-13 at 12 37 56 PM](https://user-images.githubusercontent.com/50491000/195655613-c75b0797-8915-4181-b347-a063bf2c2d2b.jpg)


## Motivation and Context
Requested by Zack Weinberg.

## How Has This Been Tested?
* Extensions with varying number of days
* Infinite extensions
* New column shows on update & delete
* Tested on several laptop screen sizes

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR

