### PR TITLE
Add loading spinner to annotations panel when annotations are updating

### DIFF
--- a/app/assets/javascripts/annotations.js
+++ b/app/assets/javascripts/annotations.js
@@ -145,11 +145,13 @@ function plusFix(n) {
 // function called after create, update & delete of annotations
 function fillAnnotationBox() {
   retrieveSharedComments();
+  $('#loadScreen').css('display', 'flex');
   $.get(document.URL, function(data) {
     const $page = $('<div />').html(data);
     $('.problemGrades').html($page.find('.problemGrades'));
     $('#annotationPane').html($page.find(' #annotationPane'));
     $('.collapsible').collapsible({ accordion: false });
+    $('#loadScreen').hide();
     attachChangeFileEvents();
     attachAnnotationPaneEvents();
   });

--- a/app/assets/javascripts/annotations.js
+++ b/app/assets/javascripts/annotations.js
@@ -367,6 +367,7 @@ function attachAnnotationPaneEvents() {
   // Add action
   $(".global-annotation-add-button").on("click", function (e) {
     e.preventDefault();
+    if ($('#loadScreen').css('display') === 'flex') return;
     const problem = $(this).data("problem");
     const $headerDiv = $(this).parent().parent();
 
@@ -378,6 +379,7 @@ function attachAnnotationPaneEvents() {
   // Edit action
   $(".global-annotation-edit-button").on("click", function (e) {
     e.preventDefault();
+    if ($('#loadScreen').css('display') === 'flex') return;
     const problem = $(this).parent().data("problem");
     const score = $(this).parent().data("score");
     const comment = $(this).parent().data("comment");
@@ -393,6 +395,7 @@ function attachAnnotationPaneEvents() {
   // Delete action for global annotations
   $('.global-annotation-delete-button').on("click", function (e) {
     e.preventDefault();
+    if ($('#loadScreen').css('display') === 'flex') return;
     if (!confirm("Are you sure you want to delete this annotation?")) return;
     const annotationIdData = $(this).parent().data('annotationid');
     const annotationId = annotations.findIndex((e) => e.id === annotationIdData);
@@ -414,6 +417,7 @@ function attachAnnotationPaneEvents() {
   // Chevron events (collapse / show problem)
   $('.collapsible-header-controls .collapse-icon, .collapsible-header-controls .expand-icon').on('click', function(e) {
     e.preventDefault();
+    if ($('#loadScreen').css('display') === 'flex') return;
     $(e.target).closest(".collapsible-header-wrap").find(".collapsible-header").click();
   });
 }

--- a/app/assets/stylesheets/annotations.scss
+++ b/app/assets/stylesheets/annotations.scss
@@ -507,6 +507,16 @@
   height: 100%;
   overflow-y: auto;
 }
+#loadScreen {
+  height: inherit;
+  width: 100%;
+  position: absolute;
+  background-color: rgba(0,0,0,.3);
+  display: none;
+  pointer-events: none;
+  justify-content: center;
+  align-items: center;
+}
 .annotationSummary{
   margin-bottom: 15px;
   color: #4f4f4f;

--- a/app/views/submissions/_annotation_pane.html.erb
+++ b/app/views/submissions/_annotation_pane.html.erb
@@ -1,4 +1,17 @@
 <div id="annotationPane">
+  <div id="loadScreen">
+    <div class="preloader-wrapper small active">
+      <div class="spinner-layer spinner-red-only">
+        <div class="circle-clipper left">
+          <div class="circle"></div>
+        </div><div class="gap-patch">
+          <div class="circle"></div>
+        </div><div class="circle-clipper right">
+          <div class="circle"></div>
+        </div>
+      </div>
+    </div>
+  </div>
   <div class="annotationSummary">
     <ul class="collapsible expandable">
       <% p_scores = @submission.problems_to_scores %>


### PR DESCRIPTION
## Description
https://user-images.githubusercontent.com/50491000/218332433-3f926e53-f086-4383-96fa-3006e322c83f.mp4
Resolves #1771

Grays out & disables the the annotations panel and adds a loading spinner when annotation scores are being updated.

## Motivation and Context
There's a bit of a lag from the time an annotation is added and when the scores update, causing confusion for some of the TA's. Based on how this feature is engineered right now, it's not very feasible to remove the lag, so we instead will add an indication that loading is occurring.

## How Has This Been Tested?
* Create regular annotation --> see loading
* Create global annotation --> see loading

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR

