### PR TITLE
Fix flaky test: only test API on released assessments

### DIFF
--- a/spec/api/v1/api_shared_context.rb
+++ b/spec/api/v1/api_shared_context.rb
@@ -2,7 +2,8 @@ RSpec.shared_context "api shared context" do
   all_users = CourseUserDatum.joins(:user).where("users.administrator" => false, :instructor => false, :course_assistant => false)
   let(:user) { all_users.offset(rand(all_users.count)).first.user }
   let(:course) { CourseUserDatum.where(user_id: user.id).first.course }
-  let(:assessment) { course.assessments.offset(rand(course.assessments.count)).first }
+  let(:released_assessments) { course.assessments.where('start_at < ?', DateTime.now) }
+  let(:assessment) { released_assessments.offset(rand(released_assessments.count)).first }
   let(:msg) { JSON.parse(response.body) }
 
   # default application with access to user_info and user_courses


### PR DESCRIPTION
## Description
- Select from released assessments in tests

## Motivation and Context
Currently, the tests are intermittently failing because of the test `it 'returns all the problems of an assignment` in `assessments_api_spec.rb`. It attempts to call the API to retrieve all problems of an assessment. However, the API call fails if the assessment is unreleased.

![Screenshot 2022-12-02 at 00 57 17](https://user-images.githubusercontent.com/9074856/205228099-38df3e04-1fc8-4857-97c3-9f96307bbde3.png)

It appears that one out of the 19 auto-populated assessments is repeatedly given a `start_at` in the future, leading to a 1-in-19 chance of a test failure.

This PR updates the testing logic to select a released assessment.

## How Has This Been Tested?
- Drop the test database and re-create + populate it
  - `RAILS_ENV=test bundle exec rails db:drop`
  - `RAILS_ENV=test bundle exec rails db:create`
  - `RAILS_ENV=test bundle exec rails db:schema:load`
  - `RAILS_ENV=test bundle exec rake autolab:populate`
- Comment out the lines after `Suppress stdout and stderr while testing.` in `spec/spec_helper.rb`
- Add the following debug code to the test at line 35 of `assessments_api_spec.rb`
```ruby
course.assessments.each do |ass|
  puts "#{ass.name} #{ass.start_at}"
end
released_assessments.each do |ass|
  puts "#{ass.name} #{ass.start_at}"
end
```
- Run `rake spec SPEC=./spec/api/v1/assessments_api_spec.rb:35` and compare the two outputs. You should notice that the unreleased `quiz5` doesn't appear in the second set of outputs.

For good measure, you could run something like ``for i in `seq 50` ; do rake spec SPEC=./spec/api/v1/assessments_api_spec.rb:35  ; [[ ! $? = 0 ]] && break ; done`` and see that it doesn't fail in 50 trials.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting