### PR TITLE
Update MacOS install docs to use Homebrew

### DIFF
--- a/docs/installation/osx.md
+++ b/docs/installation/osx.md
@@ -7,14 +7,14 @@ Follow the step-by-step instructions below:
     -  <a href="https://www.tutorialspoint.com/sqlite/sqlite_installation.htm" target="_blank">SQLite</a> should **only** be used in development
     -  <a href="https://dev.mysql.com/doc/refman/8.0/en/macos-installation-pkg.html" target="_blank">MySQL</a> can be used in development or production
 
-2. Install <a href="https://github.com/sstephenson/rbenv" target="_blank">rbenv</a> (use the Basic GitHub Checkout method)
+2. Install <a href="https://brew.sh/"> homebrew </a>
 
-3. Install <a href="https://github.com/sstephenson/ruby-build" target="_blank">ruby-build</a> as an rbenv plugin:
-
+3. Install <a href="https://github.com/sstephenson/rbenv" target="_blank">rbenv</a> and ruby-build using homebrew:
+       
         :::bash
-        git clone https://github.com/sstephenson/ruby-build.git ~/.rbenv/plugins/ruby-build
-
-    Restart your shell at this point in order to start using your newly installed rbenv
+        brew install rbenv ruby-build
+    
+    Restart your shell at this point in order to start using your newly installed rbenv.
 
 4. Clone the Autolab repo into home directory and enter it:
 
@@ -56,10 +56,9 @@ Follow the step-by-step instructions below:
 
     Refer to [Troubleshooting](/installation/troubleshoot) for issues installing gems
 
-8. Install <a href="https://brew.sh/" target="_blank">homebrew</a>, as well as the <a href="https://github.com/universal-ctags/homebrew-universal-ctags" target="_blank">universal-ctags</a> package:
+8. Install the <a href="https://github.com/universal-ctags/homebrew-universal-ctags" target="_blank">universal-ctags</a> package:
 
         :::bash
-        /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
         brew install --HEAD universal-ctags/universal-ctags/universal-ctags
 
     Afterward, run `which ctags` to ensure that the package lies on your `PATH` and can be found.
@@ -125,4 +124,4 @@ as well.
 
 19. If you would like to configure LTI integration to link Autolab courses to LTI platforms, please follow the [LTI integration setup instructions](/installation/lti_integration).
 
-19. Now you are all set to start using Autolab! Please fill out [this form](https://docs.google.com/forms/d/e/1FAIpQLSctfi3kwa03yuCuLgGF7qS_PItfk__1s80twhVDiKGQHvqUJg/viewform?usp=sf_link) to join our registry so that we can provide you with news about the latest features, bug-fixes, and security updates. For more info, visit the [Guide for Instructors](/instructors) and [Guide for Lab Authors](/lab).
+20. Now you are all set to start using Autolab! Please fill out [this form](https://docs.google.com/forms/d/e/1FAIpQLSctfi3kwa03yuCuLgGF7qS_PItfk__1s80twhVDiKGQHvqUJg/viewform?usp=sf_link) to join our registry so that we can provide you with news about the latest features, bug-fixes, and security updates. For more info, visit the [Guide for Instructors](/instructors) and [Guide for Lab Authors](/lab).

--- a/docs/installation/troubleshoot.md
+++ b/docs/installation/troubleshoot.md
@@ -154,3 +154,26 @@ it is likely that you need to purge the cache. This is because `FileStore` cache
 To purge the cache, click on `Manage Autolab` followed by `Clear Cache` to clear expired entries.
 
 Alternatively, run `rake user:cleanup_cache` (to clear expired entries) or `rake user:clear_cache` (to clear **all** entries) in your terminal.
+
+#### MacOS: OpenSSL error
+
+If you get the following error when trying to run rake or rails
+
+
+```bash
+Library not loaded: libssl.1.1.dylib (LoadError)
+```
+
+paths to OpenSSL may not be properly set up. To enable proper linking:
+
+```bash
+brew install openssl@1.1
+brew link openssl@1.1. --force
+```
+
+You may need to export paths as well during this process, which homebrew will display. You may also need to reinstall the
+`mysql2` gem (the following command is for Apple Silicon):
+
+```bash
+gem install mysql2 -v "{version}" -- --with-ldflags=-L/opt/homebrew/opt/openssl@1.1/lib --with-cppflags=-I/opt/homebrew/opt/openssl@1.1/include
+```


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Update MacOS docs for an easier installation process, by recommending using homebrew to install rbenv and ruby-build, instead of from cloning the github source. Homebrew is more convenient, and less likely to cause build errors due to weird dependency issues.

Also add a section in troubleshooting for an OpenSSL related LoadError, due to paths mismatch.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Recently had to reinstall Autolab, found that using Homebrew just worked very easily.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Run docs server locally, checked that `installation/troubleshoot/` and `installation/osx` look okay with new changes.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have updated the documentation accordingly, included in this PR