### PR TITLE
Revert "View Submission" and "Download Submission" to link_to

### DIFF
--- a/app/views/assessments/_downloadSubmission.html.erb
+++ b/app/views/assessments/_downloadSubmission.html.erb
@@ -3,7 +3,7 @@
     <% if link = view_course_assessment_submission_path(@course, @assessment, sub) then %>
       <%= link_to link, data: {toggle: "tooltip", placement: "top"}, title: "View Source",
                     aria: {label: "Justify"}, style: "margin-right:3px",
-                    class: "btn btn-small white submission-history-button", :method => :get do
+                    class: "btn btn-small white submission-history-button" do
       %>
         <span><i class="material-icons">zoom_in</i></span>
          View Source
@@ -16,7 +16,7 @@
     <% if mime_type =~ /text\/.*/ then %>
       <%= link_to download_course_assessment_submission_path(@course, @assessment, sub, forceMime: 'text/plain'),
           data: {toggle: "tooltip", placement: "top"}, title: "Download as text/plain",
-          class: "btn btn-small white submission-history-button", :method => :get do
+          class: "btn btn-small white submission-history-button" do
       %>
         <span style="margin-right:3px;"><i class="material-icons">file_download</i></span>
         Download Submission
@@ -24,7 +24,7 @@
     <% else %>
       <%= link_to download_course_assessment_submission_path(@course, @assessment, sub),
           data: {toggle: "tooltip", placement:"top"}, title: "Download Submission",
-          style:"", class: "btn btn-small white submission-history-button", :method => :get do
+          style:"", class: "btn btn-small white submission-history-button" do
       %>
         <span style="margin-right:3px;"><i class="material-icons">file_download</i></span>
         Download Submission

--- a/app/views/assessments/_downloadSubmission.html.erb
+++ b/app/views/assessments/_downloadSubmission.html.erb
@@ -1,7 +1,7 @@
 <div class="history-download-pane" style="margin-right: 30px;">
   <% if can_always_download or not (sub.assessment.exam or sub.assessment.course.exam_in_progress) then %>
     <% if link = view_course_assessment_submission_path(@course, @assessment, sub) then %>
-      <%= button_to link, data: {toggle: "tooltip", placement: "top"}, title: "View Source",
+      <%= link_to link, data: {toggle: "tooltip", placement: "top"}, title: "View Source",
                     aria: {label: "Justify"}, style: "margin-right:3px",
                     class: "btn btn-small white submission-history-button", :method => :get do
       %>
@@ -14,7 +14,7 @@
     </div>
     <% mime_type = sub.detected_mime_type %>
     <% if mime_type =~ /text\/.*/ then %>
-      <%= button_to download_course_assessment_submission_path(@course, @assessment, sub, forceMime: 'text/plain'),
+      <%= link_to download_course_assessment_submission_path(@course, @assessment, sub, forceMime: 'text/plain'),
           data: {toggle: "tooltip", placement: "top"}, title: "Download as text/plain",
           class: "btn btn-small white submission-history-button", :method => :get do
       %>
@@ -22,7 +22,7 @@
         Download Submission
       <% end %>
     <% else %>
-      <%= button_to download_course_assessment_submission_path(@course, @assessment, sub),
+      <%= link_to download_course_assessment_submission_path(@course, @assessment, sub),
           data: {toggle: "tooltip", placement:"top"}, title: "Download Submission",
           style:"", class: "btn btn-small white submission-history-button", :method => :get do
       %>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Brought up by @damianhxy. In #1624, links to "view submission" and "download submission" in the submission summary were turned into `button_to` rather than `link_to`. This resulted in buttons where users can't middle-click or right-click to open in a new tab. 

This PR reverts the buttons into `link_to` buttons, to bring the above functionality back.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`link_to` buttons (Minimal visual differences)
<img width="1053" alt="Screen Shot 2022-11-24 at 6 45 36" src="https://user-images.githubusercontent.com/25730111/203807168-2ba2c3fb-2bb7-4292-91e9-3a37eb935e45.png">

Previous `button_to` buttons
<img width="1055" alt="Screen Shot 2022-11-24 at 6 45 44" src="https://user-images.githubusercontent.com/25730111/203807174-37b62b09-5651-4f1e-88cf-d12706e8e164.png">

- check submission summaries of varying amounts of problems, varying amounts of submissions etc.
- check that buttons still work
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR