### PR TITLE
Grade Export: Move total column to be after email

### DIFF
--- a/app/helpers/assessment_helper.rb
+++ b/app/helpers/assessment_helper.rb
@@ -47,9 +47,8 @@ module AssessmentHelper
   def gradesheet_csv(asmt, as_seen_by)
     CSV.generate do |csv|
       # title row with the column names:
-      title = ["Submission Time:","Email:"]
+      title = ["Submission Time:","Email:","Total:"]
       asmt.problems.each { |problem| title << "#{problem.name}:" }
-      title << "Total:"
       csv << title
 
       asmt.course.course_user_data.each do |cud|
@@ -92,17 +91,17 @@ private
                     Array.new asmt.problems.count
     end
 
-    # add scores to csv row (for scores columns)
-    row.concat score_cells
-
-    # add AUD status (see AUD.status method) as final column
+    # add AUD status (see AUD.status method)
     final = aud.status as_seen_by
     row << case final
-      when Symbol
-        final
-      when Float
-        round final
-    end
+           when Symbol
+             final
+           when Float
+             round final
+           end
+
+    # add scores to csv row (for scores columns)
+    row.concat score_cells
 
     row
   end

--- a/app/views/assessments/_bulkGrade_initial.html.erb
+++ b/app/views/assessments/_bulkGrade_initial.html.erb
@@ -29,8 +29,8 @@ Choose a file that contain rows of problem scores or feedback in the following c
   </div>
 
   <p>
-    We will show you a preview of the uploaded data before it used to update grades. The update will occur as a 
-    <a href="http://en.wikipedia.org/wiki/Database_transaction#Transactional_databases">transaction</a>,
+    We will show you a preview of the uploaded data before it is used to update grades. The update will occur as a
+    <a href="https://en.wikipedia.org/wiki/Database_transaction#Transactional_databases">transaction</a>,
     allowing you to correct errors and re-submit.
   </p>
   <%= f.submit 'Start', { :class => "btn primary"} %>


### PR DESCRIPTION
## Description
Reorder columns of CSV file generated by grade export so that total column is after the email column, rather than at the end.

## Motivation and Context
This makes it easier to process final grades via scripts.

Closes #1728

## How Has This Been Tested?
Create an assessment with multiple problems, where some students have submitted and some have not. Export grades.

**Before**
![Screenshot 2023-03-13 at 00 03 58](https://user-images.githubusercontent.com/9074856/224605632-e0dbdb6e-db5b-4c19-b486-88745330235a.png)

**After**
![Screenshot 2023-03-13 at 00 03 53](https://user-images.githubusercontent.com/9074856/224605622-db67d434-2ac7-45da-bdd8-38793f394d5e.png)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR