### PR TITLE
Removed deadline warning for non-submittable assignments

### DIFF
--- a/app/assets/stylesheets/style.css.scss
+++ b/app/assets/stylesheets/style.css.scss
@@ -642,6 +642,11 @@ p.attention {
   font-style: italic;
 }
 
+span.disabled-submission {
+  color: red;
+  padding: 5px;
+}
+
 .autolab .tooltip-inner {
   white-space: pre;
   max-width: none;

--- a/app/assets/stylesheets/style.css.scss
+++ b/app/assets/stylesheets/style.css.scss
@@ -642,11 +642,6 @@ p.attention {
   font-style: italic;
 }
 
-span.disabled-submission {
-  color: red;
-  padding: 5px;
-}
-
 .autolab .tooltip-inner {
   white-space: pre;
   max-width: none;

--- a/app/views/assessments/show.html.erb
+++ b/app/views/assessments/show.html.erb
@@ -191,7 +191,7 @@
         <div class="handin-panel card z-depth-0">
             <p class="valign-wrapper">
               <i class="material-icons valign">file_upload_off</i>
-              <span class="disabled-submission">Attention:<b>&nbsp;The submission has been disabled by the instructor!</b></span>
+              <b class="red-text">&nbsp;Handins are disabled for this assessment.</b>
             </p>
         </div>
       <% end %>

--- a/app/views/assessments/show.html.erb
+++ b/app/views/assessments/show.html.erb
@@ -154,7 +154,7 @@
   <div class="col s12 m8">
     <br>
     <br>
-    <% if !@assessment.disable_handins%>
+    <% if !@assessment.disable_handins %>
       <div class="handin-panel card z-depth-0">
         <div class="card-content">
           <p class="valign-wrapper">
@@ -188,13 +188,15 @@
         <%= render partial: "handin_form", locals: {modal: false, id: "handin_show_assessment"} %>
       </div>
     <% else %>
-        <div class="handin-panel card z-depth-0">
-            <p class="valign-wrapper">
-              <i class="material-icons valign">file_upload_off</i>
-              <b class="red-text">&nbsp;Handins are disabled for this assessment.</b>
-            </p>
+      <div class="handin-panel card z-depth-0">
+        <div class="card-content">
+          <p class="valign-wrapper">
+            <i class="material-icons valign">file_upload_off</i>
+            <b class="red-text">&nbsp;Handins are disabled for this assessment.</b>
+          </p>
         </div>
-      <% end %>
+      </div>
+    <% end %>
   </div>
 </div>
 <% download_access = (@cud.instructor?) %>

--- a/app/views/assessments/show.html.erb
+++ b/app/views/assessments/show.html.erb
@@ -154,38 +154,47 @@
   <div class="col s12 m8">
     <br>
     <br>
-    <div class="handin-panel card z-depth-0">
-      <div class="card-content">
-        <p class="valign-wrapper">
-          <i class="material-icons valign">access_time</i>
-            &nbsp;&nbsp;Due<% if @extension %> (with <% if @extension.infinite? %> infinite <% else %> <%= pluralize(@extension.days, "day") %> <% end %> extension)<% end %>:&nbsp;
+    <% if !@assessment.disable_handins%>
+      <div class="handin-panel card z-depth-0">
+        <div class="card-content">
+          <p class="valign-wrapper">
+            <i class="material-icons valign">access_time</i>
+              &nbsp;&nbsp;Due<% if @extension %> (with <% if @extension.infinite? %> infinite <% else %> <%= pluralize(@extension.days, "day") %> <% end %> extension)<% end %>:&nbsp;
+              <b>
+                <% if @extension&.infinite? %>
+                  <%= due_at_display @aud.due_at %>
+                <% else %>
+                  <span class="moment-date-time" data-format="MMMM Do YYYY, h:mm a z [(UTC] Z[)]"><%= due_at_display @aud.due_at %></span>
+                <% end %>
+              </b>
+          </p>
+
+          <p class="valign-wrapper">
+            <i class="valign material-icons">today</i>
+            &nbsp;&nbsp;Last day to handin:&nbsp;
             <b>
               <% if @extension&.infinite? %>
-                <%= due_at_display @aud.due_at %>
+                <%= end_at_display(@aud.end_at false) %>
               <% else %>
-                <span class="moment-date-time" data-format="MMMM Do YYYY, h:mm a z [(UTC] Z[)]"><%= due_at_display @aud.due_at %></span>
+                <span class="moment-date-time" data-format="MMMM Do YYYY, h:mm a z [(UTC] Z[)]"><%= end_at_display(@aud.end_at false) %></span>
               <% end %>
             </b>
-        </p>
+          </p>
 
-        <p class="valign-wrapper">
-          <i class="valign material-icons">today</i>
-          &nbsp;&nbsp;Last day to handin:&nbsp;
-          <b>
-            <% if @extension&.infinite? %>
-              <%= end_at_display(@aud.end_at false) %>
-            <% else %>
-              <span class="moment-date-time" data-format="MMMM Do YYYY, h:mm a z [(UTC] Z[)]"><%= end_at_display(@aud.end_at false) %></span>
-            <% end %>
-          </b>
-        </p>
-
-        <% if @cud.instructor? and @assessment.exam? %>
-        <p class="attention">This is an exam. While it is in progress, please check Admin > Edit Course > Exam In Progress.</p>
-        <% end %>
+          <% if @cud.instructor? and @assessment.exam? %>
+          <p class="attention">This is an exam. While it is in progress, please check Admin > Edit Course > Exam In Progress.</p>
+          <% end %>
+        </div>
+        <%= render partial: "handin_form", locals: {modal: false, id: "handin_show_assessment"} %>
       </div>
-      <%= render partial: "handin_form", locals: {modal: false, id: "handin_show_assessment"} %>
-    </div>
+    <% else %>
+        <div class="handin-panel card z-depth-0">
+            <p class="valign-wrapper">
+              <i class="material-icons valign">file_upload_off</i>
+              <span class="disabled-submission">Attention:<b>&nbsp;The submission has been disabled by the instructor!</b></span>
+            </p>
+        </div>
+      <% end %>
   </div>
 </div>
 <% download_access = (@cud.instructor?) %>


### PR DESCRIPTION
Removed deadline warning for non-submittable assignments

## Description
Any submission would have a due datetime as well as a late datetime to submit the assignment. These datetimes are displayed on the submission page. The user also have a option to disable the submissions. Previously, these datetimes were displayed even when the submissions are closed. I changed this such that if the submission is disabled, then instead of the datetime, it shows the attention message to the user that the submission is closed.

### Before change - 

![Screenshot from 2023-01-28 00-02-39](https://user-images.githubusercontent.com/64639902/215166868-81a21bcf-8af7-4e01-b372-c7bfe2b75344.png)


### After change -
 
![Screenshot from 2023-01-28 00-00-38](https://user-images.githubusercontent.com/64639902/215166903-c048b0b8-4bfe-4c04-8c99-25455d9698f7.png)

## Motivation and Context
The change is in regards to the issue mentioned in #1696.

## How Has This Been Tested?
As can be seen in the description section, the screenshots are attached about how a change in submission acceptance can change the output message on the submission page.
  
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR
