### PR TITLE
Fix bug in GitHub api rate limit check

### DIFF
--- a/app/models/github_integration.rb
+++ b/app/models/github_integration.rb
@@ -134,7 +134,8 @@ class GithubIntegration < ApplicationRecord
     begin
       limit = client.rate_limit!
     rescue StandardError
-      limit = { limit: 0 }
+      limit = ActiveSupport::OrderedOptions.new
+      limit.limit = 0
     end
     limit
   end


### PR DESCRIPTION


## Description
`Hash` values cannot be accessed like methods, making the code in the `rescue` clause of `check_github_authorization` invalid. This code is usually unreachable, even with incorrect GitHub key information or none at all. But when reached, it breaks a bunch of things including assessment creation since many pages do a check for whether GitHub integration is enabled.

## How Has This Been Tested?
Before:

![image](https://user-images.githubusercontent.com/14984764/220546819-9c876a8b-7948-4ff6-aa81-accdd07eedc6.png)
After:

![image](https://user-images.githubusercontent.com/14984764/220546916-c27bdc86-98c0-4d61-9313-88f19c104a7a.png)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have run rubocop for style check.

