### PR TITLE
[Breaking] Use ActiveStorage for attachments, update attachments tests

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,12 +13,12 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ master, `develop/**` ]
+    branches: [ master, 'develop/**' ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ master, `develop/**` ]
+    branches: [ master, 'develop/**' ]
   merge_group:
-    branches: [ master, `develop/**` ]
+    branches: [ master, 'develop/**' ]
   schedule:
     - cron: '32 10 * * 4'
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,12 +13,12 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, `develop/**` ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ master ]
+    branches: [ master, `develop/**` ]
   merge_group:
-    branches: [ master ]
+    branches: [ master, `develop/**` ]
   schedule:
     - cron: '32 10 * * 4'
 

--- a/.github/workflows/rubyonrails.yml
+++ b/.github/workflows/rubyonrails.yml
@@ -53,7 +53,7 @@ jobs:
           cp config/school.yml.template config/school.yml
           cp config/autogradeConfig.rb.template config/autogradeConfig.rb
           cp .env.template .env
-          mkdir attachments/ tmp/
+          mkdir tmp/
 
       - name: Set up database
         run: |

--- a/.github/workflows/rubyonrails.yml
+++ b/.github/workflows/rubyonrails.yml
@@ -7,11 +7,11 @@
 name: "Ruby on Rails CI"
 on:
   push:
-    branches: [ master, `develop/**` ]
+    branches: [ master, 'develop/**' ]
   pull_request:
-    branches: [ master, `develop/**` ]
+    branches: [ master, 'develop/**' ]
   merge_group:
-    branches: [ master, `develop/**` ]
+    branches: [ master, 'develop/**' ]
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/rubyonrails.yml
+++ b/.github/workflows/rubyonrails.yml
@@ -7,11 +7,11 @@
 name: "Ruby on Rails CI"
 on:
   push:
-    branches: [ master ]
+    branches: [ master, `develop/**` ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, `develop/**` ]
   merge_group:
-    branches: [ master ]
+    branches: [ master, `develop/**` ]
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,6 @@ config/lti_settings.yml
 
 # autolab user documents
 app/views/home/_topannounce.html.erb
-attachments/
 doc/
 storage/
 out.txt
@@ -46,7 +45,6 @@ tags
 .idea/
 .yardoc
 app/views/home/_topannounce.html.erb
-attachments/
 doc/
 out.txt
 .vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ config/lti_settings.yml
 app/views/home/_topannounce.html.erb
 attachments/
 doc/
+storage/
 out.txt
 
 # compiled assets

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ We released new documentation! Check it out [here](https://docs.autolabproject.c
 3. Create necessary directories.
 
 	```
-	mkdir attachments/ tmp/
+	mkdir tmp/
 	```
 
 ### Running Tests

--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -67,8 +67,8 @@ class AttachmentsController < ApplicationController
     if @cud.instructor? || @attachment.released?
       # Default disposition is "attachment" which forces download
       send_data attached_file.download,
-                :filename => @attachment.filename,
-                :type => @attachment.mime_type
+                filename: @attachment.filename,
+                type: @attachment.mime_type
       return
     end
 

--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -65,10 +65,14 @@ class AttachmentsController < ApplicationController
       redirect_to([@course, :attachments]) && return
     end
     if @cud.instructor? || @attachment.released?
-      # Default disposition is "attachment" which forces download
-      send_data attached_file.download,
-                filename: @attachment.filename,
-                type: @attachment.mime_type
+      begin
+        send_data attached_file.download, filename: @attachment.filename,
+                                          type: @attachment.mime_type
+      rescue StandardError
+        COURSE_LOGGER.log("Error viewing attachment '#{@attachment.name}'")
+        flash[:error] = "Error viewing attachment '#{@attachment.name}'"
+        redirect_to([@course, @assessment])
+      end
       return
     end
 

--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -122,13 +122,13 @@ private
     @attachment = if @is_assessment
                     @course.attachments.find_by(assessment_id: @assessment.id, id: params[:id])
                   else
-                    @course.attachments.find(params[:id])
+                    @course.attachments.find_by(id: params[:id])
                   end
 
     return unless @attachment.nil?
 
     COURSE_LOGGER.log("Cannot find attachment with id: #{params[:id]}")
-    flash[:error] = "Could not find Attachment \# #{params[:id]}"
+    flash[:error] = "Could not find Attachment \##{params[:id]}"
     redirect_to_attachment_list
   end
 

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -7,26 +7,14 @@ require "fileutils"
 class Attachment < ApplicationRecord
   validates :name, presence: true
   validates :filename, presence: true
+  has_one_attached :attachment_file
 
   belongs_to :course
   belongs_to :assessment
 
   def file=(upload)
-    directory = "attachments"
-    filename = File.basename(upload.original_filename)
-    dir_path = Rails.root.join(directory)
-    FileUtils.mkdir_p(dir_path) unless File.exist?(dir_path)
-
-    path = Rails.root.join(directory, filename)
-    addendum = 1
-
-    # Deal with duplicate filenames on disk
-    while File.exist?(path)
-      path = Rails.root.join(directory, "#{filename}.#{addendum}")
-      addendum += 1
-    end
-    self.filename = File.basename(path)
-    File.open(path, "wb") { |f| f.write(upload.read) }
+    self.filename = File.basename(upload.original_filename)
+    self.attachment_file = upload
     self.mime_type = upload.content_type
   end
 

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -14,7 +14,7 @@ class Attachment < ApplicationRecord
 
   def file=(upload)
     self.filename = File.basename(upload.original_filename)
-    self.attachment_file = upload
+    self.attachment_file.attach(upload)
     self.mime_type = upload.content_type
   end
 

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -14,7 +14,7 @@ class Attachment < ApplicationRecord
 
   def file=(upload)
     self.filename = File.basename(upload.original_filename)
-    self.attachment_file.attach(upload)
+    attachment_file.attach(upload)
     self.mime_type = upload.content_type
   end
 

--- a/app/views/attachments/_attachment.html.erb
+++ b/app/views/attachments/_attachment.html.erb
@@ -26,11 +26,11 @@
   <span class="secondary-content">
   <% if @cud.instructor? %>
     <% if attachment.assessment.nil? %>
-      <%= link_to '<i class="material-icons left">mode_edit</i>'.html_safe, [:edit, @course, attachment], {class:"small"} %>
-      <%= link_to '<i class="material-icons left">delete</i>'.html_safe, [@course, attachment], {method: :delete, class:"small"} %>
+      <%= link_to '<i class="material-icons left">mode_edit</i>'.html_safe, [:edit, @course, attachment], class:"small" %>
+      <%= link_to '<i class="material-icons left">delete</i>'.html_safe, [@course, attachment], method: :delete, class:"small", data: {confirm: "Are you sure?"} %>
     <% else %>
-      <%= link_to '<i class="material-icons left">mode_edit</i>'.html_safe, [:edit, @course, attachment.assessment, attachment], {class:"small"} %>
-      <%= link_to '<i class="material-icons left">delete</i>'.html_safe, [@course, attachment.assessment, attachment], {method: :delete, class:"small"} %>
+      <%= link_to '<i class="material-icons left">mode_edit</i>'.html_safe, [:edit, @course, attachment.assessment, attachment], class:"small" %>
+      <%= link_to '<i class="material-icons left">delete</i>'.html_safe, [@course, attachment.assessment, attachment], method: :delete, class:"small", data: {confirm: "Are you sure?"} %>
     <% end %>
   <% end %>
   </span>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -61,7 +61,7 @@ Rails.application.configure do
   # config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
   # OAuth2 Application Configuration for Github
-  # See (TODO replace with doc link)
+  # See https://docs.autolabproject.com/installation/github_integration/
   config.x.github.client_id = ENV['GITHUB_CLIENT_ID']
   config.x.github.client_secret = ENV['GITHUB_CLIENT_SECRET']
 end

--- a/config/environments/production.rb.template
+++ b/config/environments/production.rb.template
@@ -116,7 +116,7 @@ Autolab3::Application.configure do
   config.x.google_analytics_id = nil
 
   # OAuth2 Application Configuration for Github
-  # See (TODO replace with doc link)
+  # See https://docs.autolabproject.com/installation/github_integration/
   config.x.github.client_id = ENV['GITHUB_CLIENT_ID']
   config.x.github.client_secret = ENV['GITHUB_CLIENT_SECRET']
   # LTI configuration file storage location. Needs to be in a private folder

--- a/config/environments/production.rb.template
+++ b/config/environments/production.rb.template
@@ -55,6 +55,9 @@ Autolab3::Application.configure do
   # Enable serving of images, stylesheets, and JavaScripts from an asset server
   # config.action_controller.asset_host = "http://assets.example.com"
 
+  # Store uploaded files on the local file system (see config/storage.yml for options).
+  config.active_storage.service = :local
+
   # Disable delivery errors, bad email addresses will be ignored
   # config.action_mailer.raise_delivery_errors = false
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -34,6 +34,9 @@ Rails.application.configure do
   # Store uploaded files on the local file system in a temporary directory.
   config.active_storage.service = :test
 
+  # Perform ActiveStorage jobs immediately.
+  config.active_job.queue_adapter = :inline
+
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false
 

--- a/db/migrate/20230212191438_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20230212191438_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,27 @@
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
+  def change
+    create_table :active_storage_blobs do |t|
+      t.string   :key,        null: false
+      t.string   :filename,   null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.bigint   :byte_size,  null: false
+      t.string   :checksum,   null: false
+      t.datetime :created_at, null: false
+
+      t.index [ :key ], unique: true
+    end
+
+    create_table :active_storage_attachments do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false
+      t.references :blob,     null: false
+
+      t.datetime :created_at, null: false
+
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: "index_active_storage_attachments_uniqueness", unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -33,7 +33,7 @@ ActiveRecord::Schema.define(version: 2023_02_12_191438) do
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
   end
 
-  create_table "annotations", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "annotations", force: :cascade do |t|
     t.integer "submission_id"
     t.string "filename"
     t.integer "position"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,30 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_11_28_044321) do
+ActiveRecord::Schema.define(version: 2023_02_12_191438) do
 
-  create_table "annotations", force: :cascade do |t|
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.bigint "byte_size", null: false
+    t.string "checksum", null: false
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "annotations", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "submission_id"
     t.string "filename"
     t.integer "position"

--- a/spec/controllers/attachments_controller_spec.rb
+++ b/spec/controllers/attachments_controller_spec.rb
@@ -4,18 +4,26 @@ include ControllerMacros
 RSpec.describe AttachmentsController, type: :controller do
   render_views
 
-  # Course attachments
+  # Render tests
 
   # INDEX
   shared_examples "index_success" do |u|
     login_as(u)
     let!(:cid)  { get_course_id_by_uid(u.id) }
     let!(:cname) { Course.find(cid).name }
-    it "renders successfully" do
+    it "renders course successfully" do
       get :index, params: {course_name: cname}
       expect(response).to be_successful
       expect(response.body).to match(cname)
       expect(response.body).to match(/Course Attachments/m)
+    end
+    let!(:aid)  { get_first_aid_by_cid(cid) }
+    let!(:aname) { Assessment.find(aid).name }
+    it "renders assessment successfully" do
+      get :index, params: {course_name: cname, assessment_name: aname}
+      expect(response).to be_successful
+      expect(response.body).to match(aname)
+      expect(response.body).to match(/Add/m)
     end
   end
 
@@ -23,11 +31,19 @@ RSpec.describe AttachmentsController, type: :controller do
     login_as(u) if login
     let!(:cid)  { get_course_id_by_uid(u.id) }
     let!(:cname) { Course.find(cid).name }
-    it "renders with failure" do
+    it "renders course with failure" do
       get :index, params: {course_name: cname}
       expect(response).not_to be_successful
       expect(response.body).not_to match(cname)
       expect(response.body).not_to match(/Course Attachments/m)
+    end
+    let!(:aid)  { get_first_aid_by_cid(cid) }
+    let!(:aname) { Assessment.find(aid).name }
+    it "renders assessment with failure" do
+      get :index, params: {course_name: cname, assessment_name: aname}
+      expect(response).not_to be_successful
+      expect(response.body).not_to match(aname)
+      expect(response.body).not_to match(/Add/m)
     end
   end
 
@@ -189,4 +205,9 @@ RSpec.describe AttachmentsController, type: :controller do
       it_behaves_like "show_failure", get_admin, login: false, released: false
     end
   end
+
+  # Functionality tests
+  # Create
+  # Update
+  # Destroy
 end

--- a/spec/controllers/attachments_controller_spec.rb
+++ b/spec/controllers/attachments_controller_spec.rb
@@ -9,18 +9,18 @@ RSpec.describe AttachmentsController, type: :controller do
   # INDEX
   shared_examples "index_success" do |u|
     login_as(u)
-    let!(:cid)  { get_course_id_by_uid(u.id) }
+    let!(:cid) { get_course_id_by_uid(u.id) }
     let!(:cname) { Course.find(cid).name }
     it "renders course successfully" do
-      get :index, params: {course_name: cname}
+      get :index, params: { course_name: cname }
       expect(response).to be_successful
       expect(response.body).to match(cname)
       expect(response.body).to match(/Course Attachments/m)
     end
-    let!(:aid)  { get_first_aid_by_cid(cid) }
+    let!(:aid) { get_first_aid_by_cid(cid) }
     let!(:aname) { Assessment.find(aid).name }
     it "renders assessment successfully" do
-      get :index, params: {course_name: cname, assessment_name: aname}
+      get :index, params: { course_name: cname, assessment_name: aname }
       expect(response).to be_successful
       expect(response.body).to match(cname)
       expect(response.body).to match(aname)
@@ -33,15 +33,15 @@ RSpec.describe AttachmentsController, type: :controller do
     let!(:cid)  { get_course_id_by_uid(u.id) }
     let!(:cname) { Course.find(cid).name }
     it "renders course with failure" do
-      get :index, params: {course_name: cname}
+      get :index, params: { course_name: cname }
       expect(response).not_to be_successful
       expect(response.body).not_to match(cname)
       expect(response.body).not_to match(/Course Attachments/m)
     end
-    let!(:aid)  { get_first_aid_by_cid(cid) }
+    let!(:aid) { get_first_aid_by_cid(cid) }
     let!(:aname) { Assessment.find(aid).name }
     it "renders assessment with failure" do
-      get :index, params: {course_name: cname, assessment_name: aname}
+      get :index, params: { course_name: cname, assessment_name: aname }
       expect(response).not_to be_successful
       expect(response.body).not_to match(cname)
       expect(response.body).not_to match(aname)
@@ -70,19 +70,19 @@ RSpec.describe AttachmentsController, type: :controller do
   # NEW
   shared_examples "new_success" do |u|
     login_as(u)
-    let!(:cid)  { get_course_id_by_uid(u.id) }
+    let!(:cid) { get_course_id_by_uid(u.id) }
     let!(:cname) { Course.find(cid).name }
     it "renders course successfully" do
-      get :new, params: {course_name: cname}
+      get :new, params: { course_name: cname }
       expect(response).to be_successful
       expect(response.body).to match(cname)
       expect(response.body).to match(/Name/m)
       expect(response.body).to match(/Released/m)
     end
-    let!(:aid)  { get_first_aid_by_cid(cid) }
+    let!(:aid) { get_first_aid_by_cid(cid) }
     let!(:aname) { Assessment.find(aid).name }
     it "renders assessment successfully" do
-      get :new, params: {course_name: cname, assessment_name: aname}
+      get :new, params: { course_name: cname, assessment_name: aname }
       expect(response).to be_successful
       expect(response.body).to match(cname)
       expect(response.body).to match(aname)
@@ -96,16 +96,16 @@ RSpec.describe AttachmentsController, type: :controller do
     let!(:cid)  { get_course_id_by_uid(u.id) }
     let!(:cname) { Course.find(cid).name }
     it "renders course with failure" do
-      get :new, params: {course_name: cname}
+      get :new, params: { course_name: cname }
       expect(response).not_to be_successful
       expect(response.body).not_to match(cname)
       expect(response.body).not_to match(/Name/m)
       expect(response.body).not_to match(/Released/m)
     end
-    let!(:aid)  { get_first_aid_by_cid(cid) }
+    let!(:aid) { get_first_aid_by_cid(cid) }
     let!(:aname) { Assessment.find(aid).name }
     it "renders assessment with failure" do
-      get :new, params: {course_name: cname, assessment_name: aname}
+      get :new, params: { course_name: cname, assessment_name: aname }
       expect(response).not_to be_successful
       expect(response.body).not_to match(cname)
       expect(response.body).not_to match(aname)
@@ -135,11 +135,11 @@ RSpec.describe AttachmentsController, type: :controller do
   # EDIT
   shared_examples "edit_success" do |u|
     login_as(u)
-    let!(:cid)  { get_course_id_by_uid(u.id) }
+    let!(:cid) { get_course_id_by_uid(u.id) }
     let!(:cname) { Course.find(cid).name }
     let!(:att) { create_course_att_with_cid(cid, true) }
     it "renders course successfully" do
-      get :edit, params: {course_name: cname, id: att.id}
+      get :edit, params: { course_name: cname, id: att.id }
       expect(response).to be_successful
       expect(response.body).to match(cname)
       expect(response.body).to match(att.name)
@@ -148,11 +148,11 @@ RSpec.describe AttachmentsController, type: :controller do
       expect(response.body).to match(/Mime type/m)
       expect(response.body).to match(/Released/m)
     end
-    let!(:aid)  { get_first_aid_by_cid(cid) }
+    let!(:aid) { get_first_aid_by_cid(cid) }
     let!(:aname) { Assessment.find(aid).name }
     let!(:assess_att) { create_assess_att_with_cid_aid(cid, aid, true) }
     it "renders assessment successfully" do
-      get :edit, params: {course_name: cname, assessment_name: aname, id: assess_att.id}
+      get :edit, params: { course_name: cname, assessment_name: aname, id: assess_att.id }
       expect(response).to be_successful
       expect(response.body).to match(cname)
       expect(response.body).to match(aname)
@@ -170,7 +170,7 @@ RSpec.describe AttachmentsController, type: :controller do
     let!(:cname) { Course.find(cid).name }
     let!(:att) { create_course_att_with_cid(cid, true) }
     it "renders course with failure" do
-      get :edit, params: {course_name: cname, id: att.id}
+      get :edit, params: { course_name: cname, id: att.id }
       expect(response).not_to be_successful
       expect(response.body).not_to match(cname)
       expect(response.body).not_to match(att.name)
@@ -179,11 +179,11 @@ RSpec.describe AttachmentsController, type: :controller do
       expect(response.body).not_to match(/Mime type/m)
       expect(response.body).not_to match(/Released/m)
     end
-    let!(:aid)  { get_first_aid_by_cid(cid) }
+    let!(:aid) { get_first_aid_by_cid(cid) }
     let!(:aname) { Assessment.find(aid).name }
     let!(:assess_att) { create_assess_att_with_cid_aid(cid, aid, true) }
     it "renders assessment with failure" do
-      get :edit, params: {course_name: cname, assessment_name: aname, id: assess_att.id}
+      get :edit, params: { course_name: cname, assessment_name: aname, id: assess_att.id }
       expect(response).not_to be_successful
       expect(response.body).not_to match(cname)
       expect(response.body).not_to match(aname)
@@ -197,16 +197,16 @@ RSpec.describe AttachmentsController, type: :controller do
 
   shared_examples "edit_missing" do |u|
     login_as(u)
-    let!(:cid)  { get_course_id_by_uid(u.id) }
+    let!(:cid) { get_course_id_by_uid(u.id) }
     let!(:cname) { Course.find(cid).name }
     it "flashes error for non-existent course attachment" do
-      get :edit, params: {course_name: cname, id: -1}
+      get :edit, params: { course_name: cname, id: -1 }
       expect(flash[:error]).to match(/Could not find/)
     end
-    let!(:aid)  { get_first_aid_by_cid(cid) }
+    let!(:aid) { get_first_aid_by_cid(cid) }
     let!(:aname) { Assessment.find(aid).name }
     it "flashes error for non-existent assessment attachment" do
-      get :edit, params: {course_name: cname, assessment_name: aname, id: -1}
+      get :edit, params: { course_name: cname, assessment_name: aname, id: -1 }
       expect(flash[:error]).to match(/Could not find/)
     end
   end
@@ -234,18 +234,18 @@ RSpec.describe AttachmentsController, type: :controller do
   # SHOW
   shared_examples "show_success" do |u, released: true|
     login_as(u)
-    let!(:cid)  { get_course_id_by_uid(u.id) }
+    let!(:cid) { get_course_id_by_uid(u.id) }
     let!(:cname) { Course.find(cid).name }
     let!(:att) { create_course_att_with_cid(cid, released) }
     it "renders course successfully" do
-      get :show, params: {course_name: cname, id: att.id}
+      get :show, params: { course_name: cname, id: att.id }
       expect(response).to be_successful
     end
-    let!(:aid)  { get_first_aid_by_cid(cid) }
+    let!(:aid) { get_first_aid_by_cid(cid) }
     let!(:aname) { Assessment.find(aid).name }
     let!(:assess_att) { create_assess_att_with_cid_aid(cid, aid, released) }
     it "renders assessment successfully" do
-      get :show, params: {course_name: cname, assessment_name: aname, id: assess_att.id}
+      get :show, params: { course_name: cname, assessment_name: aname, id: assess_att.id }
       expect(response).to be_successful
     end
   end
@@ -256,30 +256,30 @@ RSpec.describe AttachmentsController, type: :controller do
     let!(:cname) { Course.find(cid).name }
     let!(:att) { create_course_att_with_cid(cid, released) }
     it "renders course with failure" do
-      get :show, params: {course_name: cname, id: att.id}
+      get :show, params: { course_name: cname, id: att.id }
       expect(response).not_to be_successful
     end
-    let!(:aid)  { get_first_aid_by_cid(cid) }
+    let!(:aid) { get_first_aid_by_cid(cid) }
     let!(:aname) { Assessment.find(aid).name }
     let!(:assess_att) { create_assess_att_with_cid_aid(cid, aid, released) }
     it "renders assessment with failure" do
-      get :show, params: {course_name: cname, assessment_name: aname, id: assess_att.id}
+      get :show, params: { course_name: cname, assessment_name: aname, id: assess_att.id }
       expect(response).not_to be_successful
     end
   end
 
   shared_examples "show_missing" do |u|
     login_as(u)
-    let!(:cid)  { get_course_id_by_uid(u.id) }
+    let!(:cid) { get_course_id_by_uid(u.id) }
     let!(:cname) { Course.find(cid).name }
     it "flashes error for non-existent course attachment" do
-      get :show, params: {course_name: cname, id: -1}
+      get :show, params: { course_name: cname, id: -1 }
       expect(flash[:error]).to match(/Could not find/)
     end
-    let!(:aid)  { get_first_aid_by_cid(cid) }
+    let!(:aid) { get_first_aid_by_cid(cid) }
     let!(:aname) { Assessment.find(aid).name }
     it "flashes error for non-existent assessment attachment" do
-      get :show, params: {course_name: cname, assessment_name: aname, id: -1}
+      get :show, params: { course_name: cname, assessment_name: aname, id: -1 }
       expect(flash[:error]).to match(/Could not find/)
     end
   end

--- a/spec/controllers/attachments_controller_spec.rb
+++ b/spec/controllers/attachments_controller_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe AttachmentsController, type: :controller do
     it "renders assessment successfully" do
       get :index, params: {course_name: cname, assessment_name: aname}
       expect(response).to be_successful
+      expect(response.body).to match(cname)
       expect(response.body).to match(aname)
       expect(response.body).to match(/Add/m)
     end
@@ -42,6 +43,7 @@ RSpec.describe AttachmentsController, type: :controller do
     it "renders assessment with failure" do
       get :index, params: {course_name: cname, assessment_name: aname}
       expect(response).not_to be_successful
+      expect(response.body).not_to match(cname)
       expect(response.body).not_to match(aname)
       expect(response.body).not_to match(/Add/m)
     end
@@ -70,10 +72,20 @@ RSpec.describe AttachmentsController, type: :controller do
     login_as(u)
     let!(:cid)  { get_course_id_by_uid(u.id) }
     let!(:cname) { Course.find(cid).name }
-    it "renders successfully" do
+    it "renders course successfully" do
       get :new, params: {course_name: cname}
       expect(response).to be_successful
       expect(response.body).to match(cname)
+      expect(response.body).to match(/Name/m)
+      expect(response.body).to match(/Released/m)
+    end
+    let!(:aid)  { get_first_aid_by_cid(cid) }
+    let!(:aname) { Assessment.find(aid).name }
+    it "renders assessment successfully" do
+      get :new, params: {course_name: cname, assessment_name: aname}
+      expect(response).to be_successful
+      expect(response.body).to match(cname)
+      expect(response.body).to match(aname)
       expect(response.body).to match(/Name/m)
       expect(response.body).to match(/Released/m)
     end
@@ -83,10 +95,20 @@ RSpec.describe AttachmentsController, type: :controller do
     login_as(u) if login
     let!(:cid)  { get_course_id_by_uid(u.id) }
     let!(:cname) { Course.find(cid).name }
-    it "renders with failure" do
+    it "renders course with failure" do
       get :new, params: {course_name: cname}
       expect(response).not_to be_successful
       expect(response.body).not_to match(cname)
+      expect(response.body).not_to match(/Name/m)
+      expect(response.body).not_to match(/Released/m)
+    end
+    let!(:aid)  { get_first_aid_by_cid(cid) }
+    let!(:aname) { Assessment.find(aid).name }
+    it "renders assessment with failure" do
+      get :new, params: {course_name: cname, assessment_name: aname}
+      expect(response).not_to be_successful
+      expect(response.body).not_to match(cname)
+      expect(response.body).not_to match(aname)
       expect(response.body).not_to match(/Name/m)
       expect(response.body).not_to match(/Released/m)
     end
@@ -116,13 +138,28 @@ RSpec.describe AttachmentsController, type: :controller do
     let!(:cid)  { get_course_id_by_uid(u.id) }
     let!(:cname) { Course.find(cid).name }
     let!(:att) { create_course_att_with_cid(cid, true) }
-    it "renders successfully" do
+    it "renders course successfully" do
       get :edit, params: {course_name: cname, id: att.id}
       expect(response).to be_successful
       expect(response.body).to match(cname)
       expect(response.body).to match(att.name)
-      expect(response.body).to match("text/plain")
+      expect(response.body).to match(att.mime_type)
       expect(response.body).to match(/Name/m)
+      expect(response.body).to match(/Mime type/m)
+      expect(response.body).to match(/Released/m)
+    end
+    let!(:aid)  { get_first_aid_by_cid(cid) }
+    let!(:aname) { Assessment.find(aid).name }
+    let!(:assess_att) { create_assess_att_with_cid_aid(cid, aid, true) }
+    it "renders assessment successfully" do
+      get :edit, params: {course_name: cname, assessment_name: aname, id: assess_att.id}
+      expect(response).to be_successful
+      expect(response.body).to match(cname)
+      expect(response.body).to match(aname)
+      expect(response.body).to match(assess_att.name)
+      expect(response.body).to match(assess_att.mime_type)
+      expect(response.body).to match(/Name/m)
+      expect(response.body).to match(/Mime type/m)
       expect(response.body).to match(/Released/m)
     end
   end
@@ -132,13 +169,28 @@ RSpec.describe AttachmentsController, type: :controller do
     let!(:cid)  { get_course_id_by_uid(u.id) }
     let!(:cname) { Course.find(cid).name }
     let!(:att) { create_course_att_with_cid(cid, true) }
-    it "renders with failure" do
+    it "renders course with failure" do
       get :edit, params: {course_name: cname, id: att.id}
       expect(response).not_to be_successful
       expect(response.body).not_to match(cname)
       expect(response.body).not_to match(att.name)
-      expect(response.body).not_to match("text/plain")
+      expect(response.body).not_to match(att.mime_type)
       expect(response.body).not_to match(/Name/m)
+      expect(response.body).not_to match(/Mime type/m)
+      expect(response.body).not_to match(/Released/m)
+    end
+    let!(:aid)  { get_first_aid_by_cid(cid) }
+    let!(:aname) { Assessment.find(aid).name }
+    let!(:assess_att) { create_assess_att_with_cid_aid(cid, aid, true) }
+    it "renders assessment with failure" do
+      get :edit, params: {course_name: cname, assessment_name: aname, id: assess_att.id}
+      expect(response).not_to be_successful
+      expect(response.body).not_to match(cname)
+      expect(response.body).not_to match(aname)
+      expect(response.body).not_to match(assess_att.name)
+      expect(response.body).not_to match(assess_att.mime_type)
+      expect(response.body).not_to match(/Name/m)
+      expect(response.body).not_to match(/Mime type/m)
       expect(response.body).not_to match(/Released/m)
     end
   end
@@ -167,8 +219,15 @@ RSpec.describe AttachmentsController, type: :controller do
     let!(:cid)  { get_course_id_by_uid(u.id) }
     let!(:cname) { Course.find(cid).name }
     let!(:att) { create_course_att_with_cid(cid, released) }
-    it "renders successfully" do
+    it "renders course successfully" do
       get :show, params: {course_name: cname, id: att.id}
+      expect(response).to be_successful
+    end
+    let!(:aid)  { get_first_aid_by_cid(cid) }
+    let!(:aname) { Assessment.find(aid).name }
+    let!(:assess_att) { create_assess_att_with_cid_aid(cid, aid, released) }
+    it "renders assessment successfully" do
+      get :show, params: {course_name: cname, assessment_name: aname, id: assess_att.id}
       expect(response).to be_successful
     end
   end
@@ -178,8 +237,15 @@ RSpec.describe AttachmentsController, type: :controller do
     let!(:cid)  { get_course_id_by_uid(u.id) }
     let!(:cname) { Course.find(cid).name }
     let!(:att) { create_course_att_with_cid(cid, released) }
-    it "renders with failure" do
+    it "renders course with failure" do
       get :show, params: {course_name: cname, id: att.id}
+      expect(response).not_to be_successful
+    end
+    let!(:aid)  { get_first_aid_by_cid(cid) }
+    let!(:aname) { Assessment.find(aid).name }
+    let!(:assess_att) { create_assess_att_with_cid_aid(cid, aid, released) }
+    it "renders assessment with failure" do
+      get :show, params: {course_name: cname, assessment_name: aname, id: assess_att.id}
       expect(response).not_to be_successful
     end
   end

--- a/spec/controllers/attachments_controller_spec.rb
+++ b/spec/controllers/attachments_controller_spec.rb
@@ -195,13 +195,31 @@ RSpec.describe AttachmentsController, type: :controller do
     end
   end
 
+  shared_examples "edit_missing" do |u|
+    login_as(u)
+    let!(:cid)  { get_course_id_by_uid(u.id) }
+    let!(:cname) { Course.find(cid).name }
+    it "flashes error for non-existent course attachment" do
+      get :edit, params: {course_name: cname, id: -1}
+      expect(flash[:error]).to match(/Could not find/)
+    end
+    let!(:aid)  { get_first_aid_by_cid(cid) }
+    let!(:aname) { Assessment.find(aid).name }
+    it "flashes error for non-existent assessment attachment" do
+      get :edit, params: {course_name: cname, assessment_name: aname, id: -1}
+      expect(flash[:error]).to match(/Could not find/)
+    end
+  end
+
   describe "#edit" do
     context "when user is Autolab admin" do
       it_behaves_like "edit_success", get_admin
+      it_behaves_like "edit_missing", get_admin
     end
 
     context "when user is Autolab instructor" do
       it_behaves_like "edit_success", get_instructor
+      it_behaves_like "edit_missing", get_instructor
     end
 
     context "when user is Autolab user" do
@@ -250,20 +268,39 @@ RSpec.describe AttachmentsController, type: :controller do
     end
   end
 
+  shared_examples "show_missing" do |u|
+    login_as(u)
+    let!(:cid)  { get_course_id_by_uid(u.id) }
+    let!(:cname) { Course.find(cid).name }
+    it "flashes error for non-existent course attachment" do
+      get :show, params: {course_name: cname, id: -1}
+      expect(flash[:error]).to match(/Could not find/)
+    end
+    let!(:aid)  { get_first_aid_by_cid(cid) }
+    let!(:aname) { Assessment.find(aid).name }
+    it "flashes error for non-existent assessment attachment" do
+      get :show, params: {course_name: cname, assessment_name: aname, id: -1}
+      expect(flash[:error]).to match(/Could not find/)
+    end
+  end
+
   describe "#show" do
     context "when user is Autolab admin" do
       it_behaves_like "show_success", get_admin
       it_behaves_like "show_success", get_admin, released: false
+      it_behaves_like "show_missing", get_admin
     end
 
     context "when user is Autolab instructor" do
       it_behaves_like "show_success", get_instructor
       it_behaves_like "show_success", get_instructor, released: false
+      it_behaves_like "show_missing", get_instructor
     end
 
     context "when user is Autolab user" do
       it_behaves_like "show_success", get_user
       it_behaves_like "show_failure", get_user, released: false
+      it_behaves_like "show_missing", get_user
     end
 
     context "when user is not logged in" do

--- a/spec/controllers/attachments_controller_spec.rb
+++ b/spec/controllers/attachments_controller_spec.rb
@@ -1,4 +1,5 @@
 require "rails_helper"
+include ControllerMacros
 
 RSpec.describe AttachmentsController, type: :controller do
   render_views
@@ -105,7 +106,7 @@ RSpec.describe AttachmentsController, type: :controller do
       login_as(u)
       cid = get_course_id_by_uid(u.id)
       cname = Course.find(cid).name
-      att = create_course_att_with_cid(cid)
+      let!(:att) { create_course_att_with_cid(cid) }
       it "renders successfully" do
         get :edit, params: {course_name: cname, id: att.id}
         expect(response).to be_successful
@@ -119,7 +120,7 @@ RSpec.describe AttachmentsController, type: :controller do
       login_as(u)
       cid = get_course_id_by_uid(u.id)
       cname = Course.find(cid).name
-      att = create_course_att_with_cid(cid)
+      let!(:att) { create_course_att_with_cid(cid) }
       it "renders successfully" do
         get :edit, params: {course_name: cname, id: att.id}
         expect(response).to be_successful
@@ -133,7 +134,7 @@ RSpec.describe AttachmentsController, type: :controller do
       login_as(u)
       cid = get_course_id_by_uid(u.id)
       cname = Course.find(cid).name
-      att = create_course_att_with_cid(cid)
+      let!(:att) { create_course_att_with_cid(cid) }
       it "renders with failure" do
         get :edit, params: {course_name: cname, id: att.id}
         expect(response).not_to be_successful
@@ -146,7 +147,7 @@ RSpec.describe AttachmentsController, type: :controller do
       u = get_admin
       cid = get_course_id_by_uid(u.id)
       cname = Course.find(cid).name
-      att = create_course_att_with_cid(cid)
+      let!(:att) { create_course_att_with_cid(cid) }
       it "renders with failure" do
         get :edit, params: {course_name: cname, id: att.id}
         expect(response).not_to be_successful
@@ -162,7 +163,7 @@ RSpec.describe AttachmentsController, type: :controller do
       login_as(u)
       cid = get_course_id_by_uid(u.id)
       cname = Course.find(cid).name
-      att = create_course_att_with_cid(cid)
+      let!(:att) { create_course_att_with_cid(cid) }
       it "renders successfully" do
         get :show, params: {course_name: cname, id: att.id}
         expect(response).to be_successful
@@ -174,7 +175,7 @@ RSpec.describe AttachmentsController, type: :controller do
       login_as(u)
       cid = get_course_id_by_uid(u.id)
       cname = Course.find(cid).name
-      att = create_course_att_with_cid(cid)
+      let!(:att) { create_course_att_with_cid(cid) }
       it "renders successfully" do
         get :show, params: {course_name: cname, id: att.id}
         expect(response).to be_successful
@@ -186,7 +187,7 @@ RSpec.describe AttachmentsController, type: :controller do
       login_as(u)
       cid = get_course_id_by_uid(u.id)
       cname = Course.find(cid).name
-      att = create_course_att_with_cid(cid)
+      let!(:att) { create_course_att_with_cid(cid) }
       it "renders successfully" do
         get :show, params: {course_name: cname, id: att.id}
         expect(response).to be_successful
@@ -197,7 +198,7 @@ RSpec.describe AttachmentsController, type: :controller do
       u = get_admin
       cid = get_course_id_by_uid(u.id)
       cname = Course.find(cid).name
-      att = create_course_att_with_cid(cid)
+      let!(:att) { create_course_att_with_cid(cid) }
       it "renders with failure" do
         get :show, params: {course_name: cname, id: att.id}
         expect(response).not_to be_successful

--- a/spec/controllers/attachments_controller_spec.rb
+++ b/spec/controllers/attachments_controller_spec.rb
@@ -94,121 +94,95 @@ RSpec.describe AttachmentsController, type: :controller do
     end
   end
 
+  # EDIT
+  shared_examples "edit_success" do |u, login: true|
+    login_as(u) if login
+    let!(:cid)  { get_course_id_by_uid(u.id) }
+    let!(:cname) { Course.find(cid).name }
+    let!(:att) { create_course_att_with_cid(cid, true) }
+    it "renders successfully" do
+      get :edit, params: {course_name: cname, id: att.id}
+      expect(response).to be_successful
+      expect(response.body).to match(cname)
+      expect(response.body).to match(att.name)
+      expect(response.body).to match("text/plain")
+      expect(response.body).to match(/Name/m)
+      expect(response.body).to match(/Released/m)
+    end
+  end
+
+  shared_examples "edit_failure" do |u, login: true|
+    login_as(u) if login
+    let!(:cid)  { get_course_id_by_uid(u.id) }
+    let!(:cname) { Course.find(cid).name }
+    let!(:att) { create_course_att_with_cid(cid, true) }
+    it "renders with failure" do
+      get :edit, params: {course_name: cname, id: att.id}
+      expect(response).not_to be_successful
+      expect(response.body).not_to match(cname)
+      expect(response.body).not_to match(att.name)
+      expect(response.body).not_to match("text/plain")
+      expect(response.body).not_to match(/Name/m)
+      expect(response.body).not_to match(/Released/m)
+    end
+  end
+
   describe "#edit" do
     context "when user is Autolab admin" do
-      u = get_admin
-      login_as(u)
-      cid = get_course_id_by_uid(u.id)
-      cname = Course.find(cid).name
-      let!(:att) { create_course_att_with_cid(cid, true) }
-      it "renders successfully" do
-        get :edit, params: {course_name: cname, id: att.id}
-        expect(response).to be_successful
-        expect(response.body).to match(cname)
-        expect(response.body).to match(att.name)
-        expect(response.body).to match("text/plain")
-        expect(response.body).to match(/Name/m)
-        expect(response.body).to match(/Released/m)
-      end
+      it_behaves_like "edit_success", get_admin
     end
 
     context "when user is Autolab instructor" do
-      u = get_instructor
-      login_as(u)
-      cid = get_course_id_by_uid(u.id)
-      cname = Course.find(cid).name
-      let!(:att) { create_course_att_with_cid(cid, true) }
-      it "renders successfully" do
-        get :edit, params: {course_name: cname, id: att.id}
-        expect(response).to be_successful
-        expect(response.body).to match(cname)
-        expect(response.body).to match(att.name)
-        expect(response.body).to match("text/plain")
-        expect(response.body).to match(/Name/m)
-        expect(response.body).to match(/Released/m)
-      end
+      it_behaves_like "edit_success", get_instructor
     end
 
     context "when user is Autolab user" do
-      u = get_user
-      login_as(u)
-      cid = get_course_id_by_uid(u.id)
-      cname = Course.find(cid).name
-      let!(:att) { create_course_att_with_cid(cid, true) }
-      it "renders with failure" do
-        get :edit, params: {course_name: cname, id: att.id}
-        expect(response).not_to be_successful
-        expect(response.body).not_to match(cname)
-        expect(response.body).not_to match(att.name)
-        expect(response.body).not_to match("text/plain")
-        expect(response.body).not_to match(/Name/m)
-        expect(response.body).not_to match(/Released/m)
-      end
+      it_behaves_like "edit_failure", get_user
     end
 
     context "when user is not logged in" do
-      u = get_admin
-      cid = get_course_id_by_uid(u.id)
-      cname = Course.find(cid).name
-      let!(:att) { create_course_att_with_cid(cid, true) }
-      it "renders with failure" do
-        get :edit, params: {course_name: cname, id: att.id}
-        expect(response).not_to be_successful
-        expect(response.body).not_to match(cname)
-        expect(response.body).not_to match(att.name)
-        expect(response.body).not_to match("text/plain")
-        expect(response.body).not_to match(/Name/m)
-        expect(response.body).not_to match(/Released/m)
-      end
+      it_behaves_like "edit_failure", get_admin, login: false
+    end
+  end
+
+  # SHOW
+  shared_examples "show_success" do |u, login: true|
+    login_as(u) if login
+    let!(:cid)  { get_course_id_by_uid(u.id) }
+    let!(:cname) { Course.find(cid).name }
+    let!(:att) { create_course_att_with_cid(cid, true) }
+    it "renders successfully" do
+      get :show, params: {course_name: cname, id: att.id}
+      expect(response).to be_successful
+    end
+  end
+
+  shared_examples "show_failure" do |u, login: true|
+    login_as(u) if login
+    let!(:cid)  { get_course_id_by_uid(u.id) }
+    let!(:cname) { Course.find(cid).name }
+    let!(:att) { create_course_att_with_cid(cid, true) }
+    it "renders with failure" do
+      get :show, params: {course_name: cname, id: att.id}
+      expect(response).not_to be_successful
     end
   end
 
   describe "#show" do
     context "when user is Autolab admin" do
-      u = get_admin
-      login_as(u)
-      cid = get_course_id_by_uid(u.id)
-      cname = Course.find(cid).name
-      let!(:att) { create_course_att_with_cid(cid, true) }
-      it "renders successfully" do
-        get :show, params: {course_name: cname, id: att.id}
-        expect(response).to be_successful
-      end
+      it_behaves_like "show_success", get_admin
     end
 
     context "when user is Autolab instructor" do
-      u = get_instructor
-      login_as(u)
-      cid = get_course_id_by_uid(u.id)
-      cname = Course.find(cid).name
-      let!(:att) { create_course_att_with_cid(cid, true) }
-      it "renders successfully" do
-        get :show, params: {course_name: cname, id: att.id}
-        expect(response).to be_successful
-      end
+      it_behaves_like "show_success", get_instructor
     end
 
     context "when user is Autolab user" do
-      u = get_user
-      login_as(u)
-      cid = get_course_id_by_uid(u.id)
-      cname = Course.find(cid).name
-      let!(:att) { create_course_att_with_cid(cid, true) }
-      it "renders successfully" do
-        get :show, params: {course_name: cname, id: att.id}
-        expect(response).to be_successful
-      end
+      it_behaves_like "show_success", get_user
     end
 
     context "when user is not logged in" do
-      u = get_admin
-      cid = get_course_id_by_uid(u.id)
-      cname = Course.find(cid).name
-      let!(:att) { create_course_att_with_cid(cid, true) }
-      it "renders with failure" do
-        get :show, params: {course_name: cname, id: att.id}
-        expect(response).not_to be_successful
-      end
+      it_behaves_like "show_failure", get_admin, login: false
     end
   end
 end

--- a/spec/controllers/attachments_controller_spec.rb
+++ b/spec/controllers/attachments_controller_spec.rb
@@ -5,56 +5,47 @@ RSpec.describe AttachmentsController, type: :controller do
   render_views
 
   # Course attachments
+
+  # INDEX
+  shared_examples "index_success" do |u, login: true|
+    login_as(u) if login
+    let!(:cid)  { get_course_id_by_uid(u.id) }
+    let!(:cname) { Course.find(cid).name }
+    it "renders successfully" do
+      get :index, params: {course_name: cname}
+      expect(response).to be_successful
+      expect(response.body).to match(cname)
+      expect(response.body).to match(/Course Attachments/m)
+    end
+  end
+
+  shared_examples "index_failure" do |u, login: true|
+    login_as(u) if login
+    let!(:cid)  { get_course_id_by_uid(u.id) }
+    let!(:cname) { Course.find(cid).name }
+    it "renders with failure" do
+      get :index, params: {course_name: cname}
+      expect(response).not_to be_successful
+      expect(response.body).not_to match(cname)
+      expect(response.body).not_to match(/Course Attachments/m)
+    end
+  end
+
   describe "#index" do
     context "when user is Autolab admin" do
-      u = get_admin
-      login_as(u)
-      cid = get_course_id_by_uid(u.id)
-      cname = Course.find(cid).name
-      it "renders successfully" do
-        get :index, params: {course_name: cname}
-        expect(response).to be_successful
-        expect(response.body).to match(cname)
-        expect(response.body).to match(/Course Attachments/m)
-      end
+      it_behaves_like "index_success", get_admin
     end
 
     context "when user is Autolab instructor" do
-      u = get_instructor
-      login_as(u)
-      cid = get_course_id_by_uid(u.id)
-      cname = Course.find(cid).name
-      it "renders successfully" do
-        get :index, params: {course_name: cname}
-        expect(response).to be_successful
-        expect(response.body).to match(cname)
-        expect(response.body).to match(/Course Attachments/m)
-      end
+      it_behaves_like "index_success", get_instructor
     end
 
     context "when user is Autolab user" do
-      u = get_user
-      login_as(u)
-      cid = get_course_id_by_uid(u.id)
-      cname = Course.find(cid).name
-      it "renders with failure" do
-        get :index, params: {course_name: cname}
-        expect(response).not_to be_successful
-        expect(response.body).not_to match(cname)
-        expect(response.body).not_to match(/Course Attachments/m)
-      end
+      it_behaves_like "index_failure", get_user
     end
 
     context "when user is not logged in" do
-      u = get_admin
-      cid = get_course_id_by_uid(u.id)
-      cname = Course.find(cid).name
-      it "renders with failure" do
-        get :index, params: {course_name: cname}
-        expect(response).not_to be_successful
-        expect(response.body).not_to match(cname)
-        expect(response.body).not_to match(/Course Attachments/m)
-      end
+      it_behaves_like "index_failure", get_admin, login: false
     end
   end
 

--- a/spec/controllers/attachments_controller_spec.rb
+++ b/spec/controllers/attachments_controller_spec.rb
@@ -4,6 +4,7 @@ include ControllerMacros
 RSpec.describe AttachmentsController, type: :controller do
   render_views
 
+  # Course attachments
   describe "#index" do
     context "when user is Autolab admin" do
       u = get_admin
@@ -13,6 +14,7 @@ RSpec.describe AttachmentsController, type: :controller do
       it "renders successfully" do
         get :index, params: {course_name: cname}
         expect(response).to be_successful
+        expect(response.body).to match(cname)
         expect(response.body).to match(/Course Attachments/m)
       end
     end
@@ -25,6 +27,7 @@ RSpec.describe AttachmentsController, type: :controller do
       it "renders successfully" do
         get :index, params: {course_name: cname}
         expect(response).to be_successful
+        expect(response.body).to match(cname)
         expect(response.body).to match(/Course Attachments/m)
       end
     end
@@ -37,14 +40,19 @@ RSpec.describe AttachmentsController, type: :controller do
       it "renders with failure" do
         get :index, params: {course_name: cname}
         expect(response).not_to be_successful
+        expect(response.body).not_to match(cname)
         expect(response.body).not_to match(/Course Attachments/m)
       end
     end
 
     context "when user is not logged in" do
+      u = get_admin
+      cid = get_course_id_by_uid(u.id)
+      cname = Course.find(cid).name
       it "renders with failure" do
-        get :index, params: {course_name: "dummy"}
+        get :index, params: {course_name: cname}
         expect(response).not_to be_successful
+        expect(response.body).not_to match(cname)
         expect(response.body).not_to match(/Course Attachments/m)
       end
     end
@@ -59,6 +67,7 @@ RSpec.describe AttachmentsController, type: :controller do
       it "renders successfully" do
         get :new, params: {course_name: cname}
         expect(response).to be_successful
+        expect(response.body).to match(cname)
         expect(response.body).to match(/Name/m)
         expect(response.body).to match(/Released/m)
       end
@@ -72,6 +81,7 @@ RSpec.describe AttachmentsController, type: :controller do
       it "renders successfully" do
         get :new, params: {course_name: cname}
         expect(response).to be_successful
+        expect(response.body).to match(cname)
         expect(response.body).to match(/Name/m)
         expect(response.body).to match(/Released/m)
       end
@@ -85,15 +95,20 @@ RSpec.describe AttachmentsController, type: :controller do
       it "renders with failure" do
         get :new, params: {course_name: cname}
         expect(response).not_to be_successful
+        expect(response.body).not_to match(cname)
         expect(response.body).not_to match(/Name/m)
         expect(response.body).not_to match(/Released/m)
       end
     end
 
     context "when user is not logged in" do
+      u = get_admin
+      cid = get_course_id_by_uid(u.id)
+      cname = Course.find(cid).name
       it "renders with failure" do
-        get :new, params: {course_name: "dummy"}
+        get :new, params: {course_name: cname}
         expect(response).not_to be_successful
+        expect(response.body).not_to match(cname)
         expect(response.body).not_to match(/Name/m)
         expect(response.body).not_to match(/Released/m)
       end
@@ -106,10 +121,13 @@ RSpec.describe AttachmentsController, type: :controller do
       login_as(u)
       cid = get_course_id_by_uid(u.id)
       cname = Course.find(cid).name
-      let!(:att) { create_course_att_with_cid(cid) }
+      let!(:att) { create_course_att_with_cid(cid, true) }
       it "renders successfully" do
         get :edit, params: {course_name: cname, id: att.id}
         expect(response).to be_successful
+        expect(response.body).to match(cname)
+        expect(response.body).to match(att.name)
+        expect(response.body).to match("text/plain")
         expect(response.body).to match(/Name/m)
         expect(response.body).to match(/Released/m)
       end
@@ -120,10 +138,13 @@ RSpec.describe AttachmentsController, type: :controller do
       login_as(u)
       cid = get_course_id_by_uid(u.id)
       cname = Course.find(cid).name
-      let!(:att) { create_course_att_with_cid(cid) }
+      let!(:att) { create_course_att_with_cid(cid, true) }
       it "renders successfully" do
         get :edit, params: {course_name: cname, id: att.id}
         expect(response).to be_successful
+        expect(response.body).to match(cname)
+        expect(response.body).to match(att.name)
+        expect(response.body).to match("text/plain")
         expect(response.body).to match(/Name/m)
         expect(response.body).to match(/Released/m)
       end
@@ -134,10 +155,13 @@ RSpec.describe AttachmentsController, type: :controller do
       login_as(u)
       cid = get_course_id_by_uid(u.id)
       cname = Course.find(cid).name
-      let!(:att) { create_course_att_with_cid(cid) }
+      let!(:att) { create_course_att_with_cid(cid, true) }
       it "renders with failure" do
         get :edit, params: {course_name: cname, id: att.id}
         expect(response).not_to be_successful
+        expect(response.body).not_to match(cname)
+        expect(response.body).not_to match(att.name)
+        expect(response.body).not_to match("text/plain")
         expect(response.body).not_to match(/Name/m)
         expect(response.body).not_to match(/Released/m)
       end
@@ -147,10 +171,13 @@ RSpec.describe AttachmentsController, type: :controller do
       u = get_admin
       cid = get_course_id_by_uid(u.id)
       cname = Course.find(cid).name
-      let!(:att) { create_course_att_with_cid(cid) }
+      let!(:att) { create_course_att_with_cid(cid, true) }
       it "renders with failure" do
         get :edit, params: {course_name: cname, id: att.id}
         expect(response).not_to be_successful
+        expect(response.body).not_to match(cname)
+        expect(response.body).not_to match(att.name)
+        expect(response.body).not_to match("text/plain")
         expect(response.body).not_to match(/Name/m)
         expect(response.body).not_to match(/Released/m)
       end
@@ -163,7 +190,7 @@ RSpec.describe AttachmentsController, type: :controller do
       login_as(u)
       cid = get_course_id_by_uid(u.id)
       cname = Course.find(cid).name
-      let!(:att) { create_course_att_with_cid(cid) }
+      let!(:att) { create_course_att_with_cid(cid, true) }
       it "renders successfully" do
         get :show, params: {course_name: cname, id: att.id}
         expect(response).to be_successful
@@ -175,7 +202,7 @@ RSpec.describe AttachmentsController, type: :controller do
       login_as(u)
       cid = get_course_id_by_uid(u.id)
       cname = Course.find(cid).name
-      let!(:att) { create_course_att_with_cid(cid) }
+      let!(:att) { create_course_att_with_cid(cid, true) }
       it "renders successfully" do
         get :show, params: {course_name: cname, id: att.id}
         expect(response).to be_successful
@@ -187,7 +214,7 @@ RSpec.describe AttachmentsController, type: :controller do
       login_as(u)
       cid = get_course_id_by_uid(u.id)
       cname = Course.find(cid).name
-      let!(:att) { create_course_att_with_cid(cid) }
+      let!(:att) { create_course_att_with_cid(cid, true) }
       it "renders successfully" do
         get :show, params: {course_name: cname, id: att.id}
         expect(response).to be_successful
@@ -198,7 +225,7 @@ RSpec.describe AttachmentsController, type: :controller do
       u = get_admin
       cid = get_course_id_by_uid(u.id)
       cname = Course.find(cid).name
-      let!(:att) { create_course_att_with_cid(cid) }
+      let!(:att) { create_course_att_with_cid(cid, true) }
       it "renders with failure" do
         get :show, params: {course_name: cname, id: att.id}
         expect(response).not_to be_successful

--- a/spec/controllers/attachments_controller_spec.rb
+++ b/spec/controllers/attachments_controller_spec.rb
@@ -49,60 +49,48 @@ RSpec.describe AttachmentsController, type: :controller do
     end
   end
 
+  # NEW
+  shared_examples "new_success" do |u, login: true|
+    login_as(u) if login
+    let!(:cid)  { get_course_id_by_uid(u.id) }
+    let!(:cname) { Course.find(cid).name }
+    it "renders successfully" do
+      get :new, params: {course_name: cname}
+      expect(response).to be_successful
+      expect(response.body).to match(cname)
+      expect(response.body).to match(/Name/m)
+      expect(response.body).to match(/Released/m)
+    end
+  end
+
+  shared_examples "new_failure" do |u, login: true|
+    login_as(u) if login
+    let!(:cid)  { get_course_id_by_uid(u.id) }
+    let!(:cname) { Course.find(cid).name }
+    it "renders with failure" do
+      get :new, params: {course_name: cname}
+      expect(response).not_to be_successful
+      expect(response.body).not_to match(cname)
+      expect(response.body).not_to match(/Name/m)
+      expect(response.body).not_to match(/Released/m)
+    end
+  end
+
   describe "#new" do
     context "when user is Autolab admin" do
-      u = get_admin
-      login_as(u)
-      cid = get_course_id_by_uid(u.id)
-      cname = Course.find(cid).name
-      it "renders successfully" do
-        get :new, params: {course_name: cname}
-        expect(response).to be_successful
-        expect(response.body).to match(cname)
-        expect(response.body).to match(/Name/m)
-        expect(response.body).to match(/Released/m)
-      end
+      it_behaves_like "new_success", get_admin
     end
 
     context "when user is Autolab instructor" do
-      u = get_instructor
-      login_as(u)
-      cid = get_course_id_by_uid(u.id)
-      cname = Course.find(cid).name
-      it "renders successfully" do
-        get :new, params: {course_name: cname}
-        expect(response).to be_successful
-        expect(response.body).to match(cname)
-        expect(response.body).to match(/Name/m)
-        expect(response.body).to match(/Released/m)
-      end
+      it_behaves_like "new_success", get_instructor
     end
 
     context "when user is Autolab user" do
-      u = get_user
-      login_as(u)
-      cid = get_course_id_by_uid(u.id)
-      cname = Course.find(cid).name
-      it "renders with failure" do
-        get :new, params: {course_name: cname}
-        expect(response).not_to be_successful
-        expect(response.body).not_to match(cname)
-        expect(response.body).not_to match(/Name/m)
-        expect(response.body).not_to match(/Released/m)
-      end
+      it_behaves_like "new_failure", get_user
     end
 
     context "when user is not logged in" do
-      u = get_admin
-      cid = get_course_id_by_uid(u.id)
-      cname = Course.find(cid).name
-      it "renders with failure" do
-        get :new, params: {course_name: cname}
-        expect(response).not_to be_successful
-        expect(response.body).not_to match(cname)
-        expect(response.body).not_to match(/Name/m)
-        expect(response.body).not_to match(/Released/m)
-      end
+      it_behaves_like "new_failure", get_admin, login: false
     end
   end
 

--- a/spec/controllers/attachments_controller_spec.rb
+++ b/spec/controllers/attachments_controller_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe AttachmentsController, type: :controller do
   # Course attachments
 
   # INDEX
-  shared_examples "index_success" do |u, login: true|
-    login_as(u) if login
+  shared_examples "index_success" do |u|
+    login_as(u)
     let!(:cid)  { get_course_id_by_uid(u.id) }
     let!(:cname) { Course.find(cid).name }
     it "renders successfully" do
@@ -50,8 +50,8 @@ RSpec.describe AttachmentsController, type: :controller do
   end
 
   # NEW
-  shared_examples "new_success" do |u, login: true|
-    login_as(u) if login
+  shared_examples "new_success" do |u|
+    login_as(u)
     let!(:cid)  { get_course_id_by_uid(u.id) }
     let!(:cname) { Course.find(cid).name }
     it "renders successfully" do
@@ -95,8 +95,8 @@ RSpec.describe AttachmentsController, type: :controller do
   end
 
   # EDIT
-  shared_examples "edit_success" do |u, login: true|
-    login_as(u) if login
+  shared_examples "edit_success" do |u|
+    login_as(u)
     let!(:cid)  { get_course_id_by_uid(u.id) }
     let!(:cname) { Course.find(cid).name }
     let!(:att) { create_course_att_with_cid(cid, true) }
@@ -146,22 +146,22 @@ RSpec.describe AttachmentsController, type: :controller do
   end
 
   # SHOW
-  shared_examples "show_success" do |u, login: true|
-    login_as(u) if login
+  shared_examples "show_success" do |u, released: true|
+    login_as(u)
     let!(:cid)  { get_course_id_by_uid(u.id) }
     let!(:cname) { Course.find(cid).name }
-    let!(:att) { create_course_att_with_cid(cid, true) }
+    let!(:att) { create_course_att_with_cid(cid, released) }
     it "renders successfully" do
       get :show, params: {course_name: cname, id: att.id}
       expect(response).to be_successful
     end
   end
 
-  shared_examples "show_failure" do |u, login: true|
+  shared_examples "show_failure" do |u, login: true, released: true|
     login_as(u) if login
     let!(:cid)  { get_course_id_by_uid(u.id) }
     let!(:cname) { Course.find(cid).name }
-    let!(:att) { create_course_att_with_cid(cid, true) }
+    let!(:att) { create_course_att_with_cid(cid, released) }
     it "renders with failure" do
       get :show, params: {course_name: cname, id: att.id}
       expect(response).not_to be_successful
@@ -171,18 +171,22 @@ RSpec.describe AttachmentsController, type: :controller do
   describe "#show" do
     context "when user is Autolab admin" do
       it_behaves_like "show_success", get_admin
+      it_behaves_like "show_success", get_admin, released: false
     end
 
     context "when user is Autolab instructor" do
       it_behaves_like "show_success", get_instructor
+      it_behaves_like "show_success", get_instructor, released: false
     end
 
     context "when user is Autolab user" do
       it_behaves_like "show_success", get_user
+      it_behaves_like "show_failure", get_user, released: false
     end
 
     context "when user is not logged in" do
       it_behaves_like "show_failure", get_admin, login: false
+      it_behaves_like "show_failure", get_admin, login: false, released: false
     end
   end
 end

--- a/spec/factories/attachments.rb
+++ b/spec/factories/attachments.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :attachment do
+    course_id { 1 }
+    assessment_id { 1 }
+    name { "attachment.txt" }
+    released { true }
+    file { fixture_file_upload("attachments/attachment.txt", "text/plain") }
+  end
+end

--- a/spec/fixtures/attachments/assessment.txt
+++ b/spec/fixtures/attachments/assessment.txt
@@ -1,0 +1,1 @@
+Assessment attachment file

--- a/spec/fixtures/attachments/attachment.txt
+++ b/spec/fixtures/attachments/attachment.txt
@@ -1,0 +1,1 @@
+Default attachment

--- a/spec/fixtures/attachments/course.txt
+++ b/spec/fixtures/attachments/course.txt
@@ -1,0 +1,1 @@
+Course attachment file

--- a/spec/support/controller_macros.rb
+++ b/spec/support/controller_macros.rb
@@ -102,33 +102,20 @@ module ControllerMacros
   end
 
   def create_course_att_with_cid(cid)
-    # Prepare course attachment file
-    course_att_file = Rails.root.join("attachments/testattach.txt")
-    File.open(course_att_file, "w") do |f|
-      f.write("Course attachment file")
-    end
-    att = Attachment.new(course_id: cid, assessment_id: nil,
-                         name: "att#{cid}",
-                         released: true)
-
-    att.file = Rack::Test::UploadedFile.new(
-        path=Rails.root.join("attachments", File.basename(course_att_file)), content_type="text/plain",
-        tempfile=Tempfile.new("attach.tmp"))
-    att.save
-    att
+    FactoryBot.create(:attachment,
+                      course_id: cid,
+                      assessment_id: nil,
+                      name: "att#{cid}",
+                      released: true,
+                      file: fixture_file_upload("attachments/course.txt", "text/plain"))
   end
 
   def create_assess_att_with_cid_aid(cid, aid)
-    # Prepare assessment attachment file
-    assess_att_file = Rails.root.join("attachments/assessattach.txt")
-    File.open(assess_att_file, "w") do |f|
-      f.write("Assessment attachment file")
-    end
-    att = Attachment.new(course_id: cid, assessment_id: aid,
-                         name: "att#{cid}-#{aid}", filename: assess_att_file,
-                         released: true, mime_type: "text/plain")
-    att.file = File.open(assess_att_file, "w")
-    att.save
-    att
+    FactoryBot.create(:attachment,
+                      course_id: cid,
+                      assessment_id: aid,
+                      name: "att#{cid}--#{aid}",
+                      released: true,
+                      file: fixture_file_upload("attachments/assessment.txt", "text/plain"))
   end
 end

--- a/spec/support/controller_macros.rb
+++ b/spec/support/controller_macros.rb
@@ -101,21 +101,21 @@ module ControllerMacros
     s
   end
 
-  def create_course_att_with_cid(cid)
+  def create_course_att_with_cid(cid, released)
     FactoryBot.create(:attachment,
                       course_id: cid,
                       assessment_id: nil,
                       name: "att#{cid}",
-                      released: true,
+                      released: released,
                       file: fixture_file_upload("attachments/course.txt", "text/plain"))
   end
 
-  def create_assess_att_with_cid_aid(cid, aid)
+  def create_assess_att_with_cid_aid(cid, aid, released)
     FactoryBot.create(:attachment,
                       course_id: cid,
                       assessment_id: aid,
                       name: "att#{cid}--#{aid}",
-                      released: true,
+                      released: released,
                       file: fixture_file_upload("attachments/assessment.txt", "text/plain"))
   end
 end

--- a/spec/support/controller_macros.rb
+++ b/spec/support/controller_macros.rb
@@ -62,6 +62,10 @@ module ControllerMacros
   def get_first_aid_by_cud(cud)
     AssessmentUserDatum.where(course_user_datum_id: cud).first.assessment_id
   end
+
+  def get_first_aid_by_cid(cid)
+    Assessment.where(course_id: cid).first.id
+  end
   # create user and add to given course as a course assistant
   def create_ca_for_course(cid, email, first_name, last_name, password)
     user = User.new(email: email, first_name: first_name, last_name: last_name, password: password,


### PR DESCRIPTION
## Description
- Use ActiveStorage to store and serve attachment files
- Update existing tests

**This is a breaking change, and old attachments will have to be re-uploaded.**

## Motivation and Context
Currently, all attachments are stored in a single top-level directory, where collisions are resolved by appending numbers to the end of the filename. This PR switches to ActiveStorage, which handles the file storage logic for us.

Using ActiveStorage also makes it easy to switch to other services such as S3 in the future.

Resolves #617 (albeit with a different approach)

More info about ActiveStorage: https://guides.rubyonrails.org/active_storage_overview.html

Note: Undoes the changes made in #1490 (in consultation with the author) in preference for a better solution to the XSS issue. 
In that PR, the mime_type was set to `application/octet-stream` to force downloads. A better solution is to remove `disposition: inline` since the default is `disposition: attachment`, which forces downloads.

More details here: https://huntr.dev/bounties/90701766-bfed-409e-b3dd-6ff884373968/

## How Has This Been Tested?
ActiveStorage

- Either clear attachments folder or remember what it looks like (or delete your attachments folder)
- Create an attachment
  - Observe that `/attachments` remains unchanged
  - Observe that attachment is stored in `/storage` (might be several directories down, with a randomly generated file name)
- Download the attachment
- Edit and download the attachment
- Delete attachment, observe that file is deleted from `/storage`
- If you want, you can test that the released / unreleased options work, but this PR doesn't touch that logic

XSS fix
- Upload example file from huntr.dev report: ![something](https://user-images.githubusercontent.com/9074856/219969212-bbfbddb9-1c7f-4b2f-814a-c6c08a2e4f45.svg)
- When attachment is clicked, ensure file is downloaded rather than displayed

Tests
- Run `rake spec SPEC=./spec/controllers/attachments_controller_spec.rb` and ensure they pass
- Also run the full test suite

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR