### PR TITLE
Update Docs to use bash to run init-letsencrypt.sh instead of sh

### DIFF
--- a/docs/installation/docker-compose.md
+++ b/docs/installation/docker-compose.md
@@ -101,7 +101,7 @@ There are three options for TLS: using Let's Encrypt (for free TLS certificates)
 2. Ensure that port 443 is exposed on your server (i.e checking your firewall, AWS security group settings, etc)
 3. In `ssl/init-letsencrypt.sh`, change `domains=(example.com)` to the list of domains that your host is associated with, and change `email` to be your email address so that Let's Encrypt will be able to email you when your certificate is about to expire
 4. If necessary, change `staging=0` to `staging=1` to avoid being rate-limited by Let's Encrypt since there is a limit of 20 certificates/week. Setting this is helpful if you have an experimental setup.
-5. Run your modified script: `sudo sh ./ssl/init-letsencrypt.sh`
+5. Run your modified script: `sudo ./ssl/init-letsencrypt.sh`
 
 ### Option 2: Using your own TLS certificate
 1. Copy your private key to `ssl/privkey.pem`


### PR DESCRIPTION
This is my first PR, please let me know if something does not look right.

## Description
I changed the command to run the LetsEncrypt Initialization script to `sudo ./ssl/init-letsencrypt.sh` so it would run in the specified shell at the top of the file  (`#!/bin/bash`) instead of `sh`.

## Motivation and Context
The LetsEncrypt guide In the docker installation docs uses the command `sudo sh ./ssl/init-letsencrypt.sh` to generate the certificates. This runs the script using `sh`, which breaks on line 10:
```
domains=(example.com) # Update this to your domains
```
with
```
Syntax error: "(" unexpected
```
because `domains=(example.com)` is bash syntax that does not work in `sh`.

## Checklist:
- [x] I have updated the documentation accordingly, included in this PR


