### PR TITLE
Remove "row metrics" class from install asmt button

### DIFF
--- a/app/views/assessments/index.html.erb
+++ b/app/views/assessments/index.html.erb
@@ -72,7 +72,7 @@
           <% end %>
 
           <% if @is_instructor %>
-            <%= link_to "<div class='row metrics'><i class='material-icons left'>assignment</i> Install Assessment</div>".html_safe, {:action=>"install_assessment"}, {:title=>"Install Assessment", :class => "btn btn-large red darken-3"} %>
+            <%= link_to "<i class='material-icons left'>assignment</i> Install Assessment".html_safe, {:action=>"install_assessment"}, {:title=>"Install Assessment", :class => "btn btn-large red darken-3"} %>
           <% end %>
       </div>
       </div>


### PR DESCRIPTION
## Description
As per title.

## Motivation and Context
In #1683, the install asmt button was mistakenly wrapped in a div with class `row metrics`.

This meant that when a course had valid metrics, the button would be overwritten due to the following piece of code in `assessments/index.html.erb`:
```js
        $.getJSON('metrics/get_num_pending_instances',function(data, status){
          if(status=='success' && data['num_pending'] != 0){
            // when there is a non-zero number of pending instances
            var pending_instances_str = 
              `<div class='col s1 metrics'>
                <i class='material-icons left metrics'>assessment</i>
              </div>
              <div class='col s4 metrics'>
                <span class='new badge metrics-badge' data-badge-caption='${data["num_pending"]}'></span>
              </div>
              <h7 class='metrics'>
                Student Metrics
              </h7>`;
            $('.row.metrics').empty().append(pending_instances_str);
          }
        });
```

## How Has This Been Tested?

Trigger metrics, e.g. set the "did not submit" metric for the autopopulated course.

**BEFORE**
![Screenshot 2023-01-21 at 23 19 29](https://user-images.githubusercontent.com/9074856/213900408-773737a9-354c-449c-8aea-58ca1f38ce84.png)

**AFTER**
![Screenshot 2023-01-21 at 23 19 19](https://user-images.githubusercontent.com/9074856/213900399-ccd83dd3-8ca3-47d2-adef-fca3ed98eb62.png)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting