### PR TITLE
Improve delete user functionality

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -186,6 +186,11 @@ class UsersController < ApplicationController
       redirect_to(users_path) && return
     end
 
+    if current_user.id == params[:id].to_i
+      flash[:error] = "You cannot delete yourself."
+      redirect_to(users_path) && return
+    end
+
     user = User.find(params[:id])
     if user.nil?
       flash[:error] = "User doesn't exist."

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -23,9 +23,3 @@
 
   <%= f.submit 'Save Changes', { :class=>"btn primary"} %>
 <% end %>
-
-<% if current_user.administrator? %>
-<br> <br><hr><br>
-<h3> Admin Only</h3>
-  <%= link_to raw('<span class="btn">Delete User</span>'), user_path(@user), method: :delete, data: {confirm: "Are you sure!?"} %>
-<% end %> 

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -34,7 +34,10 @@
     <% end %>
   </li>
 </ul>
-<%= link_to raw('<span class="btn primary">Edit Information</span>'), edit_user_path(@user) %><br>
+<%= link_to raw('<span class="btn primary">Edit Information</span>'), edit_user_path(@user) %>
+<% if current_user.administrator? && @user.id != current_user.id %>
+  <%= link_to raw('<span class="btn">Delete User</span>'), user_path(@user), method: :delete, data: {confirm: "Are you sure!?"} %>
+<% end %>
 <% if @user == current_user %>
   <hr>
   <h4>Private Settings</h4>


### PR DESCRIPTION
## Description
- Prevent admins from deleting themselves
- Move delete button from edit user page to view user page

## Motivation and Context
Currently to delete a user, admins must navigate all the way to the edit information page, which is cumbersome and unintuitive.

This PR moves the button to the show user page, while also adding safeguards against admins deleting themselves.

Fixes #495

## How Has This Been Tested?
- Ensure that delete button is no longer on edit user page
- Ensure that delete button is now on show user page
- Ensure that delete button doesn't show up on your own profile page
- Ensure that delete button doesn't show up for non-admins (they shouldn't be able to view other users anyway)
- Ensure that you can't delete yourself (modify the check in `show.html.erb`)
- Successfully delete a user

**BEFORE**

![Screenshot 2023-02-06 at 13 52 45](https://user-images.githubusercontent.com/9074856/217061894-0b1f8a56-de7b-432c-b1c7-7179b804b396.png)
![Screenshot 2023-02-06 at 13 52 49](https://user-images.githubusercontent.com/9074856/217061896-c1cb02b0-fbf0-42eb-afc0-550ebebe23d3.png)

**AFTER**

![Screenshot 2023-02-06 at 14 04 54](https://user-images.githubusercontent.com/9074856/217061958-337e6f9e-7753-4e55-b9cd-f5dd79e7e2ab.png)

![Screenshot 2023-02-06 at 13 58 11](https://user-images.githubusercontent.com/9074856/217061827-903d78b2-9c4a-4a77-9712-575655d895e2.png)


## Types of changes
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting