### PR TITLE
Fix footer on course view page

### DIFF
--- a/app/views/assessments/index.html.erb
+++ b/app/views/assessments/index.html.erb
@@ -75,7 +75,6 @@
             <%= link_to "<i class='material-icons left'>assignment</i> Install Assessment".html_safe, {:action=>"install_assessment"}, {:title=>"Install Assessment", :class => "btn btn-large red darken-3"} %>
           <% end %>
       </div>
-      </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Description
- Remove extraneous div tag

## Motivation and Context
In #1143, an extra `</div>` tag was introduced, causing the footer to display incorrectly.

## How Has This Been Tested?
**Before**
![Screenshot 2023-01-30 at 14 08 13](https://user-images.githubusercontent.com/9074856/215572018-0bcf8bb8-5f67-4838-8126-ecc3f58ae167.png)

**After**
![Screenshot 2023-01-30 at 14 08 20](https://user-images.githubusercontent.com/9074856/215572013-b9b8b88d-06db-4670-9417-cc8c10acdacd.png)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting