### PR TITLE
Update workflows to work with merge queue

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -17,6 +17,8 @@ on:
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ master ]
+  merge_group:
+    branches: [ master ]
   schedule:
     - cron: '32 10 * * 4'
 

--- a/.github/workflows/rubyonrails.yml
+++ b/.github/workflows/rubyonrails.yml
@@ -10,6 +10,8 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+  merge_group:
+    branches: [ master ]
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description
Update workflows to work with merge queue.

## Motivation and Context
Make use of new merge queue feature (https://github.blog/changelog/2023-02-08-pull-request-merge-queue-public-beta/) to increase velocity of merges.

## How Has This Been Tested?
N/A, referred to https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue