### PR TITLE
Gitstream: Automatically assign reviewers

### DIFF
--- a/.cm/gitstream.cm
+++ b/.cm/gitstream.cm
@@ -48,6 +48,29 @@ automations:
       # such PRs to save reviewers time for such changes.
       # - action: approve@v1
 
+  familiar_reviewer:
+    if:
+      - true
+    run:
+      - action: add-comment@v1
+        args:
+          comment: |
+            {{ repo | explainRankByGitBlame(gt=25) }}
+      - action: add-reviewers@v1
+        args:
+          reviewers: {{ repo | rankByGitBlame(gt=25) | random }}
+
+  share_knowledge:
+    if:
+      - true
+    run:
+      - action: add-comment@v1
+        args:
+          comment: |
+            {{ repo | explainRankByGitBlame(lt=25) }}
+      - action: add-reviewers@v1
+        args:
+          reviewers: {{ repo | rankByGitBlame(lt=25) | random }}
 
 calc:
   etr: {{ branch | estimatedReviewTime }}


### PR DESCRIPTION
## Description
- Assign one reviewer with < 25% familiarity with PR changes
- Assign one reviewer with > 25% familiarity with PR changes

## Motivation and Context
To spread knowledge of the code base, assign a reviewer unfamiliar with a PR's changes.

To ensure good quality reviews, assign a reviewer familiar with a PR's changes.

## How Has This Been Tested?
N/A

Examples taken / adapted from:
https://docs.gitstream.cm/examples/#assign-the-relevant-reviewers-to-prs
https://docs.gitstream.cm/examples/#share-knowledge
