### PR TITLE
Remove extraneous span padding on metrics page

### DIFF
--- a/app/assets/stylesheets/metrics.scss
+++ b/app/assets/stylesheets/metrics.scss
@@ -29,13 +29,13 @@ $autolab-subtle-red: #C87B7E;
   min-width: 20px !important;
 }
 
-span:before {
-  content:" "; 
+span.padded-span:before {
+  content:" ";
   display:inline-block; 
   width:10px;
 }
 
-span:after {
+span.padded-span:after {
   content:" "; 
   display:inline-block; 
   width:10px;

--- a/app/views/metrics/index.html.erb
+++ b/app/views/metrics/index.html.erb
@@ -114,7 +114,7 @@
           <input type="checkbox" tabindex="0" class="hidden" name="metrics-checkbox-1">
         </div>
         Students who have used
-        <span>
+        <span class="padded-span">
           <div class="ui selection dropdown" id="grace_days_value">
             <input type="hidden" name="grace_days">
             <i class="dropdown icon"></i>
@@ -127,7 +127,7 @@
           </div>
         </span>
         grace day(s) by
-        <span>
+        <span class="padded-span">
           <div class="ui calendar" id="grace_days_by_date">
             <div class="ui input left icon">
               <i class="calendar icon"></i>
@@ -145,11 +145,11 @@
           <input type="checkbox" tabindex="0" class="hidden" name="metrics-checkbox-2">
         </div>
         Students whose grades have dropped by
-        <span>
+        <span class="padded-span">
           <input type="text" placeholder="0" id='grade_drop_percentage'>
         </span>
         percent within
-        <span>
+        <span class="padded-span">
           <div class="ui selection dropdown" id='grade_drop_consecutive_counts'>
             <input type="hidden" name="number">
             <i class="dropdown icon"></i>
@@ -172,7 +172,7 @@
           <input type="checkbox" tabindex="0" class="hidden" name="metrics-checkbox-3">
         </div>
         Students who did not submit at least
-        <span>
+        <span class="padded-span">
           <div class="ui selection dropdown" id="no_submit_value">
             <input type="hidden" name="number">
             <i class="dropdown icon"></i>
@@ -195,7 +195,7 @@
           <input type="checkbox" tabindex="0" class="hidden" name="metrics-checkbox-4">
         </div>
         Students with at least
-        <span>
+        <span class="padded-span">
           <div class="ui selection dropdown" id="low_grades_count">
             <input type="hidden" name="number">
             <i class="dropdown icon"></i>
@@ -208,7 +208,7 @@
           </div>
         </span>
         submitted assignment(s) below a percentage of
-        <span>
+        <span class="padded-span">
           <input type="text" placeholder="0" id='low_grades_percentage'>
         </span>
       </div>


### PR DESCRIPTION
## Description

Add `.padded-span` class used to target `span`s that require padding.

## Motivation and Context

Currently, `metrics.scss` applies a style on all `span`s:

![Screen Shot 2022-10-27 at 16 01 50](https://user-images.githubusercontent.com/9074856/198386923-c791d84a-9297-4545-b999-dc6efa80b081.png)

This affects other elements that should not be selected.

**Metrics page** (the breadcrumb and site version in the footer are affected)

![Screen Shot 2022-10-27 at 16 03 19](https://user-images.githubusercontent.com/9074856/198387178-bf8f74b0-d0fb-4e97-90ec-e2a23e59615a.png)

**Other pages**

![Screen Shot 2022-10-27 at 16 04 43](https://user-images.githubusercontent.com/9074856/198387398-6bef76a8-5970-4c2c-a423-d87b6204706a.png)

## How Has This Been Tested?
- Verify that breadcrumbs and site version spans are now positioned correctly
- Ensure that metrics page appears visually the same

Namely, this page which the styling was meant for (the dropdown boxes). There are other spans on the page (the table bodies on the watchlist tabs), but they appear unaffected by the styling.
![Screen Shot 2022-10-27 at 16 08 15](https://user-images.githubusercontent.com/9074856/198388029-7ec5219c-241e-4142-a3e6-faf23d3d7297.png)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting