### PR TITLE
Gitstream: Filter list of reviewers

### DIFF
--- a/.cm/gitstream.cm
+++ b/.cm/gitstream.cm
@@ -55,10 +55,10 @@ automations:
       - action: add-comment@v1
         args:
           comment: |
-            {{ repo | explainRankByGitBlame(gt=25) }}
-      - action: add-reviewers@v1
-        args:
-          reviewers: {{ repo | rankByGitBlame(gt=25) | random }}
+            {{ repo | filter(list=['20wildmanj', 'najclark', 'damianhxy', 'michellexliu', 'victorhuangwq', 'lykimchee', 'jlge', 'evanyeyeye', 'KesterTan']) | explainRankByGitBlame(gt=25) }}
+      # - action: add-reviewers@v1
+      #   args:
+      #     reviewers: {{ repo | rankByGitBlame(gt=25) | random }}
 
   share_knowledge:
     if:
@@ -67,10 +67,10 @@ automations:
       - action: add-comment@v1
         args:
           comment: |
-            {{ repo | explainRankByGitBlame(lt=25) }}
-      - action: add-reviewers@v1
-        args:
-          reviewers: {{ repo | rankByGitBlame(lt=25) | random }}
+            {{ repo | filter(list=['20wildmanj', 'najclark', 'damianhxy', 'michellexliu', 'victorhuangwq', 'lykimchee', 'jlge', 'evanyeyeye', 'KesterTan']) | explainRankByGitBlame(lt=25) }}
+      # - action: add-reviewers@v1
+      #   args:
+      #     reviewers: {{ repo | rankByGitBlame(lt=25) | random }}
 
 calc:
   etr: {{ branch | estimatedReviewTime }}

--- a/.cm/gitstream.cm
+++ b/.cm/gitstream.cm
@@ -55,10 +55,10 @@ automations:
       - action: add-comment@v1
         args:
           comment: |
-            {{ repo | filter(list=['20wildmanj', 'najclark', 'damianhxy', 'michellexliu', 'victorhuangwq', 'lykimchee', 'jlge', 'evanyeyeye', 'KesterTan']) | explainRankByGitBlame(gt=25) }}
-      # - action: add-reviewers@v1
-      #   args:
-      #     reviewers: {{ repo | rankByGitBlame(gt=25) | random }}
+            {{ repo | explainRankByGitBlame(gt=25) }}
+      - action: add-reviewers@v1
+        args:
+          reviewers: {{ repo | rankByGitBlame(gt=25) | filter(list=['20wildmanj', 'najclark', 'damianhxy', 'michellexliu', 'victorhuangwq', 'lykimchee', 'jlge', 'evanyeyeye', 'KesterTan']) | random }}
 
   share_knowledge:
     if:
@@ -67,10 +67,10 @@ automations:
       - action: add-comment@v1
         args:
           comment: |
-            {{ repo | filter(list=['20wildmanj', 'najclark', 'damianhxy', 'michellexliu', 'victorhuangwq', 'lykimchee', 'jlge', 'evanyeyeye', 'KesterTan']) | explainRankByGitBlame(lt=25) }}
-      # - action: add-reviewers@v1
-      #   args:
-      #     reviewers: {{ repo | rankByGitBlame(lt=25) | random }}
+            {{ repo | explainRankByGitBlame(lt=25) }}
+      - action: add-reviewers@v1
+        args:
+          reviewers: {{ repo | rankByGitBlame(lt=25) | filter(list=['20wildmanj', 'najclark', 'damianhxy', 'michellexliu', 'victorhuangwq', 'lykimchee', 'jlge', 'evanyeyeye', 'KesterTan']) | random }}
 
 calc:
   etr: {{ branch | estimatedReviewTime }}


### PR DESCRIPTION
## Description
Filter list of potential reviewers to current members of the Autolab team.

## Motivation and Context
Gitstream currently does not filter the list of reviewers, and might assign a retired member of the Autolab team.

## How Has This Been Tested?
N/A -- referenced https://docs.gitstream.cm/filter-functions/#filter