### PR TITLE
Annotations improvements and bugfixes

### DIFF
--- a/app/assets/javascripts/annotations.js
+++ b/app/assets/javascripts/annotations.js
@@ -373,10 +373,11 @@ function attachAnnotationPaneEvents() {
     const score = $(this).parent().data("score");
     const comment = $(this).parent().data("comment");
     const annotationId = $(this).parent().data("annotationid");
+    const shared = $(this).parent().data("shared");
     const $annotationDiv = $(this).parents(".global-annotation");
 
     if (!$annotationDiv.next().hasClass("global-annotation-form")) {
-      $annotationDiv.after(globalAnnotationFormCode(false, { problem, score, comment, annotationId }));
+      $annotationDiv.after(globalAnnotationFormCode(false, { problem, score, comment, annotationId, shared }));
     }
   });
 
@@ -550,7 +551,7 @@ function newAnnotationFormCode() {
 }
 
 // Create form code to create / update a global annotation
-// config takes the following keys: problem, score (for edit), comment (for edit)
+// config takes the following keys: problem, score (for edit), comment (for edit), shared (for edit)
 function globalAnnotationFormCode(newAnnotation, config) {
   const box = $(".base-global-annotation-form").clone();
   box.removeClass("base-global-annotation-form");
@@ -559,6 +560,7 @@ function globalAnnotationFormCode(newAnnotation, config) {
     box.find(".annotation-form-header").text("Update global annotation");
     box.find(".comment").val(config.comment);
     box.find(".score").val(config.score);
+    box.find("#shared-comment").prop("checked", config.shared);
     box.find('input[type=submit]').val("Update annotation");
   }
 

--- a/app/assets/javascripts/annotations.js
+++ b/app/assets/javascripts/annotations.js
@@ -469,18 +469,18 @@ function newAnnotationFormCode() {
   box.removeClass("base-annotation-line");
 
   // Creates a dictionary of problem and grader_id
-  var autogradedproblems = {}
+  var problemGraderId = {};
   _.each(scores, function (score) {
-    autogradedproblems[score.problem_id] = score.grader_id;
-  })
+    problemGraderId[score.problem_id] = score.grader_id;
+  });
 
   _.each(problems, function (problem) {
-    if (autogradedproblems[problem.id] != 0) { // Because grader == 0 is autograder
+    if (problemGraderId[problem.id] !== 0) { // Because grader == 0 is autograder
       box.find("select").append(
           $("<option />").val(problem.id).text(problem.name)
-      )
+      );
     }
-  })
+  });
 
   box.find('.annotation-form').show();
   box.find('.annotation-cancel-button').click(function (e) {
@@ -612,10 +612,18 @@ function initializeBoxForm(box, annotation) {
   var valueStr = annotation.value ? annotation.value.toString() : "0";
   var commentStr = annotation.comment;
 
+  // Creates a dictionary of problem and grader_id
+  var problemGraderId = {};
+  _.each(scores, function (score) {
+    problemGraderId[score.problem_id] = score.grader_id;
+  });
+
   _.each(problems, function (problem) {
-    box.find("select").append(
-      $("<option />").val(problem.id).text(problem.name)
-    )
+    if (problemGraderId[problem.id] !== 0) { // Because grader == 0 is autograder
+      box.find("select").append(
+          $("<option />").val(problem.id).text(problem.name)
+      );
+    }
   });
 
   box.find(".comment").val(commentStr);
@@ -975,19 +983,18 @@ var newAnnotationFormTemplatePDF = function (name, pageInd) {
   });
 
   // Creates a dictionary of problem and grader_id
-  var autogradedproblems = {}
-
+  var problemGraderId = {};
   _.each(scores, function (score) {
-    autogradedproblems[score.problem_id] = score.grader_id;
-  })
+    problemGraderId[score.problem_id] = score.grader_id;
+  });
 
   _.each(problems, function (problem) {
-    if (autogradedproblems[problem.id] != 0) { // Because grader == 0 is autograder
+    if (problemGraderId[problem.id] !== 0) { // Because grader == 0 is autograder
       problemSelect.appendChild(elt("option", {
         value: problem.id
       }, problem.name));
     }
-  })
+  });
 
   var newForm = elt("form", {
     title: "Press <Enter> to Submit",

--- a/app/assets/javascripts/annotations.js
+++ b/app/assets/javascripts/annotations.js
@@ -331,7 +331,7 @@ function attachEvents() {
     const $annotationLine = $("#annotation-line-" + annotationContainer);
     if ($annotationLine.find(".new-annotation").length === 0) {
       $annotationLine.append(newAnnotationFormCode());
-
+      $('.code-table').scrollTo($annotationLine.children().last(), { duration: "fast" });
       refreshAnnotations();
     } else {
       M.toast({html: 'Only one annotation can be created per line at a time!'});

--- a/app/assets/javascripts/annotations.js
+++ b/app/assets/javascripts/annotations.js
@@ -329,7 +329,7 @@ function attachEvents() {
     // Allow multiple annotations per line
     // However, only allow one annotation to be created per line at a time
     const $annotationLine = $("#annotation-line-" + annotationContainer);
-    if ($annotationLine.find(".new-annotation .annotation-form:visible").length === 0) {
+    if ($annotationLine.find(".new-annotation").length === 0) {
       $annotationLine.append(newAnnotationFormCode());
 
       refreshAnnotations();

--- a/app/assets/javascripts/annotations.js
+++ b/app/assets/javascripts/annotations.js
@@ -326,10 +326,16 @@ function attachEvents() {
     const line = $(this).parent().parent().parent();
     const annotationContainer = line.data("lineId");
 
-    // allow multiple annotations per line, as per 122's feedback
-    $("#annotation-line-" + annotationContainer).append(newAnnotationFormCode());
+    // Allow multiple annotations per line
+    // However, only allow one annotation to be created per line at a time
+    const $annotationLine = $("#annotation-line-" + annotationContainer);
+    if ($annotationLine.find(".new-annotation .annotation-form:visible").length === 0) {
+      $annotationLine.append(newAnnotationFormCode());
 
-    refreshAnnotations();
+      refreshAnnotations();
+    } else {
+      M.toast({html: 'Only one annotation can be created per line at a time!'});
+    }
   });
 }
 
@@ -477,6 +483,9 @@ function createAnnotation() {
 function newAnnotationFormCode() {
   var box = $(".base-annotation-line").clone();
   box.removeClass("base-annotation-line");
+
+  // Allow us to enforce the creation of one annotation per line at a time
+  box.addClass("new-annotation");
 
   // Creates a dictionary of problem and grader_id
   var problemGraderId = {};

--- a/app/assets/javascripts/annotations.js
+++ b/app/assets/javascripts/annotations.js
@@ -138,8 +138,10 @@ function plusFix(n) {
 // function called after create, update & delete of annotations
 function fillAnnotationBox() {
   retrieveSharedComments();
-  $('.problemGrades').load(document.URL + ' .problemGrades');
-  $('#annotationPane').load(document.URL + ' #annotationPane', function() {
+  $.get(document.URL, function(data) {
+    const $page = $('<div />').html(data);
+    $('.problemGrades').html($page.find('.problemGrades'));
+    $('#annotationPane').html($page.find(' #annotationPane'));
     $('.collapsible').collapsible({ accordion: false });
     attachChangeFileEvents();
     attachAnnotationPaneEvents();

--- a/app/assets/javascripts/annotations.js
+++ b/app/assets/javascripts/annotations.js
@@ -317,12 +317,10 @@ function attachEvents() {
     const line = $(this).parent().parent().parent();
     const annotationContainer = line.data("lineId");
 
-    // append an annotation form only if there is none currently
-    if ($("#annotation-line-" + annotationContainer).find(".annotation-line").length === 0) {
-      $("#annotation-line-" + annotationContainer).append(newAnnotationFormCode());
+    // allow multiple annotations per line, as per 122's feedback
+    $("#annotation-line-" + annotationContainer).append(newAnnotationFormCode());
 
-      refreshAnnotations();
-    }
+    refreshAnnotations();
   });
 }
 

--- a/app/assets/stylesheets/annotations.css
+++ b/app/assets/stylesheets/annotations.css
@@ -570,6 +570,11 @@
   display: flex;
 }
 
+.annotationSummary .global-annotation .annotation-badge,
+.annotationSummary .descript-link .annotation-badge {
+  flex-shrink: 0;
+}
+
 .annotationSummary .global-annotation .annotation-tools {
   flex-shrink: 0;
   margin-left: auto;
@@ -828,6 +833,7 @@
 }
 
 .descript-link {
+  display: flex;
   color: inherit;
   text-decoration: inherit;
 }

--- a/app/controllers/annotations_controller.rb
+++ b/app/controllers/annotations_controller.rb
@@ -62,7 +62,7 @@ class AnnotationsController < ApplicationController
   # Gets all shared_comments of annotations
   action_auth_level :shared_comments, :course_assistant
   def shared_comments
-    result = Annotation.select("annotations.id, annotations.comment")
+    result = Annotation.select("annotations.id, annotations.comment, annotations.problem_id")
                        .joins(:submission).where(shared_comment: true)
                        .where("submissions.assessment_id = ?", @assessment.id)
                        .order(updated_at: :desc).limit(50).as_json

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -464,8 +464,9 @@ class SubmissionsController < ApplicationController
     @scores = Score.where(submission_id: @submission.id)
 
     # @problemSummaries and @problemGrades are used in _annotation_pane.html.erb
-    @problemSummaries = {}
-    @problemGrades = {}
+    @problemAnnotations = {}
+    @problemMaxScores = {}
+    @problemScores = {}
     autogradedProblems = {}
 
     @scores.each do |score|
@@ -478,10 +479,11 @@ class SubmissionsController < ApplicationController
     @problems.each do |problem|
       # exclude problems that were autograded
       # so that we do not render the header in the annotation pane
-      unless autogradedProblems.key? problem.id
-        @problemSummaries[problem.name] ||= []
-        @problemGrades[problem.name] ||= 0
-      end
+      next if autogradedProblems.key? problem.id
+
+      @problemAnnotations[problem.name] ||= []
+      @problemMaxScores[problem.name] ||= problem.max_score
+      @problemScores[problem.name] ||= 0
     end
 
     # extract information from annotations
@@ -498,18 +500,19 @@ class SubmissionsController < ApplicationController
       filename = get_correct_filename(annotation, files, @submission)
 
       # To handle annotations on deleted problems
-      @problemSummaries[problem] ||= []
-      @problemGrades[problem] ||= 0
+      @problemAnnotations[problem] ||= []
+      @problemMaxScores[problem] ||= 0
+      @problemScores[problem] ||= 0
 
-      @problemSummaries[problem] << [description, value, line, annotation.submitted_by,
-                                     annotation.id, annotation.position, filename, global]
-      @problemGrades[problem] += value
+      @problemAnnotations[problem] << [description, value, line, annotation.submitted_by,
+                                       annotation.id, annotation.position, filename, global]
+      @problemScores[problem] += value
     end
 
     # Process @problemSummaries
     # Group into global annotations, sorted by id
     # and file annotations, sorted by filename, followed by line, and then grouped by filename
-    @problemSummaries.each do |problem, descriptTuples|
+    @problemAnnotations.each do |problem, descriptTuples|
       # group by global (a[7])
       annotations_by_type = descriptTuples.group_by { |a| a[7] }
 
@@ -521,7 +524,7 @@ class SubmissionsController < ApplicationController
       # sort by filename (a[6]), followed by line (a[2]) and group by filename (a[6])
       annotations_by_file = annotations_by_file.sort_by{ |a| [a[6], a[2]] }.group_by { |a| a[6] }
 
-      @problemSummaries[problem] = {
+      @problemAnnotations[problem] = {
         global_annotations: global_annotations,
         annotations_by_file: annotations_by_file
       }

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -496,6 +496,7 @@ class SubmissionsController < ApplicationController
                 else
                   annotation.problem_id ? "Deleted Problem(s)" : "Global"
                 end
+      shared = annotation.shared_comment
       global = annotation.global_comment
       filename = get_correct_filename(annotation, files, @submission)
 
@@ -505,7 +506,7 @@ class SubmissionsController < ApplicationController
       @problemScores[problem] ||= 0
 
       @problemAnnotations[problem] << [description, value, line, annotation.submitted_by,
-                                       annotation.id, annotation.position, filename, global]
+                                       annotation.id, annotation.position, filename, shared, global]
       @problemScores[problem] += value
     end
 
@@ -513,8 +514,8 @@ class SubmissionsController < ApplicationController
     # Group into global annotations, sorted by id
     # and file annotations, sorted by filename, followed by line, and then grouped by filename
     @problemAnnotations.each do |problem, descriptTuples|
-      # group by global (a[7])
-      annotations_by_type = descriptTuples.group_by { |a| a[7] }
+      # group by global (a[8])
+      annotations_by_type = descriptTuples.group_by { |a| a[8] }
 
       global_annotations = annotations_by_type[true] || []
       # sort by id (a[4])

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -463,10 +463,11 @@ class SubmissionsController < ApplicationController
     # Allow scores to be assessed by the view
     @scores = Score.where(submission_id: @submission.id)
 
-    # @problemSummaries and @problemGrades are used in _annotation_pane.html.erb
+    # Used in _annotation_pane.html.erb
     @problemAnnotations = {}
     @problemMaxScores = {}
     @problemScores = {}
+    @problemNameToId = {}
     autogradedProblems = {}
 
     @scores.each do |score|
@@ -484,6 +485,7 @@ class SubmissionsController < ApplicationController
       @problemAnnotations[problem.name] ||= []
       @problemMaxScores[problem.name] ||= problem.max_score
       @problemScores[problem.name] ||= 0
+      @problemNameToId[problem.name] ||= problem.id
     end
 
     # extract information from annotations
@@ -504,6 +506,7 @@ class SubmissionsController < ApplicationController
       @problemAnnotations[problem] ||= []
       @problemMaxScores[problem] ||= 0
       @problemScores[problem] ||= 0
+      @problemNameToId[problem] ||= -1
 
       @problemAnnotations[problem] << [description, value, line, annotation.submitted_by,
                                        annotation.id, annotation.position, filename, shared, global]

--- a/app/views/assessments/_submission_history_table.html.erb
+++ b/app/views/assessments/_submission_history_table.html.erb
@@ -10,11 +10,11 @@
         <% for problem in @problems do %>
           <th title="Max <%=problem.max_score %> points">
             <%=problem.name %><br>
-            (<%=problem.max_score%>)
+            (<%= problem.max_score || raw('&ndash;') %>)
           </th>
         <%end%>
 
-        <% if @course.grace_days >= 0 then %>
+        <% if @course.grace_days >= 0 %>
           <th>Late Days Used</th>
         <% end %>
 
@@ -24,7 +24,7 @@
 
         <th>Total Score</th>
 
-        <% if @cud.instructor? then %>
+        <% if @cud.instructor? %>
           <th>Tweak</th>
           <th>Instructor Actions</th>
           <th>Errors</th>

--- a/app/views/assessments/viewGradesheet.html.erb
+++ b/app/views/assessments/viewGradesheet.html.erb
@@ -34,12 +34,6 @@
                   "tweak",
                 <% end %>
                 "total"];
-    problems = [<% for p in @assessment.problems do %>
-                  {
-                    name: "<%= p.name %>",
-                    max_score: "<%= p.max_score %>"
-                  },
-                <% end %>];
 
     // raw data for each row
     table_data = [

--- a/app/views/assessments/viewGradesheet.html.erb
+++ b/app/views/assessments/viewGradesheet.html.erb
@@ -110,7 +110,7 @@
       { title: "Sec", className: "sec", data: "sec" },
       <% @assessment.problems.each_with_index do |p,i| %>
         { title: `<%= p.name %>
-            <span class="max_score">(<%= p.max_score %>)</span>`,
+            <span class="max_score">(<%= p.max_score || raw("&ndash;") %>)</span>`,
           className: "problem",
           data: "problem<%= i %>",
           render: function(data, type, full, meta) {

--- a/app/views/problems/_fields.html.erb
+++ b/app/views/problems/_fields.html.erb
@@ -6,7 +6,11 @@
 
 <%= f.text_field :description, help_text: "Short description of the problem.", placeholder: "(Optional)" %>
 
+<% if @problem %>
+<%= f.number_field :max_score, help_text: "The maximum score for this problem.", value: @problem.max_score, placeholder: "E.g. 0", step: "any", required: true %>
+<% else %>
 <%= f.number_field :max_score, help_text: "The maximum score for this problem.", value: 0, placeholder: "E.g. 0", step: "any", required: true %>
+<% end %>
 
 <%= f.check_box :optional, help_text: "By default, all problems are
 \"required\". Autolab will only display the total score to a student if all
@@ -17,7 +21,7 @@ unchecked." %>
 
 <div class="action_buttons">
 	<%= f.submit "Save Problem" , {:class=>"btn primary"} %>
-	<% if @problem then %>
+	<% if @problem %>
 	<button class="delete_btn"> 
 	  <%= link_to "Delete this Problem", [@course, @assessment, @problem], method: :delete, class: 'btn btn-danger', data: { confirm: "Deleting will delete all associated problem data (such as scores and annotations) and cannot be undone. Are you sure you want to delete this problem?" } %>
 	</button>

--- a/app/views/submissions/_annotation_pane.html.erb
+++ b/app/views/submissions/_annotation_pane.html.erb
@@ -32,7 +32,7 @@
               <% end %>
               <% if !global_annotations.empty? %>
                   <div class="file_annotations">
-                    <% global_annotations.each do |description, value, line, user, id, position, filename, global| %>
+                    <% global_annotations.each do |description, value, line, user, id, position, filename, shared, global| %>
                       <div class="global-annotation" id="li-annotation-<%= id %>">
                         <div class="annotation-description">
                           <span class="point_badge <%= value > 0 ? "positive" : value < 0 ? "negative" : "neutral" %>">
@@ -47,6 +47,7 @@
                                 data-problem="<%= problem %>"
                                 data-score="<%= value %>"
                                 data-comment="<%= description %>"
+                                data-shared="<%= shared %>"
                           >
                             <a class="global-annotation-edit-button" href="#"
                                title="Edit global annotation"

--- a/app/views/submissions/_annotation_pane.html.erb
+++ b/app/views/submissions/_annotation_pane.html.erb
@@ -1,14 +1,14 @@
 <div id="annotationPane">
   <div class="annotationSummary">
     <ul class="collapsible expandable">
-      <% @problemSummaries.each do |problem, all_annotations| %>
+      <% @problemAnnotations.each do |problem, all_annotations| %>
         <li id="li-problem-<%= problem %>" class="active">
           <div class="collapsible-header-wrap">
             <div class="collapsible-header">
               <h4> <%= problem.capitalize %>
                   <div class="summary_score">
                     <% if @cud.instructor? or @cud.course_assistant? or @problemReleased %>
-                      <%= plus_fix(@problemGrades[problem]) %>
+                      <%= plus_fix(@problemScores[problem]) %> / <%= plus_fix(@problemMaxScores[problem]) %>
                     <% end %>
                   </div>
               </h4>

--- a/app/views/submissions/_annotation_pane.html.erb
+++ b/app/views/submissions/_annotation_pane.html.erb
@@ -12,7 +12,7 @@
                     <% if @cud.instructor? or @cud.course_assistant? or @problemReleased %>
                       <%= plus_fix(@problemScores[problem]) %>
                       (<%= p_score&.score ? sprintf("%.2f", p_score.score) : raw("&ndash;") %>
-                      / <%= sprintf("%.2f", @problemMaxScores[problem]) %>)
+                      / <%= @problemMaxScores[problem] ? sprintf("%.2f", @problemMaxScores[problem]) : raw("&ndash;") %>)
                     <% end %>
                   </div>
               </h4>

--- a/app/views/submissions/_annotation_pane.html.erb
+++ b/app/views/submissions/_annotation_pane.html.erb
@@ -38,7 +38,9 @@
                           <span class="point_badge <%= value > 0 ? "positive" : value < 0 ? "negative" : "neutral" %>">
                             <%= plus_fix(value) %>
                           </span>
-                          <%= description %>
+                          <span style="white-space: pre-line;">
+                            <%= description %>
+                          </span>
                         </div>
                         <% if @cud.instructor? or @cud.course_assistant? %>
                         <div class="annotation-tools">
@@ -82,7 +84,9 @@
                               <% end %>
                               <%= plus_fix(value) %>
                             </span>
-                          <%= description %>
+                            <span style="white-space: pre-line;">
+                              <%= description %>
+                            </span>
                         <% end %>
                       </div>
                     <% end %>

--- a/app/views/submissions/_annotation_pane.html.erb
+++ b/app/views/submissions/_annotation_pane.html.erb
@@ -1,14 +1,18 @@
 <div id="annotationPane">
   <div class="annotationSummary">
     <ul class="collapsible expandable">
+      <% p_scores = @submission.problems_to_scores %>
       <% @problemAnnotations.each do |problem, all_annotations| %>
         <li id="li-problem-<%= problem %>" class="active">
           <div class="collapsible-header-wrap">
             <div class="collapsible-header">
               <h4> <%= problem.capitalize %>
                   <div class="summary_score">
+                    <% p_score = p_scores[@problemNameToId[problem]] %>
                     <% if @cud.instructor? or @cud.course_assistant? or @problemReleased %>
-                      <%= plus_fix(@problemScores[problem]) %> / <%= plus_fix(@problemMaxScores[problem]) %>
+                      <%= plus_fix(@problemScores[problem]) %>
+                      (<%= p_score&.score ? sprintf("%.2f", p_score.score) : raw("&ndash;") %>
+                      / <%= sprintf("%.2f", @problemMaxScores[problem]) %>)
                     <% end %>
                   </div>
               </h4>

--- a/app/views/submissions/_annotation_pane.html.erb
+++ b/app/views/submissions/_annotation_pane.html.erb
@@ -38,13 +38,13 @@
                   <div class="file_annotations">
                     <% global_annotations.each do |description, value, line, user, id, position, filename, shared, global| %>
                       <div class="global-annotation" id="li-annotation-<%= id %>">
-                        <div class="annotation-description">
+                        <div class="annotation-badge">
                           <span class="point_badge <%= value > 0 ? "positive" : value < 0 ? "negative" : "neutral" %>">
                             <%= plus_fix(value) %>
                           </span>
-                          <span style="white-space: pre-line;">
-                            <%= description %>
-                          </span>
+                        </div>
+                        <div class="annotation-description">
+                          <span style="white-space: pre-line;"><%= description %></span>
                         </div>
                         <% if @cud.instructor? or @cud.course_assistant? %>
                         <div class="annotation-tools">
@@ -82,15 +82,17 @@
                             "data-line": line.nil? ? 1 : line+1,
                             remote: true,
                           ) do %>
-                            <span class="point_badge <%= value > 0 ? "positive" : value < 0 ? "negative" : "neutral" %>">
-                              <% unless line.nil? %>
-                                <span class="line_number">Line <%= line + 1 %>:</span>
-                              <% end %>
-                              <%= plus_fix(value) %>
-                            </span>
-                            <span style="white-space: pre-line;">
-                              <%= description %>
-                            </span>
+                            <div class="annotation-badge">
+                              <span class="point_badge <%= value > 0 ? "positive" : value < 0 ? "negative" : "neutral" %>">
+                                <% unless line.nil? %>
+                                  <span class="line_number">Line <%= line + 1 %>:</span>
+                                <% end %>
+                                <%= plus_fix(value) %>
+                              </span>
+                            </div>
+                            <div class="annotation-description">
+                              <span style="white-space: pre-line;"><%= description %></span>
+                            </div>
                         <% end %>
                       </div>
                     <% end %>

--- a/app/views/submissions/_annotation_pane.html.erb
+++ b/app/views/submissions/_annotation_pane.html.erb
@@ -11,8 +11,8 @@
                     <% p_score = p_scores[@problemNameToId[problem]] %>
                     <% if @cud.instructor? or @cud.course_assistant? or @problemReleased %>
                       <%= plus_fix(@problemScores[problem]) %>
-                      (<%= p_score&.score ? sprintf("%.2f", p_score.score) : raw("&ndash;") %>
-                      / <%= @problemMaxScores[problem] ? sprintf("%.2f", @problemMaxScores[problem]) : raw("&ndash;") %>)
+                      (<%= p_score&.score ? sprintf("%.2f", p_score.score.round(2)) : raw("&ndash;") %>
+                      / <%= @problemMaxScores[problem] ? sprintf("%.2f", @problemMaxScores[problem].round(2)) : raw("&ndash;") %>)
                     <% end %>
                   </div>
               </h4>

--- a/app/views/submissions/_code_viewer.html.erb
+++ b/app/views/submissions/_code_viewer.html.erb
@@ -51,7 +51,7 @@
                 <div class="code-separator"></div>
               </div>
               <div class="add-comment">
-                <% if @cud.instructor? or @cud.course_assistant? then %><div class="add-button-container"><button class="add-button" id="add-btn-<%= index+1 %>"><i class="material-icons">add_comment</i></button></div><% end %>
+                <% if @cud.instructor? or @cud.course_assistant? then %><div class="add-button-container"><button class="add-button" id="add-btn-<%= index+1 %>" title="Annotate this line"><i class="material-icons">add_comment</i></button></div><% end %>
               </div>
               <% begin %>
               <div class="code"><pre><code class="<%= @displayFilename.split(".")[-1].downcase %>"><%= code %></code></pre></div>

--- a/app/views/submissions/_grades.html.erb
+++ b/app/views/submissions/_grades.html.erb
@@ -10,7 +10,7 @@
         <% else %>
           <b> &ndash; </b>
         <% end %>
-        <b> / <%= sprintf("%.2f", p.max_score) %></b>
+        <b> / <%= p.max_score ? sprintf("%.2f", p.max_score) : raw("&ndash;") %></b>
       </div>
     </div>
   <% end %>

--- a/app/views/submissions/_grades.html.erb
+++ b/app/views/submissions/_grades.html.erb
@@ -10,7 +10,7 @@
         <% else %>
           <b> &ndash; </b>
         <% end %>
-        <b> / <%= p.max_score ? sprintf("%.2f", p.max_score) : raw("&ndash;") %></b>
+        <b> / <%= p.max_score ? sprintf("%.2f", p.max_score.round(2)) : raw("&ndash;") %></b>
       </div>
     </div>
   <% end %>

--- a/docs/features/annotations.md
+++ b/docs/features/annotations.md
@@ -12,9 +12,9 @@ Annotations is a feature introduced as part of the Speedgrader update to Autolab
 Hover over any line of the code and click on the green arrow, and the annotation form will appear. Add the comment, adjust the score, and select the targeted problem.
 
 When the "Add to shared comment pool" option is checked, the comment will be saved to a shared comment pool.
-When creating new annotations, shared comments matching what you have typed will be available via a dropdown list.
+When creating new annotations, shared comments matching what you have typed will be available via a dropdown list. Only the 50 most recently added shared comments will be displayed.
 
-Note that the shared comment pool operates on a per-assessment basis, so a shared comment for one problem is available when creating an annotation for another problem within the same assessment.
+Note that the shared comment pool operates on a per-problem basis, so a shared comment for one problem will not be available when creating an annotation for another problem within the same assessment.
 Additionally, the same shared comment pool is used by all instructors and course-assistants, so your shared comments will be available to other instructors and course-assistants, and vice-versa.
 
 ![Shared Comments](/images/shared_comments.png)


### PR DESCRIPTION
## Description
**Bug fixes**
- Prevent selection of autograded problems when editing annotation
- Persist shared comments checkbox for global annotations
- Preserve newlines in descriptions
- Add handling for `nil` problem `max_score`

**New features**
- Display current max score on edit problem page
- Add problem max score to annotation panel
- Allow multiple annotations per line

**Breaking changes**
- Make shared comments operate on a per-problem basis

**Others**
- Optimize performance of updating grades and annotation panes

## Motivation and Context
Addresses the following feedback from 122:

1. Keep newlines in the global annotations when displayed. In the screenshot below, I input A, B, C, D on separately lines, but to students, it’ll be all on one line, which is undesirable
2. Make comments added to the shared pool specific to a problem (or not, should be user defined). I currently see that if a comment is added to one problem, it’ll show up in the shared pool for other problems too. This might introduce a lot of clutter if we want problem-specific shared comments.
3. Add the max number of points for each problem to the annotations panel
4. When I hover a line that already has a comment, the green + button appears, making me assume that I can add another comment, but clicking the button doesn’t do anything. It’d be nice to have multiple comments per line. This is depicted in the screenshot above as well.

**Note**
Feedback included the following, to be addressed in a future PR:

Point values should stay with a shared comment added to the pool. In the screenshot below, "A1: Has contract”’s point values when I created it, +1.0, should be automatically applied when I choose this comment from the shared pool. This issue comes up not only when I attach it to another Problem, but within the same Problem as well.

## How Has This Been Tested?

**1. Prevent selection of autograded problems when editing annotation**
- On an autograded assessment, make an annotation (ensure that we can't select the autograded problem)
- [**previously**] Edit the annotation, we are able to select the autograded problem
- [**now**] Edit the annotation, we are **not** able to select the autograded problem

**2. Persist shared comments checkbox for global annotations**
- Make a global annotation, mark it as a shared comment
- [**previously**] Edit the annotation, the shared comment checkbox is not checked
- [**now**] Edit the annotation, the shared comment checkbox **is** checked

**3. Preserve newlines in descriptions**
- Create a multi-line global annotation, check that newlines are preserved in the annotation pane
- Create a multi-line normal annotation, check that newlines are preserved in the annotation pane
- Also observe that annotations descriptions start to the immediate right of the point badge as usual

![Screenshot 2022-12-02 at 00 38 18](https://user-images.githubusercontent.com/9074856/205222721-383fb707-4605-478f-90a6-56d87aa478c9.png)

**4. Display current max score on edit problem page**
- [**previously**] Edit an existing problem, observe that "max score" field shows 0
- [**now**] Edit an existing problem, observe that "max score" field shows the current max value
- Create a new problem, ensure the page renders, and the "max score" field shows 0

**5. Add problem max score to annotation panel**
- Observe that annotation pane displays problem score and max score next to current delta. i.e. `<delta> (<current score> / <max score>)`
- Update a problem's max score, ensure the number changes accordingly
- Create a new problem, ensure the number displays accordingly
- Test with positive grading too

Negative Grading
![Screenshot 2022-12-02 at 00 39 00](https://user-images.githubusercontent.com/9074856/205222841-fb50bd36-eae5-4f98-862e-74633b15d404.png)

Positive Grading
![Screenshot 2022-12-02 at 00 39 37](https://user-images.githubusercontent.com/9074856/205222932-38e0a2b8-79fa-4e1d-9bd4-ca79983bface.png)

**6. Allow multiple annotations per line**
- If user clicks add button multiple times without first cancelling / submitting the first open form, observe that we do not create any more forms and display a warning message
<img width="431" alt="Screenshot 2022-12-01 at 20 16 42" src="https://user-images.githubusercontent.com/9074856/205192814-379f155f-4b31-4cbb-a2a7-b31ab184050a.png">

- Successfully create multiple annotations per line
- Ensure that "edit" forms do not count towards this limit. That is, we can be editing multiple annotations on the same line at once, but even so, we can still click the add button to start creating a new annotation.
- Check that the page automatically scrolls to the new annotation form

**7. Make shared comments operate on a per-problem basis**
- Create a bunch of normal / global shared annotations
- Start creating a new annotation, ensure that the correct shared annotations show up for the autocomplete (i.e. only the shared annotations from the same problem). Ensure that the autocomplete options change when the problem dropdown is changed.
- Edit an existing annotation, ensure that the autocomplete options change accordingly too.

**8. Optimize performance of updating grades and annotation panes**
- Make an annotation, ensure that grades and annotation panes update correctly

**9. Add handling for `nil` problem `max_score`**
- Remove `:max_score` from the `validates :name, :max_score, presence: true` line in `models/problem.rb`
- Create a problem with no max score (disable the required validation on the field)
- [**previously**] An error is thrown (from trying to `printf` `nil`)
- [**now**] View a submission, page should load with a `-` in the place of max score on the annotations and grades pane

<img width="299" alt="Screenshot 2022-12-02 at 12 19 47" src="https://user-images.githubusercontent.com/9074856/205349121-c4347f33-9abb-4a98-afa1-e47db562b3ed.png">

<img width="311" alt="Screenshot 2022-12-02 at 12 19 50" src="https://user-images.githubusercontent.com/9074856/205349102-3b08bbf2-1e66-4160-bb4a-4a4c4e812941.png">

- Also check gradesheet and submission history table

![Screenshot 2022-12-02 at 15 31 57](https://user-images.githubusercontent.com/9074856/205380762-dee6598a-c475-418d-9a21-d4940be8458c.png)

![Screenshot 2022-12-02 at 15 32 05](https://user-images.githubusercontent.com/9074856/205380777-46b362e5-02b0-43e4-a496-1f2f577b8e30.png)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [x] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [x] I have updated the documentation accordingly, included in this PR