### PR TITLE
Update Dockerfile to use passenger-ruby27

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@
 #     https://github.com/phusion/passenger-docker
 #
 #
-FROM phusion/passenger-ruby26:2.0.0
+FROM phusion/passenger-ruby27
 
 MAINTAINER Autolab Development Team "autolab-dev@andrew.cmu.edu"
 


### PR DESCRIPTION
Update dockerfile to use version of passenger that supports Ruby 2.7.7

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Necessary for Autolab docker container to build due to update to Ruby 2.7.7 in #1698.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

phusion/passenger-ruby27 works on Nightly.

