### PR TITLE
Annotation scrolling to line UI bug fix

### DIFF
--- a/app/assets/javascripts/annotations.js
+++ b/app/assets/javascripts/annotations.js
@@ -342,7 +342,11 @@ function attachEvents() {
 function attachChangeFileEvents() {
   // Set up file switching to use the local cache
   function changeFileClickHandler(e) {
-    const wasCachedLocally = changeFile($(this).data("header_position"));
+    const headerURL = new URLSearchParams(location.search);
+    const currentHeader = parseInt(headerURL.get("header_position"));
+
+    const targetHeader = $(this).data("header_position");
+    const wasCachedLocally = (targetHeader === currentHeader) || changeFile(targetHeader);
     if (wasCachedLocally) {
       e.preventDefault();
       if ($(this).data("line")) {

--- a/app/assets/javascripts/annotations.js
+++ b/app/assets/javascripts/annotations.js
@@ -342,11 +342,8 @@ function attachEvents() {
 function attachChangeFileEvents() {
   // Set up file switching to use the local cache
   function changeFileClickHandler(e) {
-    const headerURL = new URLSearchParams(location.search);
-    const currentHeader = parseInt(headerURL.get("header_position"));
-
     const targetHeader = $(this).data("header_position");
-    const wasCachedLocally = (targetHeader === currentHeader) || changeFile(targetHeader);
+    const wasCachedLocally = (targetHeader === currentHeaderPos) || changeFile(targetHeader);
     if (wasCachedLocally) {
       e.preventDefault();
       if ($(this).data("line")) {


### PR DESCRIPTION
## Description
Changed `app/assets/javascripts/annotations.js` to fix the scroll animation jumping around when clicking on an annotation that was already in view. (Issue #1665 No. 5)

The jumping animation was caused due to the entire code file being reloaded every time a user clicked on an annotation link (inside `annotations.js`, the function `attachChangeFileEvents` would always call `changeFile` and thus reload the code pane). This was fixed by adding a check to ensure `changeFile` would only be called if the header position (code file) of the annotation clicked was different from the current code file in view.

## Motivation and context
Previously, when we clicked on an annotation on the right side bar, we would start scrolling from the top of the code viewer each time (even if the annotation was already in view), which resulted in a buggy animation.

Before changes:
![before](https://user-images.githubusercontent.com/66969001/217990241-0c504f55-bfd3-4b94-8cb7-f7a1dac0d0c9.gif)

After changes:
![after](https://user-images.githubusercontent.com/66969001/217990396-93fb87e9-f331-415f-945e-b49fd01186f4.gif)

## How has this been tested?
To test this bug fix, create a submission with multiple files (with at least one multiline file long enough to require scrolling within the Autolab submission viewer). Then, write an annotation for any line in the multiline file (preferably on a line not initially visible when the file is loaded, such that you have to scroll in order to view the line), and annotations in other files as well. Test by clicking annotations on the right side bar when:
- [Within the multiline file] The annotated line is not in view (is below your current position on the file)
- [Within the multiline file] The annotated line is not in view (is above your current position on the file)
- [Within the multiline file] The line is in view
- [Within any file] Click an annotation for a line inside another file
- [For any annotation] Immediately after clicking the annotation (so the annotation should've already been scrolled to)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR