### PR TITLE
Add db migration support for spec tests

### DIFF
--- a/.github/workflows/rubyonrails.yml
+++ b/.github/workflows/rubyonrails.yml
@@ -61,6 +61,7 @@ jobs:
           ./bin/initialize_secrets.sh
           RAILS_ENV=test bundle exec rails db:create
           RAILS_ENV=test bundle exec rails db:schema:load
+          RAILS_ENV=test bundle exec rails db:migrate
           RAILS_ENV=test bundle exec rake autolab:populate
 
       - name: Run tests

--- a/.github/workflows/rubyonrails.yml
+++ b/.github/workflows/rubyonrails.yml
@@ -61,7 +61,6 @@ jobs:
           ./bin/initialize_secrets.sh
           RAILS_ENV=test bundle exec rails db:create
           RAILS_ENV=test bundle exec rails db:schema:load
-          RAILS_ENV=test bundle exec rails db:migrate
           RAILS_ENV=test bundle exec rake autolab:populate
 
       - name: Run tests

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -184,6 +184,16 @@ ActiveRecord::Schema.define(version: 2022_11_06_192532) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "lti_course_data", force: :cascade do |t|
+    t.string "context_id"
+    t.integer "course_id"
+    t.datetime "last_synced"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "membership_url"
+    t.string "platform"
+  end
+
   create_table "module_data", force: :cascade do |t|
     t.integer "field_id"
     t.integer "data_id"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Allows Ruby on rails spec tests to run db migrations.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
Previously without running migrations before running spec tests, the tests would immediately fail if a PR involved any db migrations.

## How Has This Been Tested?
Has not been tested, this is a speculative change based on the output of CI/CD runs that failed due to pending migrations.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR
