### PR TITLE
Fix annotated PDF download when global annotation is present

### DIFF
--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -230,7 +230,7 @@ class SubmissionsController < ApplicationController
 
       Prawn::Document.generate(@filename_annotated, template: @filename) do |pdf|
         @annotations.each do |annotation|
-          return if annotation.coordinate.nil?
+          next if annotation.coordinate.nil?
 
           position = annotation.coordinate.split(",")
           page  = position[2].to_i


### PR DESCRIPTION
## Description
When rendering an annotated pdf, use `next`, rather than `return` when `annotation.coordinate` is `nil`.

## Motivation and Context
Currently, the "download annotated" button doesn't work for PDF submissions if a global annotation is present. This is because global annotations do not have coordinates associated, and the current logic is to `return` from the loop.

![Screenshot 2023-03-13 at 23 21 59](https://user-images.githubusercontent.com/9074856/224884902-bcf1099e-c1f4-4967-854c-34a92bdf9006.png)

This is not what we want to do, because rails then attempts to render a erb template that does not exist (by default, when control reaches the end of a controller, rails renders the erb template of the same name). Instead, we should simply skip the particular annotation.

Note: Global annotations are purposely not rendered on the pdf, since imo that's not what they're meant for.

## How Has This Been Tested?

1. Create an assessment that accepts PDFs (remember to set handin filename).

2. Make a submission, and then make a PDF annotation (click on the pdf) + a global annotation.

![Screenshot 2023-03-13 at 23 23 08](https://user-images.githubusercontent.com/9074856/224885033-029dd421-e00b-438f-b74b-9c9b4f391adf.png)

4. Click the "Download Annotated" button (top right corner, next to "Download File").

![Screenshot 2023-03-13 at 23 23 40](https://user-images.githubusercontent.com/9074856/224885118-65a0bd18-5b33-4c93-9751-0499fb83e65f.png)

**Before**
![Screenshot 2023-03-13 at 23 16 41](https://user-images.githubusercontent.com/9074856/224884306-062a5d57-31a8-47e0-9e49-9675f6e5aefc.png)

**After**
![Screenshot 2023-03-13 at 23 16 47](https://user-images.githubusercontent.com/9074856/224884308-888e75dd-dc58-45e9-800f-5b507434e337.png)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR