### PR TITLE
Change overflow-x on .submissions from scroll to auto

### DIFF
--- a/app/assets/stylesheets/style.css.scss
+++ b/app/assets/stylesheets/style.css.scss
@@ -1463,7 +1463,7 @@ table.sub td, th {
 }
 
 .submissions {
-  overflow-x: scroll;
+  overflow-x: auto;
 }
 
 .submission-history-button {


### PR DESCRIPTION
## Description
As per title.

## Motivation and Context
Currently, `.submissions` uses `overflow-x: scroll`. However, that means a disabled scroll bar displays when there is no overflow. Instead, `overflow-x: auto` should be used, which adds scrollbars only when necessary.

## How Has This Been Tested?
**Before** (disabled scroll bar at the bottom)

![Screenshot 2023-01-11 at 22 00 13](https://user-images.githubusercontent.com/9074856/211965706-c1247e6d-47be-434c-aca2-d0d0ff38d2bd.png)

**After**

![Screenshot 2023-01-11 at 22 00 24](https://user-images.githubusercontent.com/9074856/211965717-6ab3ab40-d3e1-4f9f-9375-23e5d62a034d.png)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
