### PR TITLE
Correctly display filename for annotations on first file of an archive

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -338,7 +338,7 @@ protected
     if annotation.position == -1
       # position -1 maps to the Autograder Output
       "Autograder Output"
-    elsif files && annotation.position != 0
+    elsif files && !annotation.position.nil?
       # if the submission is an archive, use filename in archive;
       # otherwise, use submission filename
       Archive.get_nth_filename(files, annotation.position)


### PR DESCRIPTION
## Description
- Replace `!= 0` check with `! ... .nil?` check

## Motivation and Context
In #1590, the original check `@files && annotation.position` was refactored into `files && annotation.position != 0`. 

However, this is different since `0` is truthy in ruby (only `false` and `nil` are falsey).

As a result, any annotations on the file at position 0 of an archive will display the archive name as the filename instead of the correct name.

## How Has This Been Tested?
- Create the following assessment ([hello.tar.zip](https://github.com/autolab/Autolab/files/10388674/hello.tar.zip)) -- it's like hello lab but it takes a tar containing `hello.c` instead. Unzip before importing.
- Submit the following ([hello.tar.zip](https://github.com/autolab/Autolab/files/10388679/hello.tar.zip)). Unzip before submitting.
- Create a new problem
- Make an annotation on `hello.c` for the problem

Before (wrong name)

![Screenshot 2023-01-10 at 22 34 47](https://user-images.githubusercontent.com/9074856/211711848-cfa5edaa-ee4a-4bea-94a4-a933c36fd006.png)

After

![Screenshot 2023-01-10 at 22 34 28](https://user-images.githubusercontent.com/9074856/211711817-3359c806-ef0c-408c-89a9-77410d46fddb.png)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting