### PR TITLE
Enable Rubocop Linting within /spec directory

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,7 @@ AllCops:
   Include:
     - '**/Rakefile'
     - '**/config.ru'
-    - 'spec/factories/*.rb'
+    - 'spec/**/*.rb'
     - 'app/controllers/*.rb'
     - 'app/models/*.rb'
   Exclude:

--- a/spec/api/v1/api_shared_context.rb
+++ b/spec/api/v1/api_shared_context.rb
@@ -1,5 +1,6 @@
 RSpec.shared_context "api shared context" do
-  all_users = CourseUserDatum.joins(:user).where("users.administrator" => false, :instructor => false, :course_assistant => false)
+  all_users = CourseUserDatum.joins(:user).where("users.administrator" => false,
+                                                 :instructor => false, :course_assistant => false)
   let(:user) { all_users.offset(rand(all_users.count)).first.user }
   let(:course) { CourseUserDatum.where(user_id: user.id).first.course }
   let(:released_assessments) { course.assessments.where('start_at < ?', DateTime.now) }
@@ -7,28 +8,80 @@ RSpec.shared_context "api shared context" do
   let(:msg) { JSON.parse(response.body) }
 
   # default application with access to user_info and user_courses
-  let!(:application) { Doorkeeper::Application.create! :name => "TestApp", :redirect_uri => "https://example.com", :scopes => "user_info user_courses" }
-  let!(:token) { Doorkeeper::AccessToken.create! :application_id => application.id, :resource_owner_id => user.id, :scopes => "user_info user_courses" }
+  let!(:application) {
+    Doorkeeper::Application.create! name: "TestApp", redirect_uri: "https://example.com",
+                                    scopes: "user_info user_courses"
+  }
+  let!(:token) {
+    Doorkeeper::AccessToken.create! application_id: application.id, resource_owner_id: user.id,
+                                    scopes: "user_info user_courses"
+  }
 
   # user_info app
-  let!(:user_info_application) { Doorkeeper::Application.create! :name => "UserInfoApp", :redirect_uri => "https://user-info-example.com", :scopes => "user_info" }
-  let!(:user_info_token) { Doorkeeper::AccessToken.create! :application_id => user_info_application.id, :resource_owner_id => user.id, :scopes => "user_info" }
+  let!(:user_info_application) {
+    Doorkeeper::Application.create! name: "UserInfoApp",
+                                    redirect_uri: "https://user-info-example.com",
+                                    scopes: "user_info"
+  }
+  let!(:user_info_token) {
+    Doorkeeper::AccessToken.create! application_id: user_info_application.id,
+                                    resource_owner_id: user.id, scopes: "user_info"
+  }
 
   # device_flow app
   # The redirect_uri is just a stub. It is not involved in the test.
-  let!(:df_application) { Doorkeeper::Application.create! :name => "CLIApp", :redirect_uri => "https://localhost:3000/device_flow_auth_cb", :scopes => "user_info user_courses" }
+  let!(:df_application) {
+    Doorkeeper::Application.create!(
+      name: "CLIApp", redirect_uri: "https://localhost:3000/device_flow_auth_cb",
+      scopes: "user_info user_courses"
+    )
+  }
 
   # admin-related
   let(:admin_user) { User.where(administrator: true).first }
-  let!(:admin_application) { Doorkeeper::Application.create! :name => "AdminApp", :redirect_uri => "https://admin.example.com", :scopes => "user_info user_courses user_scores user_submit admin_all instructor_all" }
-  let!(:admin_token_for_admin) { Doorkeeper::AccessToken.create! :application_id => admin_application.id, :resource_owner_id => admin_user.id, :scopes => "user_info user_courses user_scores user_submit admin_all instructor_all" }
-  let!(:admin_token_for_user) { Doorkeeper::AccessToken.create! :application_id => admin_application.id, :resource_owner_id => user.id, :scopes => "user_info user_courses user_scores user_submit admin_all instructor_all" }
+  let!(:admin_application) {
+    Doorkeeper::Application.create!(
+      name: "AdminApp", redirect_uri: "https://admin.example.com",
+      scopes: "user_info user_courses user_scores user_submit admin_all instructor_all"
+    )
+  }
+  let!(:admin_token_for_admin) {
+    Doorkeeper::AccessToken.create!(
+      application_id: admin_application.id,
+      resource_owner_id: admin_user.id,
+      scopes: "user_info user_courses user_scores user_submit admin_all instructor_all"
+    )
+  }
+  let!(:admin_token_for_user) {
+    Doorkeeper::AccessToken.create!(
+      application_id: admin_application.id, resource_owner_id: user.id,
+      scopes: "user_info user_courses user_scores user_submit admin_all instructor_all"
+    )
+  }
 
   # instructor-related
-  let(:instructor) {admin_user}
-  let!(:instructor_application) { Doorkeeper::Application.create! :name => "InstructorApp", :redirect_uri => "https://instructor.example.com", :scopes => "user_info user_courses user_scores user_submit instructor_all" }
-  let!(:instructor_token_for_instructor){ Doorkeeper::AccessToken.create! :application_id => instructor_application.id, :resource_owner_id => instructor.id, :scopes => "user_info user_courses user_scores user_submit instructor_all" }
-  let!(:instructor_token_for_user){ Doorkeeper::AccessToken.create! :application_id => instructor_application.id, :resource_owner_id => user.id, :scopes => "user_info user_courses user_scores user_submit instructor_all" }
+  let(:instructor) { admin_user }
+  let!(:instructor_application) {
+    Doorkeeper::Application.create!(
+      name: "InstructorApp",
+      redirect_uri: "https://instructor.example.com",
+      scopes: "user_info user_courses user_scores user_submit instructor_all"
+    )
+  }
+  let!(:instructor_token_for_instructor){
+    Doorkeeper::AccessToken.create!(
+      application_id: instructor_application.id,
+      resource_owner_id: instructor.id,
+      scopes: "user_info user_courses user_scores user_submit instructor_all"
+    )
+  }
+  let!(:instructor_token_for_user){
+    Doorkeeper::AccessToken.create!(
+      application_id: instructor_application.id,
+      resource_owner_id: user.id,
+      scopes: "user_info user_courses user_scores user_submit instructor_all"
+    )
+  }
 end
 
 RSpec.shared_context "api handin context" do
@@ -36,21 +89,46 @@ RSpec.shared_context "api handin context" do
     # The adder.py file to hand in
     @handin_file = fixture_file_upload('handins/adder.py', 'text/plain')
     # The AutoPopulate Course
-    @ap_course = Course.find_by(:name => 'AutoPopulated')
-    @ap_cud = CourseUserDatum.where(:course => @ap_course, :instructor => false, :course_assistant => false).first
+    @ap_course = Course.find_by(name: 'AutoPopulated')
+    @ap_cud = CourseUserDatum.where(course: @ap_course, instructor: false,
+                                    course_assistant: false).first
     @ap_student = @ap_cud.user
     # The adder.py Assessment
-    @adder_asm = Assessment.find_by(:course => @ap_course, :name => 'labtemplate')
+    @adder_asm = Assessment.find_by(course: @ap_course, name: 'labtemplate')
     # make sure we can submit to this assessment
-    @adder_asm.due_at = Time.now + 1.hour
-    @adder_asm.end_at = Time.now + 1.hour
-    @adder_asm.grading_deadline = Time.now + 1.hour
+    @adder_asm.due_at = Time.zone.now + 1.hour
+    @adder_asm.end_at = Time.zone.now + 1.hour
+    @adder_asm.grading_deadline = Time.zone.now + 1.hour
     @adder_asm.save!
   end
 
-  let!(:bad_application) { Doorkeeper::Application.create! :name => "TestApp", :redirect_uri => "https://example.com", :scopes => "user_info user_courses" }
-  let!(:bad_token) { Doorkeeper::AccessToken.create! :application_id => application.id, :resource_owner_id => @ap_student.id, :scopes => "user_info user_courses" }
+  let!(:bad_application) {
+    Doorkeeper::Application.create!(
+      name: "TestApp",
+      redirect_uri: "https://example.com",
+      scopes: "user_info user_courses"
+    )
+  }
+  let!(:bad_token) {
+    Doorkeeper::AccessToken.create!(
+      application_id: application.id,
+      resource_owner_id: @ap_student.id,
+      scopes: "user_info user_courses"
+    )
+  }
 
-  let!(:application) { Doorkeeper::Application.create! :name => "TestApp", :redirect_uri => "https://example.com", :scopes => "user_info user_submit" }
-  let!(:token) { Doorkeeper::AccessToken.create! :application_id => application.id, :resource_owner_id => @ap_student.id, :scopes => "user_info user_submit" }
+  let!(:application) {
+    Doorkeeper::Application.create!(
+      name: "TestApp",
+      redirect_uri: "https://example.com",
+      scopes: "user_info user_submit"
+    )
+  }
+  let!(:token) {
+    Doorkeeper::AccessToken.create!(
+      application_id: application.id,
+      resource_owner_id: @ap_student.id,
+      scopes: "user_info user_submit"
+    )
+  }
 end

--- a/spec/api/v1/assessments_api_spec.rb
+++ b/spec/api/v1/assessments_api_spec.rb
@@ -1,23 +1,25 @@
 require 'rails_helper'
-require_relative "api_shared_context.rb"
-require_relative "tango_mock.rb"
+require_relative "api_shared_context"
+require_relative "tango_mock"
 
-RSpec.describe Api::V1::AssessmentsController, :type => :controller do
+RSpec.describe Api::V1::AssessmentsController, type: :controller do
   describe 'GET #index' do
     include_context "api shared context"
 
     it 'fails scope test' do
-      get :index, params: {:access_token => user_info_token.token, :course_name => course.name}
+      get :index, params: { access_token: user_info_token.token, course_name: course.name }
       expect(response.response_code).to eq(403)
     end
 
     it 'fails to find the course' do
-      get :index, params: {:access_token => token.token, :course_name => 8.times.map { (65 + rand(26)).chr }.join} # random course name
+      get :index, params: { access_token: token.token, course_name: 8.times.map {
+                                                                      rand(65..90).chr
+                                                                    }.join } # random course name
       expect(response.response_code).to eq(404)
     end
 
     it 'returns all the released assessments of a course' do
-      get :index, params: {:access_token => token.token, :course_name => course.name}
+      get :index, params: { access_token: token.token, course_name: course.name }
       expect(response.response_code).to eq(200)
       msg = JSON.parse(response.body)
       expect(msg.length).to eq(course.assessments.released.count)
@@ -29,9 +31,11 @@ RSpec.describe Api::V1::AssessmentsController, :type => :controller do
     include_context "api handin context"
 
     it 'fails scope test' do
-      subm = Hash.new
+      subm = {}
       subm['file'] = @handin_file
-      post :submit, params: {:access_token => bad_token.token, :course_name => @ap_course.name, :assessment_name => @adder_asm.name, :submission => subm}
+      post :submit,
+           params: { access_token: bad_token.token, course_name: @ap_course.name,
+                     assessment_name: @adder_asm.name, submission: subm }
       expect(response.response_code).to eq(403)
       msg = JSON.parse(response.body)
       expect(msg).to include('error')
@@ -39,8 +43,10 @@ RSpec.describe Api::V1::AssessmentsController, :type => :controller do
     end
 
     it 'rejects invalid handin with no submission[file] param' do
-      subm = Hash.new
-      post :submit, params: {:access_token => token.token, :course_name => @ap_course.name, :assessment_name => @adder_asm.name, :submission => subm}
+      subm = {}
+      post :submit,
+           params: { access_token: token.token, course_name: @ap_course.name,
+                     assessment_name: @adder_asm.name, submission: subm }
       expect(response.response_code).to eq(400)
       msg = JSON.parse(response.body)
       expect(msg).to include('error')
@@ -49,19 +55,23 @@ RSpec.describe Api::V1::AssessmentsController, :type => :controller do
 
     it 'accepts the handin' do
       # count number of submissions before
-      sub_count = Submission.where(:course_user_datum_id => @ap_cud.id, :assessment => @adder_asm).count
+      sub_count = Submission.where(course_user_datum_id: @ap_cud.id,
+                                   assessment: @adder_asm).count
 
       # perform submission
-      subm = Hash.new
+      subm = {}
       subm['file'] = @handin_file
-      post :submit, params: {:access_token => token.token, :course_name => @ap_course.name, :assessment_name => @adder_asm.name, :submission => subm}
+      post :submit,
+           params: { access_token: token.token, course_name: @ap_course.name,
+                     assessment_name: @adder_asm.name, submission: subm }
       msg = JSON.parse(response.body)
       expect(response.response_code).to eq(200)
       expect(msg).to include('version')
       expect(msg['version']).to eq(sub_count + 1)
 
       # count submissions after
-      sub_count_after = Submission.where(:course_user_datum_id => @ap_cud.id, :assessment => @adder_asm).count
+      sub_count_after = Submission.where(course_user_datum_id: @ap_cud.id,
+                                         assessment: @adder_asm).count
       expect(sub_count_after - 1).to eq(sub_count)
     end
   end

--- a/spec/api/v1/course_user_data_api_spec.rb
+++ b/spec/api/v1/course_user_data_api_spec.rb
@@ -1,17 +1,19 @@
 require 'rails_helper'
-require_relative "api_shared_context.rb"
+require_relative "api_shared_context"
 
 # test cases common to all CUD routes
 # requires "api shared context" to have been included
 RSpec.shared_examples "a CUD route" do |method, action|
   it 'fails to authenticate when the app does not have instructor scope' do
-    send method, action, params: {:access_token => token.token, :course_name => course.name, :email => user.email}
+    send method, action,
+         params: { access_token: token.token, course_name: course.name, email: user.email }
     expect(response.response_code).to eq(403)
   end
 
   it 'fails to authenticate when the user is not an instructor' do
-    send method, action, params: {:access_token => instructor_token_for_user.token, :course_name => course.name,
-      :email => instructor.email}
+    send method, action, params: { access_token: instructor_token_for_user.token,
+                                   course_name: course.name,
+                                   email: instructor.email }
     expect(response.response_code).to eq(403)
   end
 end
@@ -20,10 +22,10 @@ end
 # requires "api shared context" to have been included
 RSpec.shared_examples "a CUD member route" do |method, action|
   it "fails to #{action} when user does not exist" do
-    rand_user_email = 16.times.map { (65 + rand(26)).chr }.join
-    send method, action, params: {:access_token => instructor_token_for_instructor.token,
-      :course_name => course.name, :email => rand_user_email, :lecture => "1",
-      :section => "A", :auth_level => "student"}
+    rand_user_email = 16.times.map { rand(65..90).chr }.join
+    send method, action, params: { access_token: instructor_token_for_instructor.token,
+                                   course_name: course.name, email: rand_user_email, lecture: "1",
+                                   section: "A", auth_level: "student" }
     expect(response.response_code).to eq(400)
 
     no_user = User.find_by(email: rand_user_email)
@@ -31,15 +33,15 @@ RSpec.shared_examples "a CUD member route" do |method, action|
   end
 
   it "fails to #{action} when user is not in the course" do
-    email_name = 16.times.map { (65 + rand(26)).chr }.join
-    email_domain = 8.times.map { (65 + rand(26)).chr }.join
-    newUser = User.new(email: email_name + "@" + email_domain + ".com",
-      first_name: "hello", last_name: "there", password: "password")
+    email_name = 16.times.map { rand(65..90).chr }.join
+    email_domain = 8.times.map { rand(65..90).chr }.join
+    newUser = User.new(email: "#{email_name}@#{email_domain}.com",
+                       first_name: "hello", last_name: "there", password: "password")
     newUser.save!
 
-    send method, action, params: {:access_token => instructor_token_for_instructor.token,
-      :course_name => course.name, :email => newUser.email, :lecture => "1",
-      :section => "A", :auth_level => "student"}
+    send method, action, params: { access_token: instructor_token_for_instructor.token,
+                                   course_name: course.name, email: newUser.email, lecture: "1",
+                                   section: "A", auth_level: "student" }
     expect(response.response_code).to eq(404)
 
     no_cud = newUser.course_user_data.find_by(course: course)
@@ -47,15 +49,16 @@ RSpec.shared_examples "a CUD member route" do |method, action|
   end
 end
 
-RSpec.describe Api::V1::CourseUserDataController, :type => :controller do
-
+RSpec.describe Api::V1::CourseUserDataController, type: :controller do
   describe 'GET index' do
     include_context "api shared context"
 
     it_behaves_like "a CUD route", :get, :index
 
     it 'returns the correct number of users and have the correct fields' do
-      get :index, params: {:access_token => instructor_token_for_instructor.token, :course_name => course.name}
+      get :index,
+          params: { access_token: instructor_token_for_instructor.token,
+                    course_name: course.name }
       expect(response.response_code).to eq(200)
       msg = JSON.parse(response.body)
 
@@ -85,10 +88,10 @@ RSpec.describe Api::V1::CourseUserDataController, :type => :controller do
     it_behaves_like "a CUD route", :post, :create
 
     it 'fails to create when user does not exist' do
-      rand_user_email = 16.times.map { (65 + rand(26)).chr }.join
-      post :create, params: {:access_token => instructor_token_for_instructor.token,
-        :course_name => course.name, :email => rand_user_email, :lecture => "1",
-        :section => "A", :auth_level => "student"}
+      rand_user_email = 16.times.map { rand(65..90).chr }.join
+      post :create, params: { access_token: instructor_token_for_instructor.token,
+                              course_name: course.name, email: rand_user_email, lecture: "1",
+                              section: "A", auth_level: "student" }
       expect(response.response_code).to eq(400)
 
       user = User.find_by(email: rand_user_email)
@@ -96,26 +99,25 @@ RSpec.describe Api::V1::CourseUserDataController, :type => :controller do
     end
 
     it 'fails to create when user is already in course' do
-      rand_user_email = 16.times.map { (65 + rand(26)).chr }.join
-      post :create, params: {:access_token => instructor_token_for_instructor.token,
-        :course_name => course.name, :email => user.email, :lecture => "1",
-        :section => "A", :auth_level => "student"}
+      post :create, params: { access_token: instructor_token_for_instructor.token,
+                              course_name: course.name, email: user.email, lecture: "1",
+                              section: "A", auth_level: "student" }
       expect(response.response_code).to eq(400)
     end
 
     context "when user is valid" do
       before(:each) do
-        email_name = 16.times.map { (65 + rand(26)).chr }.join
-        email_domain = 8.times.map { (65 + rand(26)).chr }.join
-        @newUser = User.new(email: email_name + "@" + email_domain + ".com",
-          first_name: "hello", last_name: "there", password: "password")
+        email_name = 16.times.map { rand(65..90).chr }.join
+        email_domain = 8.times.map { rand(65..90).chr }.join
+        @newUser = User.new(email: "#{email_name}@#{email_domain}.com",
+                            first_name: "hello", last_name: "there", password: "password")
         @newUser.save!
       end
 
       it 'creates a student CUD' do
-        post :create, params: {:access_token => instructor_token_for_instructor.token,
-          :course_name => course.name, :email => @newUser.email, :lecture => "1",
-          :section => "A", :auth_level => "student", :grade_policy => "letter"}
+        post :create, params: { access_token: instructor_token_for_instructor.token,
+                                course_name: course.name, email: @newUser.email, lecture: "1",
+                                section: "A", auth_level: "student", grade_policy: "letter" }
         expect(response.response_code).to eq(200)
 
         cud = @newUser.course_user_data.find_by(course: course)
@@ -130,9 +132,9 @@ RSpec.describe Api::V1::CourseUserDataController, :type => :controller do
       end
 
       it 'creates a dropped student CUD' do
-        post :create, params: {:access_token => instructor_token_for_instructor.token,
-          :course_name => course.name, :email => @newUser.email, :lecture => "1",
-          :section => "A", :auth_level => "student", :dropped => true}
+        post :create, params: { access_token: instructor_token_for_instructor.token,
+                                course_name: course.name, email: @newUser.email, lecture: "1",
+                                section: "A", auth_level: "student", dropped: true }
         expect(response.response_code).to eq(200)
 
         cud = @newUser.course_user_data.find_by(course: course)
@@ -141,9 +143,9 @@ RSpec.describe Api::V1::CourseUserDataController, :type => :controller do
       end
 
       it 'creates an instructor CUD' do
-        post :create, params: {:access_token => instructor_token_for_instructor.token,
-          :course_name => course.name, :email => @newUser.email, :lecture => "2",
-          :section => "D", :auth_level => "instructor"}
+        post :create, params: { access_token: instructor_token_for_instructor.token,
+                                course_name: course.name, email: @newUser.email, lecture: "2",
+                                section: "D", auth_level: "instructor" }
         expect(response.response_code).to eq(200)
 
         cud = @newUser.course_user_data.find_by(course: course)
@@ -157,16 +159,16 @@ RSpec.describe Api::V1::CourseUserDataController, :type => :controller do
       end
 
       it 'fails to create if missing parameter' do
-        post :create, params: {:access_token => instructor_token_for_instructor.token,
-          :course_name => course.name, :email => @newUser.email, :lecture => "1",
-          :auth_level => "student"}# no section
+        post :create, params: { access_token: instructor_token_for_instructor.token,
+                                course_name: course.name, email: @newUser.email, lecture: "1",
+                                auth_level: "student" } # no section
         expect(response.response_code).to eq(400)
       end
 
       it 'fails to create if auth_level is invalid' do
-        post :create, params: {:access_token => instructor_token_for_instructor.token,
-          :course_name => course.name, :email => @newUser.email, :lecture => "1",
-          :section => "A", :auth_level => "blah"}
+        post :create, params: { access_token: instructor_token_for_instructor.token,
+                                course_name: course.name, email: @newUser.email, lecture: "1",
+                                section: "A", auth_level: "blah" }
         expect(response.response_code).to eq(400)
       end
     end
@@ -181,8 +183,8 @@ RSpec.describe Api::V1::CourseUserDataController, :type => :controller do
 
     context 'when user is valid' do
       it 'returns the info correctly' do
-        get :show, params: {:access_token => instructor_token_for_instructor.token,
-          :course_name => course.name, :email => user.email}
+        get :show, params: { access_token: instructor_token_for_instructor.token,
+                             course_name: course.name, email: user.email }
         expect(response.response_code).to eq(200)
         msg = JSON.parse(response.body)
 
@@ -205,9 +207,9 @@ RSpec.describe Api::V1::CourseUserDataController, :type => :controller do
 
     context 'when user is valid' do
       it 'updates the auth_level correctly' do
-        put :update, params: {:access_token => instructor_token_for_instructor.token,
-          :course_name => course.name, :email => user.email, :lecture => "1",
-          :auth_level => "course_assistant"}
+        put :update, params: { access_token: instructor_token_for_instructor.token,
+                               course_name: course.name, email: user.email, lecture: "1",
+                               auth_level: "course_assistant" }
         expect(response.response_code).to eq(200)
         msg = JSON.parse(response.body)
 
@@ -219,14 +221,14 @@ RSpec.describe Api::V1::CourseUserDataController, :type => :controller do
 
       it 'updates other info correctly' do
         cud = user.course_user_data.find_by(course: course)
-        new_lecture = cud.lecture + "_24"
-        new_section = cud.section + "_42"
+        new_lecture = "#{cud.lecture}_24"
+        new_section = "#{cud.section}_42"
         new_dropped = !cud.dropped
         new_grade_policy = "pass_fail"
-        put :update, params: {:access_token => instructor_token_for_instructor.token,
-          :course_name => course.name, :email => user.email,
-          :lecture => new_lecture, :section => new_section,
-          :dropped => new_dropped, :grade_policy => new_grade_policy}
+        put :update, params: { access_token: instructor_token_for_instructor.token,
+                               course_name: course.name, email: user.email,
+                               lecture: new_lecture, section: new_section,
+                               dropped: new_dropped, grade_policy: new_grade_policy }
         expect(response.response_code).to eq(200)
         msg = JSON.parse(response.body)
 
@@ -256,8 +258,8 @@ RSpec.describe Api::V1::CourseUserDataController, :type => :controller do
         cud.dropped = false
         cud.save!
 
-        delete :destroy, params: {:access_token => instructor_token_for_instructor.token,
-          :course_name => course.name, :email => user.email}
+        delete :destroy, params: { access_token: instructor_token_for_instructor.token,
+                                   course_name: course.name, email: user.email }
         expect(response.response_code).to eq(200)
 
         cud = user.course_user_data.find_by(course: course)
@@ -270,8 +272,8 @@ RSpec.describe Api::V1::CourseUserDataController, :type => :controller do
         cud.dropped = false
         cud.save!
 
-        delete :destroy, params: {:access_token => instructor_token_for_instructor.token,
-          :course_name => course.name, :email => user.email, :dropped => false}
+        delete :destroy, params: { access_token: instructor_token_for_instructor.token,
+                                   course_name: course.name, email: user.email, dropped: false }
         expect(response.response_code).to eq(200)
 
         cud = user.course_user_data.find_by(course: course)
@@ -282,10 +284,12 @@ RSpec.describe Api::V1::CourseUserDataController, :type => :controller do
       it 'does not update other attributes' do
         cud = user.course_user_data.find_by(course: course)
         old_lecture = cud.lecture
-        new_lecture = cud.lecture + "4242"
+        new_lecture = "#{cud.lecture}4242"
 
-        delete :destroy, params: {:access_token => instructor_token_for_instructor.token,
-          :course_name => course.name, :email => user.email, :lecture => new_lecture}
+        delete :destroy, params: { access_token: instructor_token_for_instructor.token,
+                                   course_name: course.name,
+                                   email: user.email,
+                                   lecture: new_lecture }
         expect(response.response_code).to eq(200)
 
         cud = user.course_user_data.find_by(course: course)

--- a/spec/api/v1/courses_api_spec.rb
+++ b/spec/api/v1/courses_api_spec.rb
@@ -1,38 +1,40 @@
 require 'rails_helper'
-require_relative "api_shared_context.rb"
+require_relative "api_shared_context"
 
-RSpec.describe Api::V1::CoursesController, :type => :controller do
+RSpec.describe Api::V1::CoursesController, type: :controller do
   describe 'GET #index' do
     include_context "api shared context"
 
     it 'fails to authenticate when the token is invalid' do
-      get :index, params: {:access_token => token.token.length.times.map { (65 + rand(26)).chr }.join} # a random token
+      get :index, params: { access_token: token.token.length.times.map {
+                                            rand(65..90).chr
+                                          }.join } # a random token
       expect(response.response_code).to eq(401)
     end
 
     it 'fails scope test' do
-      get :index, params: {:access_token => user_info_token.token}
+      get :index, params: { access_token: user_info_token.token }
       expect(response.response_code).to eq(403)
     end
 
     it 'returns all the user\'s courses' do
-      get :index, params: {:access_token => token.token}
+      get :index, params: { access_token: token.token }
       expect(response.response_code).to eq(200)
-      expect{ msg = JSON.parse(response.body) }.not_to raise_exception
+      expect{ JSON.parse(response.body) }.not_to raise_exception
     end
 
     it 'returns only current courses' do
-      get :index, params: {:access_token => token.token, :state => "current"}
+      get :index, params: { access_token: token.token, state: "current" }
       expect(response.response_code).to eq(200)
       msg = JSON.parse(response.body)
       msg.each do |c|
-        course = Course.find_by(:name => c["name"])
+        course = Course.find_by(name: c["name"])
         expect(course.temporal_status).to eq(:current)
       end
     end
 
     it 'reports a state error' do
-      get :index, params: {:access_token => token.token, :state => "blah"}
+      get :index, params: { access_token: token.token, state: "blah" }
       expect(response.response_code).to eq(400)
       msg = JSON.parse(response.body)
       expect(msg["error"]).to eq("Unexpected course state")
@@ -49,25 +51,32 @@ RSpec.describe Api::V1::CoursesController, :type => :controller do
     end
 
     it 'fails to authenticate when the app does not have admin scope' do
-      get :create, params: {:access_token => token.token}
+      get :create, params: { access_token: token.token }
       expect(response.response_code).to eq(403)
     end
 
     it 'fails to authenticate when the user is not an admin' do
-      get :create, params: {:access_token => admin_token_for_user.token}
+      get :create, params: { access_token: admin_token_for_user.token }
       expect(response.response_code).to eq(403)
     end
 
     it 'fails to create when name is invalid' do
-      get :create, params: {:access_token => admin_token_for_admin.token, :name => "Hello There", :semester => @course_sem, :instructor_email => @instructor_email}
+      get :create,
+          params: { access_token: admin_token_for_admin.token,
+                    name: "Hello There",
+                    semester: @course_sem,
+                    instructor_email: @instructor_email }
       expect(response.response_code).not_to eq(200)
     end
 
     it 'creates a course successfully for an existing user' do
-      get :create, params: {:access_token => admin_token_for_admin.token, :name => @course_name, :semester => @course_sem, :instructor_email => @instructor_email}
+      get :create,
+          params: { access_token: admin_token_for_admin.token,
+                    name: @course_name, semester: @course_sem,
+                    instructor_email: @instructor_email }
       expect(response.response_code).to eq(200)
 
-      course = Course.find_by(:name => @course_name)
+      course = Course.find_by(name: @course_name)
       expect(course).not_to be_nil
       expect(course.semester).to eq(@course_sem)
 
@@ -78,13 +87,16 @@ RSpec.describe Api::V1::CoursesController, :type => :controller do
 
     it 'creates a course successfully for a non-existing user' do
       new_email = "new_instructor@test.com"
-      get :create, params: {:access_token => admin_token_for_admin.token, :name => @course_name, :semester => @course_sem, :instructor_email => new_email}
+      get :create,
+          params: { access_token: admin_token_for_admin.token,
+                    name: @course_name, semester: @course_sem,
+                    instructor_email: new_email }
       expect(response.response_code).to eq(200)
 
       newly_created_user = User.find_by(email: new_email)
       expect(newly_created_user).not_to be_nil
 
-      course = Course.find_by(:name => @course_name)
+      course = Course.find_by(name: @course_name)
       expect(course).not_to be_nil
       expect(course.semester).to eq(@course_sem)
 

--- a/spec/api/v1/device_flow_requests_spec.rb
+++ b/spec/api/v1/device_flow_requests_spec.rb
@@ -1,12 +1,12 @@
 require 'rails_helper'
-require_relative "api_shared_context.rb"
+require_relative "api_shared_context"
 
-RSpec.describe Oauth::DeviceFlowController, :type => :controller do
+RSpec.describe Oauth::DeviceFlowController, type: :controller do
   describe 'GET #init' do
     include_context "api shared context"
 
     it 'returns a valid device_code and user_code pair' do
-      get :init, params: {:client_id => df_application.uid}
+      get :init, params: { client_id: df_application.uid }
       expect(response.response_code).to eq(200)
 
       expect(msg).to have_key("device_code")
@@ -17,7 +17,9 @@ RSpec.describe Oauth::DeviceFlowController, :type => :controller do
     end
 
     it 'does not allow invalid client_id' do
-      get :init, params: {:client_id => df_application.uid.length.times.map { (65 + rand(26)).chr }.join}
+      get :init, params: { client_id: df_application.uid.length.times.map {
+                                        rand(65..90).chr
+                                      }.join }
       expect(response.response_code).to eq(400)
     end
 
@@ -38,7 +40,7 @@ RSpec.describe Oauth::DeviceFlowController, :type => :controller do
       end
 
       it 'returns pending when not resolved' do
-        get :authorize, params: {:client_id => df_application.uid, :device_code => @req.device_code}
+        get :authorize, params: { client_id: df_application.uid, device_code: @req.device_code }
         expect(response.response_code).to eq(400)
         expect(msg["error"]).to eq("authorization_pending")
       end
@@ -47,7 +49,7 @@ RSpec.describe Oauth::DeviceFlowController, :type => :controller do
         @req.deny_request(:user)
         device_code = @req.device_code
 
-        get :authorize, params: {:client_id => df_application.uid, :device_code => device_code}
+        get :authorize, params: { client_id: df_application.uid, device_code: device_code }
         expect(response.response_code).to eq(400)
         expect(msg["error"]).to include("denied")
 
@@ -57,11 +59,11 @@ RSpec.describe Oauth::DeviceFlowController, :type => :controller do
       end
 
       it 'returns the access code when granted access' do
-        access_code = 32.times.map { (65 + rand(26)).chr }.join
+        access_code = 32.times.map { rand(65..90).chr }.join
         @req.grant_request(:user, access_code)
         device_code = @req.device_code
 
-        get :authorize, params: {:client_id => df_application.uid, :device_code => device_code}
+        get :authorize, params: { client_id: df_application.uid, device_code: device_code }
         expect(response.response_code).to eq(200)
         expect(msg).to have_key("code")
         expect(msg["code"]).to eq(access_code)
@@ -73,17 +75,21 @@ RSpec.describe Oauth::DeviceFlowController, :type => :controller do
     end
 
     it 'does not allow invalid device_code' do
-      get :authorize, params: {:client_id => df_application.uid, :device_code => 32.times.map { (65 + rand(26)).chr }.join}
+      get :authorize, params: { client_id: df_application.uid, device_code: 32.times.map {
+                                                                              rand(65..90).chr
+                                                                            }.join }
       expect(response.response_code).to eq(400)
     end
 
     it 'does not allow missing device_code' do
-      get :authorize, params: {:client_id => df_application.uid}
+      get :authorize, params: { client_id: df_application.uid }
       expect(response.response_code).to eq(400)
     end
 
     it 'does not allow invalid client_id' do
-      get :authorize, params: {:client_id => df_application.uid.length.times.map { (65 + rand(26)).chr }.join}
+      get :authorize, params: { client_id: df_application.uid.length.times.map {
+                                             rand(65..90).chr
+                                           }.join }
       expect(response.response_code).to eq(400)
     end
 

--- a/spec/api/v1/problems_api_spec.rb
+++ b/spec/api/v1/problems_api_spec.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
-require_relative "api_shared_context.rb"
+require_relative "api_shared_context"
 
 RSpec.describe Api::V1::ProblemsController, type: :controller do
   describe 'GET #problems' do

--- a/spec/api/v1/submission_roundtrip_spec.rb
+++ b/spec/api/v1/submission_roundtrip_spec.rb
@@ -1,38 +1,43 @@
 require 'rails_helper'
-require_relative "tango_mock.rb"
-require_relative "api_shared_context.rb"
+require_relative "tango_mock"
+require_relative "api_shared_context"
 
-RSpec.describe "API Submission Autograding Roundtrip Test", :type => :request do
+RSpec.describe "API Submission Autograding Roundtrip Test", type: :request do
   include_context "tango mock"
   include_context "api handin context"
 
   it "accepts handin and handles Tango callback correctly" do
     # count number of submissions before
-    sub_count = Submission.where(:course_user_datum_id => @ap_cud.id, :assessment => @adder_asm).count
+    sub_count = Submission.where(course_user_datum_id: @ap_cud.id,
+                                 assessment: @adder_asm).count
 
     # perform submission
-    subm = Hash.new
+    subm = {}
     subm['file'] = @handin_file
-    post "/api/v1/courses/#{@ap_course.name}/assessments/#{@adder_asm.name}/submit", params: {:access_token => token.token, :submission => subm}
+    post "/api/v1/courses/#{@ap_course.name}/assessments/#{@adder_asm.name}/submit",
+         params: { access_token: token.token, submission: subm }
     msg = JSON.parse(response.body)
     expect(response.response_code).to eq(200)
     expect(msg).to include('version')
     expect(msg['version']).to match(sub_count + 1)
 
     # count submissions after
-    sub_count_after = Submission.where(:course_user_datum_id => @ap_cud.id, :assessment => @adder_asm).count
+    sub_count_after = Submission.where(course_user_datum_id: @ap_cud.id,
+                                       assessment: @adder_asm).count
     expect(sub_count_after - 1).to eq(sub_count)
 
     # check submitted_by_app_id
-    latest_sub = Submission.where(:course_user_datum_id => @ap_cud.id, :assessment => @adder_asm).order(:version).last
+    latest_sub = Submission.where(course_user_datum_id: @ap_cud.id,
+                                  assessment: @adder_asm).order(:version).last
     expect(latest_sub.submitted_by_app_id).to eq(application.id)
 
     # mock a Tango callback
-    mock_tango_callback(@ap_course.name, @adder_asm.name, latest_sub.dave, latest_sub.id, 'feedback.txt')
+    mock_tango_callback(@ap_course.name, @adder_asm.name, latest_sub.dave, latest_sub.id,
+                        'feedback.txt')
 
     # check score
-    problem = @adder_asm.problems.find_by(:name => "autograded")
-    score = Score.find_by(:submission => latest_sub, :problem => problem)
+    problem = @adder_asm.problems.find_by(name: "autograded")
+    score = Score.find_by(submission: latest_sub, problem: problem)
     expect(score).not_to be_nil
     expect(score.score).to eq(42)
   end

--- a/spec/api/v1/tango_mock.rb
+++ b/spec/api/v1/tango_mock.rb
@@ -1,10 +1,9 @@
-require Rails.root.join("config", "autogradeConfig.rb")
+require Rails.root.join("config/autogradeConfig.rb")
 
 RSpec.shared_context "tango mock" do
-
   before :each do
     base_uri = "#{RESTFUL_HOST}:#{RESTFUL_PORT}"
-    
+
     default_resp_header = { 'Content-Type' => 'application/json' }
 
     #------#
@@ -15,38 +14,38 @@ RSpec.shared_context "tango mock" do
     files = {}
     files["hello.c"] = SecureRandom.hex(32);
     files["Makefile"] = SecureRandom.hex(32);
-    open_result = {statusId: 0,
-                   statusMsg: "Found directory",
-                   files: files}
+    open_result = { statusId: 0,
+                    statusMsg: "Found directory",
+                    files: files }
 
     @tango_stub_open = stub_request(:get, open_uri).
                        to_return(status: 200, body: open_result.to_json,
-                         headers: default_resp_header)
+                                 headers: default_resp_header)
 
     #--------#
     # upload #
     #--------#
     upload_uri = Addressable::Template.new "#{base_uri}/upload/{key}/{courselab}/"
 
-    upload_result = {statusId: 0,
-                     statusMsg: "Uploaded file"}
+    upload_result = { statusId: 0,
+                      statusMsg: "Uploaded file" }
 
     @tango_stub_upload = stub_request(:post, upload_uri).
                          to_return(status: 200, body: upload_result.to_json,
-                           headers: default_resp_header)
+                                   headers: default_resp_header)
 
     #--------#
     # addJob #
     #--------#
     addjob_uri = Addressable::Template.new "#{base_uri}/addJob/{key}/{courselab}/"
 
-    addjob_result = {statusId: 0,
-                     statusMsg: "Job added",
-                     jobId: 42}
+    addjob_result = { statusId: 0,
+                      statusMsg: "Job added",
+                      jobId: 42 }
 
     @tango_stub_addjob = stub_request(:post, addjob_uri).
                          to_return(status: 200, body: addjob_result.to_json,
-                           headers: default_resp_header)
+                                   headers: default_resp_header)
 
     # Mock a tango callback when autograding is done
     # params:
@@ -57,7 +56,10 @@ RSpec.shared_context "tango mock" do
     #  - filename: name of fixture file to send back as feedback
     def mock_tango_callback(course_name, asmt_name, dave, sub_id, filename)
       feedback_file = fixture_file_upload(filename, 'text/plain')
-      post "/courses/#{course_name}/assessments/#{asmt_name}/autograde_done?dave=#{dave}&submission_id=#{sub_id}", params: {:file => feedback_file}
+      # rubocop:disable Layout/LineLength
+      post "/courses/#{course_name}/assessments/#{asmt_name}/autograde_done?dave=#{dave}&submission_id=#{sub_id}",
+           params: { file: feedback_file }
+      # rubocop:enable Layout/LineLength
     end
   end
 
@@ -66,5 +68,4 @@ RSpec.shared_context "tango mock" do
     remove_request_stub(@tango_stub_upload)
     remove_request_stub(@tango_stub_addjob)
   end
-
 end

--- a/spec/api/v1/user_api_spec.rb
+++ b/spec/api/v1/user_api_spec.rb
@@ -1,12 +1,12 @@
 require 'rails_helper'
-require_relative "api_shared_context.rb"
+require_relative "api_shared_context"
 
-RSpec.describe Api::V1::UserController, :type => :controller do
+RSpec.describe Api::V1::UserController, type: :controller do
   describe 'GET #show' do
     include_context "api shared context"
 
     it 'returns correct user email' do
-      get :show, params: {:access_token => token.token}
+      get :show, params: { access_token: token.token }
       expect(response.response_code).to eq(200)
       msg = JSON.parse(response.body)
       expect(msg["email"]).to eq(user.email)

--- a/spec/controllers/attachments_controller_spec.rb
+++ b/spec/controllers/attachments_controller_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe AttachmentsController, type: :controller do
       cid = get_course_id_by_uid(u.id)
       cname = Course.find(cid).name
       it "renders successfully" do
-        get :index, params: {course_name: cname}
+        get :index, params: { course_name: cname }
         expect(response).to be_successful
         expect(response.body).to match(/Course Attachments/m)
       end
@@ -22,7 +22,7 @@ RSpec.describe AttachmentsController, type: :controller do
       cid = get_course_id_by_uid(u.id)
       cname = Course.find(cid).name
       it "renders successfully" do
-        get :index, params: {course_name: cname}
+        get :index, params: { course_name: cname }
         expect(response).to be_successful
         expect(response.body).to match(/Course Attachments/m)
       end
@@ -34,7 +34,7 @@ RSpec.describe AttachmentsController, type: :controller do
       cid = get_course_id_by_uid(u.id)
       cname = Course.find(cid).name
       it "renders with failure" do
-        get :index, params: {course_name: cname}
+        get :index, params: { course_name: cname }
         expect(response).not_to be_successful
         expect(response.body).not_to match(/Course Attachments/m)
       end
@@ -42,7 +42,7 @@ RSpec.describe AttachmentsController, type: :controller do
 
     context "when user is not logged in" do
       it "renders with failure" do
-        get :index, params: {course_name: "dummy"}
+        get :index, params: { course_name: "dummy" }
         expect(response).not_to be_successful
         expect(response.body).not_to match(/Course Attachments/m)
       end
@@ -56,7 +56,7 @@ RSpec.describe AttachmentsController, type: :controller do
       cid = get_course_id_by_uid(u.id)
       cname = Course.find(cid).name
       it "renders successfully" do
-        get :new, params: {course_name: cname}
+        get :new, params: { course_name: cname }
         expect(response).to be_successful
         expect(response.body).to match(/Name/m)
         expect(response.body).to match(/Released/m)
@@ -69,7 +69,7 @@ RSpec.describe AttachmentsController, type: :controller do
       cid = get_course_id_by_uid(u.id)
       cname = Course.find(cid).name
       it "renders successfully" do
-        get :new, params: {course_name: cname}
+        get :new, params: { course_name: cname }
         expect(response).to be_successful
         expect(response.body).to match(/Name/m)
         expect(response.body).to match(/Released/m)
@@ -82,7 +82,7 @@ RSpec.describe AttachmentsController, type: :controller do
       cid = get_course_id_by_uid(u.id)
       cname = Course.find(cid).name
       it "renders with failure" do
-        get :new, params: {course_name: cname}
+        get :new, params: { course_name: cname }
         expect(response).not_to be_successful
         expect(response.body).not_to match(/Name/m)
         expect(response.body).not_to match(/Released/m)
@@ -91,7 +91,7 @@ RSpec.describe AttachmentsController, type: :controller do
 
     context "when user is not logged in" do
       it "renders with failure" do
-        get :new, params: {course_name: "dummy"}
+        get :new, params: { course_name: "dummy" }
         expect(response).not_to be_successful
         expect(response.body).not_to match(/Name/m)
         expect(response.body).not_to match(/Released/m)
@@ -107,7 +107,7 @@ RSpec.describe AttachmentsController, type: :controller do
       cname = Course.find(cid).name
       att = create_course_att_with_cid(cid)
       it "renders successfully" do
-        get :edit, params: {course_name: cname, id: att.id}
+        get :edit, params: { course_name: cname, id: att.id }
         expect(response).to be_successful
         expect(response.body).to match(/Name/m)
         expect(response.body).to match(/Released/m)
@@ -121,7 +121,7 @@ RSpec.describe AttachmentsController, type: :controller do
       cname = Course.find(cid).name
       att = create_course_att_with_cid(cid)
       it "renders successfully" do
-        get :edit, params: {course_name: cname, id: att.id}
+        get :edit, params: { course_name: cname, id: att.id }
         expect(response).to be_successful
         expect(response.body).to match(/Name/m)
         expect(response.body).to match(/Released/m)
@@ -135,7 +135,7 @@ RSpec.describe AttachmentsController, type: :controller do
       cname = Course.find(cid).name
       att = create_course_att_with_cid(cid)
       it "renders with failure" do
-        get :edit, params: {course_name: cname, id: att.id}
+        get :edit, params: { course_name: cname, id: att.id }
         expect(response).not_to be_successful
         expect(response.body).not_to match(/Name/m)
         expect(response.body).not_to match(/Released/m)
@@ -148,7 +148,7 @@ RSpec.describe AttachmentsController, type: :controller do
       cname = Course.find(cid).name
       att = create_course_att_with_cid(cid)
       it "renders with failure" do
-        get :edit, params: {course_name: cname, id: att.id}
+        get :edit, params: { course_name: cname, id: att.id }
         expect(response).not_to be_successful
         expect(response.body).not_to match(/Name/m)
         expect(response.body).not_to match(/Released/m)
@@ -164,7 +164,7 @@ RSpec.describe AttachmentsController, type: :controller do
       cname = Course.find(cid).name
       att = create_course_att_with_cid(cid)
       it "renders successfully" do
-        get :show, params: {course_name: cname, id: att.id}
+        get :show, params: { course_name: cname, id: att.id }
         expect(response).to be_successful
       end
     end
@@ -176,7 +176,7 @@ RSpec.describe AttachmentsController, type: :controller do
       cname = Course.find(cid).name
       att = create_course_att_with_cid(cid)
       it "renders successfully" do
-        get :show, params: {course_name: cname, id: att.id}
+        get :show, params: { course_name: cname, id: att.id }
         expect(response).to be_successful
       end
     end
@@ -188,7 +188,7 @@ RSpec.describe AttachmentsController, type: :controller do
       cname = Course.find(cid).name
       att = create_course_att_with_cid(cid)
       it "renders successfully" do
-        get :show, params: {course_name: cname, id: att.id}
+        get :show, params: { course_name: cname, id: att.id }
         expect(response).to be_successful
       end
     end
@@ -199,7 +199,7 @@ RSpec.describe AttachmentsController, type: :controller do
       cname = Course.find(cid).name
       att = create_course_att_with_cid(cid)
       it "renders with failure" do
-        get :show, params: {course_name: cname, id: att.id}
+        get :show, params: { course_name: cname, id: att.id }
         expect(response).not_to be_successful
       end
     end

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -31,7 +31,9 @@ RSpec.describe HomeController, type: :controller do
     it "renders successfully" do
       get :no_user
       expect(response).to be_successful
-      expect(response.body).to match(/We noticed that you're not currently associated with any courses/m)
+      expect(
+        response.body
+      ).to match(/We noticed that you're not currently associated with any courses/m)
     end
   end
 end

--- a/spec/controllers/lti_config_controller_spec.rb
+++ b/spec/controllers/lti_config_controller_spec.rb
@@ -3,9 +3,18 @@ require "rails_helper"
 RSpec.describe LtiConfigController, type: :controller do
   render_views
   before(:all) do
-    @lti_config_hash = YAML.safe_load(File.read("#{Rails.configuration.lti_config_location}/lti_config_template.yml"))
-    @lti_tool_jwk_file = Rack::Test::UploadedFile.new("#{Rails.configuration.lti_config_location}/lti_tool_jwk_template.json");
-    @lti_platform_jwk_file = Rack::Test::UploadedFile.new("#{Rails.configuration.lti_config_location}/lti_platform_jwk_template.json");
+    @lti_config_hash =
+      YAML.safe_load(
+        File.read("#{Rails.configuration.lti_config_location}/lti_config_template.yml")
+      )
+    @lti_tool_jwk_file =
+      Rack::Test::UploadedFile.new(
+        "#{Rails.configuration.lti_config_location}/lti_tool_jwk_template.json"
+      )
+    @lti_platform_jwk_file =
+      Rack::Test::UploadedFile.new(
+        "#{Rails.configuration.lti_config_location}/lti_platform_jwk_template.json"
+      )
   end
   after(:each) do
     if File.exist?("#{Rails.configuration.lti_config_location}/lti_config.yml")
@@ -29,8 +38,10 @@ RSpec.describe LtiConfigController, type: :controller do
       end
       it "rejects valid params but no file" do
         post :update_config, params: {
-          iss: @lti_config_hash["iss"], developer_key: @lti_config_hash["developer_key"],
-          auth_url: @lti_config_hash['auth_url'], platform_public_jwks_url: @lti_config_hash['platform_public_jwks_url'],
+          iss: @lti_config_hash["iss"],
+          developer_key: @lti_config_hash["developer_key"],
+          auth_url: @lti_config_hash['auth_url'],
+          platform_public_jwks_url: @lti_config_hash['platform_public_jwks_url'],
           oauth2_access_token_url: @lti_config_hash['oauth2_access_token_url']
         }
         expect(response).to have_http_status(302)
@@ -46,12 +57,18 @@ RSpec.describe LtiConfigController, type: :controller do
         }
         expect(response).to have_http_status(302)
         expect(flash[:error]).to be_present
-        expect(flash[:error]).to match(/No platform JWK JSON file or URL was uploaded. Please specify one or the other/m)
+        expect(
+          flash[:error]
+        ).to match(
+          /No platform JWK JSON file or URL was uploaded. Please specify one or the other/m
+        )
       end
       it "accepts valid POST" do
         post :update_config, params: {
-          iss: @lti_config_hash["iss"], developer_key: @lti_config_hash["developer_key"],
-          auth_url: @lti_config_hash['auth_url'], platform_public_jwks_url: @lti_config_hash['platform_public_jwks_url'],
+          iss: @lti_config_hash["iss"],
+          developer_key: @lti_config_hash["developer_key"],
+          auth_url: @lti_config_hash['auth_url'],
+          platform_public_jwks_url: @lti_config_hash['platform_public_jwks_url'],
           oauth2_access_token_url: @lti_config_hash['oauth2_access_token_url'],
           tool_jwk: @lti_tool_jwk_file
         }
@@ -121,4 +138,3 @@ RSpec.describe LtiConfigController, type: :controller do
     end
   end
 end
-

--- a/spec/controllers/schedulers_controller_spec.rb
+++ b/spec/controllers/schedulers_controller_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe SchedulersController, type: :controller do
       cid = get_course_id_by_uid(u.id)
       cname = Course.find(cid).name
       it "renders successfully" do
-        get :index, params: {course_name: cname}
+        get :index, params: { course_name: cname }
         expect(response).to be_successful
         expect(response.body).to match(/Manage Schedulers/m)
       end
@@ -23,7 +23,7 @@ RSpec.describe SchedulersController, type: :controller do
       cid = get_course_id_by_uid(u.id)
       cname = Course.find(cid).name
       it "renders successfully" do
-        get :index, params: {course_name: cname}
+        get :index, params: { course_name: cname }
         expect(response).to be_successful
         expect(response.body).to match(/Manage Schedulers/m)
       end
@@ -35,7 +35,7 @@ RSpec.describe SchedulersController, type: :controller do
       cid = get_course_id_by_uid(u.id)
       cname = Course.find(cid).name
       it "renders with failure" do
-        get :index, params: {course_name: cname}
+        get :index, params: { course_name: cname }
         expect(response).not_to be_successful
         expect(response.body).not_to match(/Manage Schedulers/m)
       end
@@ -43,7 +43,7 @@ RSpec.describe SchedulersController, type: :controller do
 
     context "when user is not logged in" do
       it "renders with failure" do
-        get :index, params: {course_name: "dummy"}
+        get :index, params: { course_name: "dummy" }
         expect(response).not_to be_successful
         expect(response.body).not_to match(/Manage Schedulers/m)
       end
@@ -57,7 +57,7 @@ RSpec.describe SchedulersController, type: :controller do
       cid = get_course_id_by_uid(u.id)
       cname = Course.find(cid).name
       it "renders successfully" do
-        get :new, params: {course_name: cname}
+        get :new, params: { course_name: cname }
         expect(response).to be_successful
         expect(response.body).to match(/New scheduler/m)
       end
@@ -69,12 +69,11 @@ RSpec.describe SchedulersController, type: :controller do
       cid = get_course_id_by_uid(u.id)
       cname = Course.find(cid).name
       it "renders successfully" do
-        get :new, params: {course_name: cname}
+        get :new, params: { course_name: cname }
         expect(response).to be_successful
         expect(response.body).to match(/New scheduler/m)
       end
     end
-
 
     context "when user is Autolab user" do
       u = get_user
@@ -82,7 +81,7 @@ RSpec.describe SchedulersController, type: :controller do
       cid = get_course_id_by_uid(u.id)
       cname = Course.find(cid).name
       it "renders with failure" do
-        get :new, params: {course_name: cname}
+        get :new, params: { course_name: cname }
         expect(response).not_to be_successful
         expect(response.body).not_to match(/New scheduler/m)
       end
@@ -90,7 +89,7 @@ RSpec.describe SchedulersController, type: :controller do
 
     context "when user is not logged in" do
       it "renders with failure" do
-        get :new, params: {course_name: "dummy"}
+        get :new, params: { course_name: "dummy" }
         expect(response).not_to be_successful
         expect(response.body).not_to match(/New scheduler/m)
       end
@@ -105,7 +104,7 @@ RSpec.describe SchedulersController, type: :controller do
       cname = Course.find(cid).name
       s = create_scheduler_with_cid(cid)
       it "renders successfully" do
-        get :edit, params: {course_name: cname, id: s.id}
+        get :edit, params: { course_name: cname, id: s.id }
         expect(response).to be_successful
         expect(response.body).to match(/Editing scheduler/m)
       end
@@ -118,7 +117,7 @@ RSpec.describe SchedulersController, type: :controller do
       cname = Course.find(cid).name
       s = create_scheduler_with_cid(cid)
       it "renders successfully" do
-        get :edit, params: {course_name: cname, id: s.id}
+        get :edit, params: { course_name: cname, id: s.id }
         expect(response).to be_successful
         expect(response.body).to match(/Editing scheduler/m)
       end
@@ -131,7 +130,7 @@ RSpec.describe SchedulersController, type: :controller do
       cname = Course.find(cid).name
       s = create_scheduler_with_cid(cid)
       it "renders with failure" do
-        get :edit, params: {course_name: cname, id: s.id}
+        get :edit, params: { course_name: cname, id: s.id }
         expect(response).not_to be_successful
         expect(response.body).not_to match(/Editing scheduler/m)
       end
@@ -140,10 +139,9 @@ RSpec.describe SchedulersController, type: :controller do
     context "when user is not logged in" do
       u = get_admin
       cid = get_course_id_by_uid(u.id)
-      cname = Course.find(cid).name
       s = create_scheduler_with_cid(cid)
       it "renders with failure" do
-        get :edit, params: {course_name: "dummy", id: s.id}
+        get :edit, params: { course_name: "dummy", id: s.id }
         expect(response).not_to be_successful
         expect(response.body).not_to match(/Editing scheduler/m)
       end
@@ -158,7 +156,7 @@ RSpec.describe SchedulersController, type: :controller do
       cname = Course.find(cid).name
       s = create_scheduler_with_cid(cid)
       it "renders successfully" do
-        get :show, params: {course_name: cname, id: s.id}
+        get :show, params: { course_name: cname, id: s.id }
         expect(response).to be_successful
         expect(response.body).to match(/Action:/m)
         expect(response.body).to match(/Interval:/m)
@@ -172,7 +170,7 @@ RSpec.describe SchedulersController, type: :controller do
       cname = Course.find(cid).name
       s = create_scheduler_with_cid(cid)
       it "renders successfully" do
-        get :show, params: {course_name: cname, id: s.id}
+        get :show, params: { course_name: cname, id: s.id }
         expect(response).to be_successful
         expect(response.body).to match(/Action:/m)
         expect(response.body).to match(/Interval:/m)
@@ -186,7 +184,7 @@ RSpec.describe SchedulersController, type: :controller do
       cname = Course.find(cid).name
       s = create_scheduler_with_cid(cid)
       it "renders with failure" do
-        get :show, params: {course_name: cname, id: s.id}
+        get :show, params: { course_name: cname, id: s.id }
         expect(response).not_to be_successful
         expect(response.body).not_to match(/Action:/m)
         expect(response.body).not_to match(/Interval:/m)
@@ -196,10 +194,9 @@ RSpec.describe SchedulersController, type: :controller do
     context "when user is not logged in" do
       u = get_admin
       cid = get_course_id_by_uid(u.id)
-      cname = Course.find(cid).name
       s = create_scheduler_with_cid(cid)
       it "renders with failure" do
-        get :show, params: {course_name: "dummy", id: s.id}
+        get :show, params: { course_name: "dummy", id: s.id }
         expect(response).not_to be_successful
         expect(response.body).not_to match(/Action:/m)
         expect(response.body).not_to match(/Interval:/m)

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe UsersController, type: :controller do
       u = get_admin
       login_as(u)
       it "renders successfully" do
-        get :show, params: {id: u.id}
+        get :show, params: { id: u.id }
         expect(response).to be_successful
         expect(response.body).to match(/Contact/m)
         expect(response.body).to match(/About/m)
@@ -87,7 +87,7 @@ RSpec.describe UsersController, type: :controller do
       u = get_user
       login_as(u)
       it "renders successfully" do
-        get :show, params: {id: u.id}
+        get :show, params: { id: u.id }
         expect(response).to be_successful
         expect(response.body).to match(/Contact/m)
         expect(response.body).to match(/About/m)
@@ -99,7 +99,7 @@ RSpec.describe UsersController, type: :controller do
 
     context "when user is not logged in" do
       it "renders with failure" do
-        get :show, params: {id: 0}
+        get :show, params: { id: 0 }
         expect(response).not_to be_successful
         expect(response.body).not_to match(/Showing user/m)
       end

--- a/spec/features/manage_submissions_spec.rb
+++ b/spec/features/manage_submissions_spec.rb
@@ -3,7 +3,7 @@ require_relative("../support/controller_macros")
 include ControllerMacros
 
 RSpec.describe "manage submissions user flow", type: :feature do
-  describe "click button", js: :true do
+  describe "click button", js: true do
     context "when user is Instructor" do
       # can't use login_as for features
       user_id = User.create!(email: "autolabintructor@foo.bar",

--- a/spec/models/annotation_spec.rb
+++ b/spec/models/annotation_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Annotation, type: :model do
                                     value: 20,
                                     submitted_by: 'admin@foo.bar')
 
-    annotation.update_non_autograded_score()
+    annotation.update_non_autograded_score
 
     # need to force reload lookup of score to avoid caching
     expect(Score.find(score.id).score).to eq(max_score + 20)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,7 +1,7 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 ENV["RAILS_ENV"] ||= "test"
 require "spec_helper"
-require File.expand_path("../../config/environment", __FILE__)
+require File.expand_path('../config/environment', __dir__)
 require "rspec/rails"
 require 'capybara/rspec'
 require 'capybara/rails'
@@ -9,7 +9,7 @@ require "devise"
 require "selenium/webdriver"
 
 # Requires supporting ruby files in spec/support/ and its subdirectories.
-Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }
+Dir[Rails.root.join("spec/support/**/*.rb")].sort.each { |f| require f }
 
 # Checks for pending migrations before tests are run.
 # If you are not using ActiveRecord, you can remove this line.

--- a/spec/support/controller_macros.rb
+++ b/spec/support/controller_macros.rb
@@ -118,8 +118,9 @@ module ControllerMacros
                          released: true)
 
     att.file = Rack::Test::UploadedFile.new(
-      path = Rails.root.join("attachments", File.basename(course_att_file)), content_type = "text/plain",
-      tempfile = Tempfile.new("attach.tmp")
+      Rails.root.join("attachments/#{File.basename(course_att_file)}"),
+      "text/plain",
+      Tempfile.new("attach.tmp")
     )
     att.save
     att
@@ -159,15 +160,15 @@ module ControllerMacros
 
     FactoryBot.create(:course_user_datum, course: course, user: instructor_user, instructor: true)
 
-    course_assistant = FactoryBot.create(:course_user_datum, course: course,
-                                                             user: course_assistant_user,
-                                                             instructor: false, course_assistant: true)
+    FactoryBot.create(:course_user_datum, course: course,
+                                          user: course_assistant_user,
+                                          instructor: false, course_assistant: true)
 
     students = FactoryBot.create_list(:student, students_count, course: course).each do |cud|
       cud.user = FactoryBot.create(:user)
     end
 
-    { course: course, admin_user: admin_user, 
+    { course: course, admin_user: admin_user,
       instructor_user: instructor_user, course_assistant_user: course_assistant_user,
       students_cud: students }
   end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

As we move towards increasing test coverage across the Autolab repository, This PR enables rubocop linting across the directory, and also fixes linting errors brought on by enabling rubocop

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Setup testing db
```
RAILS_ENV=test bundle exec rails autolab:setup_test_env
```
- Run tests, see that all tests still pass
```
bundle exec rails spec
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
