### PR TITLE
Rework watchlist top button visibility, Allow student names to be copied

### DIFF
--- a/app/assets/javascripts/watchlist.js
+++ b/app/assets/javascripts/watchlist.js
@@ -193,7 +193,8 @@ function set_tab_html(is_search, instances, tab_name, archived_instances, empty_
       }
     }
   });
-  
+
+  // contact single watchlist student associated with student
   if (tab_name === "pending") {
     $('.ui.button.contact_single').click(function() {
 
@@ -214,9 +215,10 @@ function set_tab_html(is_search, instances, tab_name, archived_instances, empty_
     });
   }
 
+  // resolve for single watchlist student
   $('.ui.button.resolve_single').click(function() {
 
-    // disable all action buttons
+    // disable all action buttons associated with student
     var button_group = $(this).parent().find('button');
     button_group.prop('disabled', true);
     
@@ -547,35 +549,58 @@ $('.ui.vertical.fluid.tabular.menu .item').on('click', function() {
   updateButtonVisibility(this);
 });
 
+
+
+// helper function to configure top button visibility
+function showTopButtons(selectAllCheckbox, resolveButton, contactButton, deleteButton) {
+  if (selectAllCheckbox === true) {
+    $("#select_all_checkbox").show();
+  } else {
+    $("#select_all_checkbox").hide();
+  }
+  if (resolveButton === true) {
+    $("#resolve_button").show();
+  } else {
+    $("#resolve_button").hide();
+  }
+  if (contactButton === true) {
+    $("#contact_button").show();
+  } else {
+    $("#contact_button").hide();
+  }
+  if (deleteButton === true) {
+    $("#delete_button").show();
+  } else {
+    $("#delete_button").hide();
+  }
+}
+// controls visibility for top bar actions (select all, contact, resolve, delete)
 function updateButtonVisibility(item){
   // Deleting instances only avilable in archive tab
-  $("#delete_button").hide();
+  showTopButtons(true, true, true, false);
   switch ($(item).attr("data-tab")) {
     case "pending_tab":
+      // if no students pending
       if ($("#pending_tab #empty_tabs").length > 0) {
-        $("#contact_button").addClass("disabled");
-        $("#resolve_button").addClass("disabled");
-      } else {
-        $("#contact_button").removeClass("disabled");
-        $("#resolve_button").removeClass("disabled");
+        showTopButtons(false, false, false, false);
       }
       break;
     case "contacted_tab":
-      $("#contact_button").addClass("disabled");
+      // no students to contact
       if ($("#contacted_tab #empty_tabs").length > 0) {
-        $("#resolve_button").addClass("disabled");
+        showTopButtons(false, false, false, false);
       } else {
-        $("#resolve_button").removeClass("disabled");
+        // still allowed to resolve
+        showTopButtons(true, true, false, false);
       }
       break;
     case "resolved_tab":
-      $("#contact_button").addClass("disabled");
-      $("#resolve_button").addClass("disabled");
+      // no actions allowed
+      showTopButtons(false, false, false, false);
       break;
     case "archived_tab":
-      $("#contact_button").addClass("disabled");
-      $("#resolve_button").addClass("disabled");
-      $("#delete_button").show();
+      // only delete is allowed
+      showTopButtons(true, false, false, true);
       break;
     default:
       console.log(`${$(this).attr("data-tab")} is not a valid tab`);

--- a/app/assets/javascripts/watchlist.js
+++ b/app/assets/javascripts/watchlist.js
@@ -102,7 +102,7 @@ function get_condition_html(condition_types) {
         return;
     }
     conditions_html += `
-        <div class="ui circular label condition" data-html="${violation_string}" data-variation="wide"> 
+        <div class="ui circular label condition gray black-text" data-html="${violation_string}" data-variation="wide"> 
           ${condition_string}
         </div>`
   });

--- a/app/assets/javascripts/watchlist.js
+++ b/app/assets/javascripts/watchlist.js
@@ -26,15 +26,20 @@ function get_html_empty_message(message){
       </div>`;
 }
 
-function get_name_email_html(name, email) {
+function get_name_email_html(name, email, tab) {
+  // janky way of conditionally rendering checkbox
+  // display: none doesn't work and adding a parent div to
+  // checkbox is difficult
+  checkbox = tab !== "resolved" ?  `<input type="checkbox"/>` : ``;
+  checkboxclass = tab !== "resolved" ? "checkbox" : ""
   return `
-      <div class="ui checkbox select_single">
-        <input type="checkbox"/>
-        <label>
-          <p class="name_label"> ${escapeHtml(name)} </p>
-          <p class="email_label"> ${escapeHtml(email)} </p>
-        </label>
-      </div>`;
+        <div class="ui select_single ${checkboxclass}">
+          ${checkbox}
+          <label>
+            <p class="name_label"> ${escapeHtml(name)} </p>
+            <p class="email_label"> ${escapeHtml(email)} </p>
+          </label>
+        </div>`;
 }
 
 function get_gradebook_link_html(course_id, user_id) {
@@ -148,7 +153,7 @@ function get_row_html(user_id, instance, tab, archived_instances) {
   var condition_types = instance["conditions"];
   var course_id = instance["course_id"];
 
-  var name_email_html = get_name_email_html(name, email);
+  var name_email_html = get_name_email_html(name, email, tab);
   var gradebook_link_html = get_gradebook_link_html(course_id, user_id);
   var conditions_html = get_condition_html(condition_types);
   var buttons_html = get_buttons_html(user_id, tab, archived_instances);
@@ -179,7 +184,7 @@ function set_tab_html(is_search, instances, tab_name, archived_instances, empty_
   $('.ui.icon').popup();
   $('.ui.circular.label.condition').popup();
 
-  $('.ui.checkbox.select_single').checkbox({
+  $('.ui.checkbox.select_single.checkbox').checkbox({
     onChecked: function () { 
       selected_user_ids.push($(this).parent().parent().attr('id'));
     },
@@ -553,26 +558,10 @@ $('.ui.vertical.fluid.tabular.menu .item').on('click', function() {
 
 // helper function to configure top button visibility
 function showTopButtons(selectAllCheckbox, resolveButton, contactButton, deleteButton) {
-  if (selectAllCheckbox === true) {
-    $("#select_all_checkbox").show();
-  } else {
-    $("#select_all_checkbox").hide();
-  }
-  if (resolveButton === true) {
-    $("#resolve_button").show();
-  } else {
-    $("#resolve_button").hide();
-  }
-  if (contactButton === true) {
-    $("#contact_button").show();
-  } else {
-    $("#contact_button").hide();
-  }
-  if (deleteButton === true) {
-    $("#delete_button").show();
-  } else {
-    $("#delete_button").hide();
-  }
+  $("#select_all_checkbox").toggle(selectAllCheckbox);
+  $("#resolve_button").toggle(resolveButton);
+  $("#contact_button").toggle(contactButton);
+  $("#delete_button").toggle(deleteButton);
 }
 // controls visibility for top bar actions (select all, contact, resolve, delete)
 function updateButtonVisibility(item){

--- a/app/assets/stylesheets/metrics.scss
+++ b/app/assets/stylesheets/metrics.scss
@@ -129,6 +129,10 @@ i.external.alternate {
   min-width: max-content;
 }
 
+.name_label {
+  font-size: 14px;
+  font-weight: 400;
+}
 .email_label {
   color: grey;
   font-size: 10px;
@@ -136,8 +140,9 @@ i.external.alternate {
 }
 
 .select_single label {
+  // color, font-weight needed here for non checkbox label
   color: black;
-  font-size: 1em;
+  font-weight: 300;
   display: inline-block !important; 
   vertical-align: middle !important;
   -webkit-touch-callout: default !important; /* iOS Safari */
@@ -148,12 +153,19 @@ i.external.alternate {
   user-select: auto !important; /* Non-prefixed version, currently
                                 supported by Chrome and Opera */
 }
-
+// override materialize style for checkbox label
+.select_single [type="checkbox"] + label {
+  color: black;
+  font-weight: 300;
+}
 .ui.checkbox.select_single label:before, 
 .ui.checkbox.select_single label:after {
   top: 6.5px;
 }
-
+// override weight for watchlist label
+.segment .label {
+  font-weight: 400;
+}
 .ui.search .ui.input {
   width: 230px;
   float: right;

--- a/app/assets/stylesheets/metrics.scss
+++ b/app/assets/stylesheets/metrics.scss
@@ -104,7 +104,7 @@ input[type="text"] {
 
 .students-buttons-right{
   display: initial;
-  float: right;
+  margin-left: auto;
 }
 
 #undefined_metrics{
@@ -136,6 +136,8 @@ i.external.alternate {
 }
 
 .select_single label {
+  color: black;
+  font-size: 1em;
   display: inline-block !important; 
   vertical-align: middle !important;
   -webkit-touch-callout: default !important; /* iOS Safari */
@@ -186,6 +188,8 @@ span.instances .segment {
   border-radius: 0;
   border: none;
   border-top: 1px solid rgba(34,36,38,0.15);
+  display: flex;
+  align-items: center;
 }
 
 .select-all-chip {

--- a/app/assets/stylesheets/metrics.scss
+++ b/app/assets/stylesheets/metrics.scss
@@ -93,12 +93,13 @@ input[type="text"] {
 
 .top-bar {
   padding-left: 21%;
-  display: none;
+  display: flex;
+  align-items: center;
 }
 
 .last-updated{
-  float: right;
   margin-top: 15px;
+  margin-left: auto;
 }
 
 .students-buttons-right{
@@ -137,6 +138,13 @@ i.external.alternate {
 .select_single label {
   display: inline-block !important; 
   vertical-align: middle !important;
+  -webkit-touch-callout: default !important; /* iOS Safari */
+  -webkit-user-select: auto !important; /* Safari */
+  -khtml-user-select: default !important; /* Konqueror HTML */
+  -moz-user-select: auto !important; /* Firefox */
+  -ms-user-select: auto !important; /* Internet Explorer/Edge */
+  user-select: auto !important; /* Non-prefixed version, currently
+                                supported by Chrome and Opera */
 }
 
 .ui.checkbox.select_single label:before, 
@@ -178,4 +186,9 @@ span.instances .segment {
   border-radius: 0;
   border: none;
   border-top: 1px solid rgba(34,36,38,0.15);
+}
+
+.select-all-chip {
+  display: flex;
+  align-items: center;
 }

--- a/app/views/metrics/index.html.erb
+++ b/app/views/metrics/index.html.erb
@@ -19,10 +19,25 @@
 </div>
 <div class="ui tab active" data-tab="watchlist" id="watchlist_tab">
   <div class="top-bar">
-    <div class="ui checkbox select_all"><input type="checkbox"/></div>
-    <button class="ui submit small button" id="contact_button"><i class="mail outline icon"></i>CONTACT</button>
-    <button class="ui submit small button" id="resolve_button"><i class="check circle icon"></i>RESOLVE</button>
-    <button class="ui icon small button" id="delete_button" data-content="Removing selected student(s)"><i class="trash alternate icon"></i></button>
+    <span class="select-all-chip" id="select_all_checkbox">
+      <!-- hacky way to get checkbox aligned perfectly vertically, spaced -->
+      <div class="ui checkbox select_all" style="margin-top: 2px; margin-right: -5px;">
+        <input type="checkbox"/>
+      </div>
+      Select All Students
+    </span>
+    <button class="ui submit small button" id="contact_button">
+      <i class="mail outline icon"></i>
+      CONTACT
+    </button>
+    <button class="ui submit small button" id="resolve_button">
+      <i class="check circle icon"></i>
+      RESOLVE
+    </button>
+    <button class="ui icon small button" id="delete_button">
+      <i class="trash alternate icon"></i>
+      Delete from watchlist
+    </button>
     <div class="last-updated">
       <b id="last-updated-time"></b> <i class="repeat link icon" id="refresh_btn"></i>
     </div>


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

As part of UI Audit. 

- Previously, select all for watchlist had no tooltip / description. Also the checkbox is not centered with the other buttons. 

![Screen Shot 2022-10-23 at 16 51 56](https://user-images.githubusercontent.com/25730111/197417687-f4cd724c-d967-467b-b957-08ad443804ee.png)

- The top buttons would also be disabled in watchlist tabs where they should be hidden, because there is no use-case where they would be enabled.  The select all checkbox also would be rendered as well.
  - contact button in contacted tab never gets used
  - contact and resolve in resolved tab never gets used
  - contact and resolve in archived tab similarly

Current Contacted tab: (note how the student-specific actions doesn't have the contact option)
![Screen Shot 2022-10-23 at 16 14 36](https://user-images.githubusercontent.com/25730111/197417791-1aa64490-a407-4c79-8989-525d1a83ae0b.png) 

Current Pending with no students on pending:
![Screen Shot 2022-10-23 at 16 14 50](https://user-images.githubusercontent.com/25730111/197417792-1affea91-572c-44d8-a762-87595976fd76.png)

Current archived (contact and resolved disabled, but delete allowed):
![Screen Shot 2022-10-23 at 16 14 57](https://user-images.githubusercontent.com/25730111/197417793-0c433c2c-2285-4af5-a497-eb0585e364e9.png)

Current Resolved (no options available, but still shows up as disabled):
![Screen Shot 2022-10-23 at 16 54 35](https://user-images.githubusercontent.com/25730111/197417871-a67e020d-92a9-47c4-8f91-979d663904be.png)

## Changes

- Move top buttons into a flexbox to help center checkbox, add text label to select all checkbox
- Add `showTopButtons` to `watchlist.js` helper function to hide and show the top buttons based on watchlist tab, instead of disabling them, update `updateButtonVisibility` to use new function
- Add some slight documentation to `watchlist.js`
- Also change css for student single select checkbox to  allow student names to be copied from watchlist screen

Closes #1612


New top tab:
![Screen Shot 2022-10-23 at 16 58 59](https://user-images.githubusercontent.com/25730111/197418021-00165c7b-cba9-4df7-8ec9-a9453a3c5339.png)

Pending with no students:
![Screen Shot 2022-10-23 at 17 00 58](https://user-images.githubusercontent.com/25730111/197418100-3eba8d3a-7270-4d08-bbf3-249d60003292.png)

Contacted with / without students:
![Screen Shot 2022-10-23 at 17 00 34](https://user-images.githubusercontent.com/25730111/197418114-253783c1-6c43-45da-8cd9-0e92ef13befe.png)
![Screen Shot 2022-10-23 at 17 01 04](https://user-images.githubusercontent.com/25730111/197418115-1f7fc4e4-051e-45e6-ae1e-2b504171716a.png)

Resolved:
![Screen Shot 2022-10-23 at 17 00 40](https://user-images.githubusercontent.com/25730111/197418121-da9acd1b-3951-4d0b-a127-acfaa144e760.png)

Archived:
![Screen Shot 2022-10-23 at 17 00 49](https://user-images.githubusercontent.com/25730111/197418122-867d01df-c993-410a-b483-22eb48dbef70.png)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- View watchlist with students on pending, see all options except for delete appear
- View watchlist with students on contacted, see only select all and resolve appear
- View watchlist with no students on pending/contacted, see no options appear
- View resolved watchlist tab, see no options appear
- View archived watchlist tab, see only select all and delete appear
- Copy student name, email from watchlist

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
