### PR TITLE
Remove unused "Additional Submission Form" feature code

### DIFF
--- a/app/controllers/assessment/handin.rb
+++ b/app/controllers/assessment/handin.rb
@@ -354,8 +354,6 @@ module AssessmentHandin
       return false
     end
 
-    validate_custom_form
-
     validity = validateHandin(params[:submission]["file"].size,
                               params[:submission]["file"].content_type,
                               params[:submission]["file"].original_filename)
@@ -399,18 +397,6 @@ module AssessmentHandin
 
     flash[:error] = msg
     return false
-  end
-
-  def validate_custom_form
-    # check if custom form exists
-    if @assessment.has_custom_form
-      for i in 0..@assessment.getTextfields.size - 1
-        if params[:submission][("formfield" + (i + 1).to_s).to_sym].blank?
-          flash[:error] = @assessment.getTextfields[i] + " is a required field."
-          return false
-        end
-      end
-    end
   end
 
   def handle_validity(validity)

--- a/app/helpers/assessment_autograde_core.rb
+++ b/app/helpers/assessment_autograde_core.rb
@@ -330,7 +330,6 @@ module AssessmentAutogradeCore
     local_handin = File.join(ass_dir, assessment.handin_directory, submission.filename)
     local_makefile = File.join(ass_dir, "autograde-Makefile")
     local_autograde = File.join(ass_dir, "autograde.tar")
-    local_settings_config = File.join(ass_dir, assessment.handin_directory, submission.filename + ".settings.json")
 
     # Name of the handin file on the destination machine
     dest_handin = assessment.handin_filename
@@ -339,14 +338,8 @@ module AssessmentAutogradeCore
     handin = { "localFile" => local_handin, "destFile" => dest_handin }
     makefile = { "localFile" => local_makefile, "destFile" => "Makefile" }
     autograde = { "localFile" => local_autograde, "destFile" => "autograde.tar" }
-    settings_config = { "localFile" => local_settings_config, "destFile" => "settings.json" }
 
-    if assessment.has_custom_form
-        [handin, makefile, autograde, settings_config]
-    else
-        [handin, makefile, autograde]
-    end
-    
+    [handin, makefile, autograde]
   end
 
   ##

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -90,14 +90,6 @@ class Assessment < ApplicationRecord
     Time.current <= grading_deadline
   end
 
-  def getLanguages
-    languages.split(/\s*,\s*/)
-  end
-
-  def getTextfields
-    textfields.split(/\s*,\s*/)
-  end
-
   def folder_path
     Rails.root.join("courses", course.name, name)
   end

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -114,34 +114,7 @@ class Submission < ApplicationRecord
     elsif upload["tar"]
       self.mime_type = "application/x-tgz"
     end
-    save_additional_form_fields(upload)
     save!
-    settings_file = "#{course_user_datum.user.email}_#{version}" \
-                    "_#{assessment.handin_filename}.settings.json"
-
-    settings_path = Rails.root.join("courses",
-                                    course_user_datum.course.name,
-                                    assessment.name, directory, settings_file)
-
-    File.open(settings_path, "wb") { |f| f.write(settings) }
-  end
-
-  def save_additional_form_fields(params)
-    form_hash = {}
-    form_hash["Language"] = params["lang"] if params["lang"]
-    form_hash[assessment.getTextfields[0]] = params["formfield1"] if params["formfield1"]
-    form_hash[assessment.getTextfields[1]] = params["formfield2"] if params["formfield2"]
-    form_hash[assessment.getTextfields[2]] = params["formfield3"] if params["formfield3"]
-    self.settings = form_hash.to_json
-    save!
-  end
-
-  def get_settings
-    if settings
-      JSON.parse(settings)
-    else
-      {}
-    end
   end
 
   def archive_handin

--- a/app/views/assessments/_edit_basic.html.erb
+++ b/app/views/assessments/_edit_basic.html.erb
@@ -23,15 +23,6 @@
 	<%= f.text_field :writeup, help_text: "File path from the assessment directory containing instructions to students, or a URL to redirect to.", placeholder: "E.g.   writeup.pdf   or   http://school.edu/class/writeup.pdf" %>
 </div>
 
-<!--
-<h4>Additional Submission Form</h4>
-<div class="form-group">
-    <span class="" onclick="validate();"><%= f.check_box :has_custom_form, class: "",
-    display_name: "Use custom submission form?",
-    help_text: "Whether to require a custom form while submitting files for this assignment. Please note that changing the form after submissions have begun may result in unexpected errors." %></span>
-<div id = "moreOptions" style="display:none"><%= f.text_field :languages, :size => 75, help_text: "Multiple Language Support: Programming Languages that the assessment can be submitted in (separated by comma)" %><%= f.text_field :textfields, :size => 75, help_text: "Any additional textfields (upto 3) that need to be filled in at the time of submission (separated by comma)" %></div>
-</div>
--->
 <h4>Modules Used</h4>
 <ul class="collection attachments">
   <li class="collection-item">

--- a/app/views/assessments/_handin_form.html.erb
+++ b/app/views/assessments/_handin_form.html.erb
@@ -44,25 +44,6 @@
           <% end %>
         <% elsif ! @assessment.disable_handins? and !@assessment.embedded_quiz then %>
           <%= form_for @submission, url: {action: :handin}, :html => {:name => "submissionForm", :onclick => "return validateIntegrity();"}, multipart: true do |f| %>
-            <% if @assessment.has_custom_form then %>
-              <% if @assessment.getLanguages.size > 0 %>
-                  <p><%= f.label :lang, 'Language *:' %>
-                  <%= f.select :lang, @assessment.getLanguages %></p>
-              <% end %>
-              <% if @assessment.getTextfields.size > 3 then %>
-                  <% for i in 1..3 do %>
-                      <p><%= f.label ("formfield" + i.to_s).to_sym, @assessment.getTextfields[i-1] + " *:" %></p>
-                      <p><%= f.text_field ("formfield" + i.to_s).to_sym %></p>
-                  <% end %>
-                  <p class="help-block">* denotes required fields. The submission cannot be completed without filling out the required fields.</p>
-              <% else %>
-                  <% for i in 1..@assessment.getTextfields.size do %>
-                      <p><%= f.label ("formfield" + i.to_s).to_sym, @assessment.getTextfields[i-1] + " *:"%></p>
-                      <p><%= f.text_field ("formfield" + i.to_s).to_sym %></p>
-                  <% end %>
-                  <p>* denotes required fields. The submission cannot be completed without filling out the required fields.</p>
-              <% end %>
-            <% end %>
             <% content_for :javascripts do %>
               <%= javascript_include_tag "handin" %>
               <%= javascript_include_tag "git_submission" %>

--- a/app/views/submissions/index.html.erb
+++ b/app/views/submissions/index.html.erb
@@ -72,14 +72,6 @@
 </div>
 <table class="prettyBorder" id="submissions">
   <% headers = ["Submitted By", "Version", "Score", "Submission Date (YYYY-MM-DD)", "File", "IP Address", "Actions", "isLatest"] %>
-  <% if @assessment.has_custom_form then %>
-    <% if @assessment.getLanguages.size > 0 then %>
-        <% headers.push("Language") %>
-    <% end %>
-    <% for i in 0..@assessment.getTextfields.size - 1 do %>
-        <% headers.push(@assessment.getTextfields[i]) %>
-    <% end %>
-  <% end %>
   <thead>
     <tr>
       <th></th>
@@ -139,16 +131,7 @@
             {:title=>"Destroy this submission forever",
               :class=>"btn small"} %>
       </td>
-      <td><%= submission.latest? %>
-      </td>
-      <% if @assessment.has_custom_form then %>
-        <% if @assessment.getLanguages.size > 0 then %>
-            <td><%= submission.get_settings["Language"] %></td>
-        <% end %>
-        <% for i in 0..@assessment.getTextfields.size-1 do %>
-            <td><%= submission.get_settings[@assessment.getTextfields[i]] %></td>
-        <% end %>
-     <% end %>
+      <td><%= submission.latest? %></td>
     </tr>
   <% end %>
   </tbody>

--- a/app/views/submissions/viewPDF.html.erb
+++ b/app/views/submissions/viewPDF.html.erb
@@ -148,14 +148,6 @@
         <i class="material-icons" aria-hidden="true">file_download</i>
         <span>Annotated</span>
       </a>
-      <% if @assessment.has_custom_form then %>
-        <% if @assessment.getLanguages.size > 0 then %>
-            <p><b>Language:</b> <%= @submission.get_settings["Language"] %></p>
-        <% end %>
-        <% for i in 0..@assessment.getTextfields.size-1 do %>
-            <p><b><%= @assessment.getTextfields[i] %>:</b> <%= @submission.get_settings[@assessment.getTextfields[i]] %></p>
-        <% end %>
-     <% end %>
     <% end %>
   </div>
   <div class="col l10">

--- a/db/migrate/20230313053555_remove_custom_form_field_from_assessments.rb
+++ b/db/migrate/20230313053555_remove_custom_form_field_from_assessments.rb
@@ -1,0 +1,13 @@
+require_relative '20160912012308_add_custom_form_field_to_assessments'
+require_relative '20160912012551_add_textfields_to_assessments'
+require_relative '20160912012406_add_languages_to_assessments'
+require_relative '20160912012512_add_settings_to_submissions'
+
+class RemoveCustomFormFieldFromAssessments < ActiveRecord::Migration[6.0]
+  def change
+    revert AddCustomFormFieldToAssessments
+    revert AddTextfieldsToAssessments
+    revert AddLanguagesToAssessments
+    revert AddSettingsToSubmissions
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -90,9 +90,6 @@ ActiveRecord::Schema.define(version: 2022_11_28_044321) do
     t.string "remote_handin_path"
     t.string "category_name"
     t.integer "group_size", default: 1
-    t.boolean "has_custom_form", default: false
-    t.text "languages"
-    t.text "textfields"
     t.text "embedded_quiz_form_data"
     t.boolean "embedded_quiz"
     t.binary "embedded_quiz_form"
@@ -332,7 +329,6 @@ ActiveRecord::Schema.define(version: 2022_11_28_044321) do
     t.integer "tweak_id"
     t.boolean "ignored", default: false, null: false
     t.string "dave", limit: 255
-    t.text "settings"
     t.text "embedded_quiz_form_answer"
     t.integer "submitted_by_app_id"
     t.string "group_key", default: ""

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_11_28_044321) do
+ActiveRecord::Schema.define(version: 2023_03_13_053555) do
 
   create_table "annotations", force: :cascade do |t|
     t.integer "submission_id"


### PR DESCRIPTION
## Description
- Remove unused `has_custom_form`, `languages`, `textfield` columns from assessments table
- Remove unused `settings` column from submissions table
- Remove dead code associated with "Additional Submission Form" feature

## Motivation and Context
In #782, the "Additional Submission Form" feature was added

What it would have roughly looked like:
![image2](https://user-images.githubusercontent.com/9074856/224618613-6625a33b-9389-4a19-95b2-b8e407cd8cba.png)

However, the feature was removed soon after in #803, but left behind dead code (some found in #1201, #1203). In particular, there are 4 unused database columns, and every submission makes a useless `.settings.json` file.

This PR cleans up the dead code once and for all.

## How Has This Been Tested?
Make a submission, ensure autograding still works. Note that there is no `<email>_<ver>_<handin name>.settings.json` file created inside `<course>/<asmt>/handin`

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR
