### PR TITLE
Moved "Install Assessment" button to top box, removed "Instructor Actions" header, renamed Assignments header to Assessments

### DIFF
--- a/app/views/assessments/index.html.erb
+++ b/app/views/assessments/index.html.erb
@@ -71,7 +71,7 @@
            <%= link_to "<div class='row metrics'><i class='material-icons left'>assessment</i> Student Metrics</div>".html_safe, course_metrics_path, title: "Metrics for Identifying Students in Need", :class => "btn btn-large red darken-3" %>
           <% end %>
           <% if @is_instructor %>
-            <%= link_to "<div class='row metrics'><i class='material-icons left'>assignment</i> Install Assessments</div>".html_safe, {:action=>"install_assessment"}, {:title=>"Install Assessment", :class => "btn btn-large red darken-3"} %>
+            <%= link_to "<div class='row metrics'><i class='material-icons left'>assignment</i> Install Assessment</div>".html_safe, {:action=>"install_assessment"}, {:title=>"Install Assessment", :class => "btn btn-large red darken-3"} %>
           <% end %>
       </div>
       </div>

--- a/app/views/assessments/index.html.erb
+++ b/app/views/assessments/index.html.erb
@@ -70,7 +70,7 @@
           <% if (@cud.instructor? || @cud.course_assistant? && @course.watchlist_allow_ca) %>
            <%= link_to "<div class='row metrics'><i class='material-icons left'>assessment</i> Student Metrics</div>".html_safe, course_metrics_path, title: "Metrics for Identifying Students in Need", :class => "btn btn-large red darken-3" %>
           <% end %>
-          
+
           <% if @is_instructor %>
             <%= link_to "<div class='row metrics'><i class='material-icons left'>assignment</i> Install Assessment</div>".html_safe, {:action=>"install_assessment"}, {:title=>"Install Assessment", :class => "btn btn-large red darken-3"} %>
           <% end %>

--- a/app/views/assessments/index.html.erb
+++ b/app/views/assessments/index.html.erb
@@ -70,6 +70,7 @@
           <% if (@cud.instructor? || @cud.course_assistant? && @course.watchlist_allow_ca) %>
            <%= link_to "<div class='row metrics'><i class='material-icons left'>assessment</i> Student Metrics</div>".html_safe, course_metrics_path, title: "Metrics for Identifying Students in Need", :class => "btn btn-large red darken-3" %>
           <% end %>
+          
           <% if @is_instructor %>
             <%= link_to "<div class='row metrics'><i class='material-icons left'>assignment</i> Install Assessment</div>".html_safe, {:action=>"install_assessment"}, {:title=>"Install Assessment", :class => "btn btn-large red darken-3"} %>
           <% end %>

--- a/app/views/assessments/index.html.erb
+++ b/app/views/assessments/index.html.erb
@@ -70,9 +70,8 @@
           <% if (@cud.instructor? || @cud.course_assistant? && @course.watchlist_allow_ca) %>
            <%= link_to "<div class='row metrics'><i class='material-icons left'>assessment</i> Student Metrics</div>".html_safe, course_metrics_path, title: "Metrics for Identifying Students in Need", :class => "btn btn-large red darken-3" %>
           <% end %>
-
           <% if @is_instructor %>
-            <%= link_to 'Install Assessment',{:action=>"install_assessment"},{:title=>"Install Assessment", :class => "btn btn-large red darken-3" } %>
+            <%= link_to "<div class='row metrics'><i class='material-icons left'>assignment</i> Install Assessments</div>".html_safe, {:action=>"install_assessment"}, {:title=>"Install Assessment", :class => "btn btn-large red darken-3"} %>
           <% end %>
       </div>
       </div>

--- a/app/views/assessments/index.html.erb
+++ b/app/views/assessments/index.html.erb
@@ -70,23 +70,18 @@
           <% if (@cud.instructor? || @cud.course_assistant? && @course.watchlist_allow_ca) %>
            <%= link_to "<div class='row metrics'><i class='material-icons left'>assessment</i> Student Metrics</div>".html_safe, course_metrics_path, title: "Metrics for Identifying Students in Need", :class => "btn btn-large red darken-3" %>
           <% end %>
+
+           <% if @is_instructor %>
+            <%= link_to 'Install Assessment',{:action=>"install_assessment"},{:title=>"Install Assessment", :class => "btn btn-large red darken-3" } %>
+          <% end %>
       </div>
       </div>
     </div>
   </div>
 </div>
 
-<% if @is_instructor %>
 <div class="section">
-  <h3 class="section-title"><span class="white">Instructor Actions</span></h3>
-  <span style="padding-left: 10px"><%= link_to 'Install Assessment',
-                    {:action=>"install_assessment"},
-                    {:title=>"Install Assessment", :class => "btn btn-large red darken-3" } %></span>
-
-<% end %>
-
-<div class="section">
-  <h3 class="section-title"><span class="white">Assignments</span></h3>
+  <h3 class="section-title"><span class="white">Assessments</span></h3>
 
   <div class="row">
     <% @course.assessment_categories.each_with_index do |cat, idx| %>

--- a/app/views/assessments/index.html.erb
+++ b/app/views/assessments/index.html.erb
@@ -71,7 +71,7 @@
            <%= link_to "<div class='row metrics'><i class='material-icons left'>assessment</i> Student Metrics</div>".html_safe, course_metrics_path, title: "Metrics for Identifying Students in Need", :class => "btn btn-large red darken-3" %>
           <% end %>
 
-           <% if @is_instructor %>
+          <% if @is_instructor %>
             <%= link_to 'Install Assessment',{:action=>"install_assessment"},{:title=>"Install Assessment", :class => "btn btn-large red darken-3" } %>
           <% end %>
       </div>
@@ -80,41 +80,43 @@
   </div>
 </div>
 
-<div class="section">
-  <h3 class="section-title"><span class="white">Assessments</span></h3>
+<% if @course.assessments.exists? %>
+  <div class="section">
+    <h3 class="section-title"><span class="white">Assessments</span></h3>
 
-  <div class="row">
-    <% @course.assessment_categories.each_with_index do |cat, idx| %>
-      <% if idx % 3 == 0 %>
-        <div class="clearfix hide-on-small-only"></div>
-      <% end %>
-      <% asmts = @course.assessments_with_category(cat, @cud.student?) %>
-      <% if asmts.any? %>
-        <div class="col s12 m4">
-          <div class="card hoverable">
-            <div class="card-content red darken-3">
-              <span class="card-title white-text"><%= cat %></span>
-            </div>
+    <div class="row">
+      <% @course.assessment_categories.each_with_index do |cat, idx| %>
+        <% if idx % 3 == 0 %>
+          <div class="clearfix hide-on-small-only"></div>
+        <% end %>
+        <% asmts = @course.assessments_with_category(cat, @cud.student?) %>
+        <% if asmts.any? %>
+          <div class="col s12 m4">
+            <div class="card hoverable">
+              <div class="card-content red darken-3">
+                <span class="card-title white-text"><%= cat %></span>
+              </div>
 
-            <div class="collection red darken-4">
-              <% asmts.each do |asmt| %>
-                <%= link_to course_assessment_url(@course, asmt),
-                    :class => "collection-item grey-text text-darken-4" do %>
-                  <%= asmt.display_name %>
-                  <% if !asmt.released? %>
-                      <span class="new badge blue darken-4" data-badge-caption="unreleased" data-url="<%= edit_course_assessment_url(@course, asmt) %>/handin"></span>
+              <div class="collection red darken-4">
+                <% asmts.each do |asmt| %>
+                  <%= link_to course_assessment_url(@course, asmt),
+                      :class => "collection-item grey-text text-darken-4" do %>
+                    <%= asmt.display_name %>
+                    <% if !asmt.released? %>
+                        <span class="new badge blue darken-4" data-badge-caption="unreleased" data-url="<%= edit_course_assessment_url(@course, asmt) %>/handin"></span>
+                    <% end %>
                   <% end %>
                 <% end %>
-              <% end %>
+              </div>
+
             </div>
-
           </div>
-        </div>
+        <% end %>
       <% end %>
-    <% end %>
 
+    </div>
   </div>
-</div>
+<% end %>
 
 <% if @attachments.any? or @cud.instructor? %>
   <div class="section">


### PR DESCRIPTION
## Description
- Moved "Install Assessment" button to top box
- Removed "Instructor Actions" header
- Renames Assignments header to Assessments
- Assessments header will only be shown if there are assessments
- Added icon to assignments

## Motivation and Context
Small UI fix because instructor actions is unnecessary as its own component and assessments is also unnecessary as a header if it is empty.

## How Has This Been Tested?
1. Tested mobile responsiveness.
2. Tested the buttons and other buttons.

### Previous:
![image](https://user-images.githubusercontent.com/65066221/211857812-f0b5474a-988b-4018-9e1c-8b32ab28c457.png)

### After:
<img width="1066" alt="Screenshot 2023-01-12 at 12 57 55 AM" src="https://user-images.githubusercontent.com/65066221/211868788-c5b80387-eea7-4bc5-9ac1-d179338c4b1e.png">

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR