### PR TITLE
Course start/end date nil checks

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -125,6 +125,8 @@ class Course < ApplicationRecord
   end
 
   def order_of_dates
+    return if start_date.nil? || end_date.nil?
+
     errors.add(:start_date, "must come before end date") if start_date > end_date
   end
 


### PR DESCRIPTION
## Description
In `/app/models/course.rb` the `order_of_dates` validation, which compares `start_date` and `end_date`, would run even if the `presence: true` validations (nil checks) for the dates failed. A `.nil?` check was added to `order_of_dates` to fix this bug.

## Motivation and Context
Previously, trying to edit course settings with no specified start date or end date would cause the following:

<img width="1440" alt="Screenshot 2023-03-15 at 12 10 10 AM" src="https://user-images.githubusercontent.com/66969001/225206126-544675c8-29e0-4dfb-8ddd-e9f234423a37.png">

Now, trying to do so will properly raise the following error to the user:

<img width="1033" alt="image" src="https://user-images.githubusercontent.com/66969001/225205694-5fbb8e9c-ec14-4fc2-963a-48d9debd232e.png">

## How Has This Been Tested?
Go to any course -> Manage Course -> Course settings -> click on either start date or end date and press backspace key to remove the date selection -> Save.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR
