### PR TITLE
Allow admins to edit school and major of users

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -347,7 +347,7 @@ private
 
   # user params that admin is allowed to edit
   def admin_user_params
-    params.require(:user).permit(:first_name, :last_name, :administrator)
+    params.require(:user).permit(:first_name, :last_name, :school, :major, :administrator)
   end
 
   def set_gh_oauth_client

--- a/app/views/users/_fields.html.erb
+++ b/app/views/users/_fields.html.erb
@@ -4,10 +4,14 @@
 
 <%= f.text_field :last_name, placeholder: "Doe" %>
 
-<%= f.text_field :school, placeholder: "School of Computer Science" %>
+<% if current_user.administrator? %>
+	<%= f.text_field :school, placeholder: "School of Computer Science" %>
 
-<%= f.text_field :major, placeholder: "Computer Science" %>
+	<%= f.text_field :major, placeholder: "Computer Science" %>
 
-<% if current_user.administrator? then %>
 	<%= f.check_box :administrator, help_text: "Administrators have total access to change anything in the system." %>
+<% else %>
+	<%= f.text_field :school, disabled: true, placeholder: "School of Computer Science" %>
+
+	<%= f.text_field :major, disabled: true, placeholder: "Computer Science" %>
 <% end %>


### PR DESCRIPTION
## Description
- Disable `school` and `major` fields on the edit user form for non-admins
- Allow admins to update `school` and `major` fields

## Motivation and Context
Currently, the `school` and `major` fields on the edit user form appear editable, but in reality can be edited neither by users nor admins.

This PR allows admins to update the fields. However, in the interest of preserving integrity of the data, we disable the fields for users.

Fixes #1659

## How Has This Been Tested?
- As an admin, update `school` and `major` fields successfully for yourself and other users
- As a normal user, fields are disabled for you, and you can't update them (even if you removed the `disabled` attribute)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
