### PR TITLE
Add warning to documentation about RAM requirements

### DIFF
--- a/docs/installation/docker-compose.md
+++ b/docs/installation/docker-compose.md
@@ -35,6 +35,10 @@ First ensure that you have Docker and Docker Compose installed on your machine. 
         :::bash
         docker compose build
 
+    !!! warning "RAM requirements"
+        You may face issues on a machine with less than 2GB of RAM as the gem `sassc` takes a significant amount of RAM to install.
+
+
 6. Run the Docker containers:
 
         :::bash

--- a/docs/installation/docker-compose.md
+++ b/docs/installation/docker-compose.md
@@ -35,10 +35,6 @@ First ensure that you have Docker and Docker Compose installed on your machine. 
         :::bash
         docker compose build
 
-    !!! warning "RAM requirements"
-        You may face issues on a machine with less than 2GB of RAM as the gem `sassc` takes a significant amount of RAM to install.
-
-
 6. Run the Docker containers:
 
         :::bash

--- a/docs/installation/osx.md
+++ b/docs/installation/osx.md
@@ -54,7 +54,10 @@ Follow the step-by-step instructions below:
         cd bin
         bundle install
 
-    Refer to [Troubleshooting](/installation/troubleshoot) for issues installing gems
+    !!! warning "RAM requirements"
+        You may face issues on a machine with less than 2GB of RAM as the gem `sassc` takes a significant amount of RAM to install.
+
+        Refer to [Troubleshooting](/installation/troubleshoot) for issues installing gems.
 
 8. Install the <a href="https://github.com/universal-ctags/homebrew-universal-ctags" target="_blank">universal-ctags</a> package:
 

--- a/docs/installation/osx.md
+++ b/docs/installation/osx.md
@@ -54,10 +54,7 @@ Follow the step-by-step instructions below:
         cd bin
         bundle install
 
-    !!! warning "RAM requirements"
-        You may face issues on a machine with less than 2GB of RAM as the gem `sassc` takes a significant amount of RAM to install.
-
-        Refer to [Troubleshooting](/installation/troubleshoot) for issues installing gems.
+    Refer to [Troubleshooting](/installation/troubleshoot) for issues installing gems.
 
 8. Install the <a href="https://github.com/universal-ctags/homebrew-universal-ctags" target="_blank">universal-ctags</a> package:
 

--- a/docs/installation/overview.md
+++ b/docs/installation/overview.md
@@ -5,5 +5,7 @@ There are 2 different ways to install Autolab and Tango:
   1. The simplest and fastest way to get up and running is to use our [Docker Compose installation](/installation/docker-compose/), which is ideal for most workloads. Both production-ready and testing deployments are available. This will set-up containers for Autolab, Tango, and other required services.
   2. You can also install Autolab manually. There are instructions for installing Autolab on [Ubuntu 18.04](/installation/ubuntu) and on [Mac OSX 10.11+](/installation/osx). The instructions for [installing Tango manually](/installation/tango) are the same for both environments.
 
-
 Most of our users prefer the Docker Compose installation method as it is simpler, production-ready, and comes deployed with MySQL and TLS/SSL. 
+
+!!! warning "RAM requirements"
+    You may face issues on a machine with less than 2GB of RAM as the gem `sassc` takes a significant amount of RAM to install.

--- a/docs/installation/troubleshoot.md
+++ b/docs/installation/troubleshoot.md
@@ -95,12 +95,12 @@ Mysql2::Error: You have an error in your SQL syntax
 this may be an issue with using an incompatible version of MySQL. Try switching to MySQL 5.7 if you are currently using a different version.
 
 #### Undefined method 'devise' for User
-You most likely missed the step of copying 'config/initializers/devise.rb.template' to 'config/initializers/devise.rb' and setting your secret key in the setup instructions.
+You most likely missed the step of copying `config/initializers/devise.rb.template` to `config/initializers/devise.rb` and setting your secret key in the setup instructions.
 
 #### Suggested Development Configuration for config/database.yml
 
 **MySQL**
-Change the <username> and <password> fields in config/database.yml to the username and password that has been set up for the mysql. For example if your username is `user1`, and your password is `123456`, then your yml would be
+Change the <username> and <password> fields in `config/database.yml` to the username and password that has been set up for the mysql. For example if your username is `user1`, and your password is `123456`, then your yml would be
 
     :::yml
     development:
@@ -126,7 +126,7 @@ Change the <username> and <password> fields in config/database.yml to the userna
             sql_mode: NO_ENGINE_SUBSTITUTION
 
 **SQLite**
-Comment out the configurations meant for MySQL in config/database.yml, and insert the following
+Comment out the configurations meant for MySQL in `config/database.yml`, and insert the following
 
     :::yml
     development:

--- a/docs/installation/ubuntu.md
+++ b/docs/installation/ubuntu.md
@@ -68,6 +68,11 @@ Following instructions from <a href="https://www.digitalocean.com/community/tuto
         rbenv rehash
         bundle install
 
+    !!! warning "RAM requirements"
+        You may face issues on a machine with less than 2GB of RAM as the gem `sassc` takes a significant amount of RAM to install.
+
+        Refer to [Troubleshooting](/installation/troubleshoot) for issues installing gems.
+
 9. Initializing Autolab Configs
 
         :::bash

--- a/docs/installation/ubuntu.md
+++ b/docs/installation/ubuntu.md
@@ -68,10 +68,7 @@ Following instructions from <a href="https://www.digitalocean.com/community/tuto
         rbenv rehash
         bundle install
 
-    !!! warning "RAM requirements"
-        You may face issues on a machine with less than 2GB of RAM as the gem `sassc` takes a significant amount of RAM to install.
-
-        Refer to [Troubleshooting](/installation/troubleshoot) for issues installing gems.
+    Refer to [Troubleshooting](/installation/troubleshoot) for issues installing gems.
 
 9. Initializing Autolab Configs
 


### PR DESCRIPTION
## Description
Add a warning to docker-compose install that a machine should have at least 2GB of RAM.

Also touched up some formatting.

## Motivation and Context
Users have reported issues following the docker-compose installation method on machines that have very little RAM. This PR updates the installation documentation to reflect this.

## How Has This Been Tested?
Run `mkdocs serve`.

**Installation overview page:**
<img width="977" alt="Screenshot 2023-03-29 at 20 45 49" src="https://user-images.githubusercontent.com/9074856/228699375-72c5b12e-7c8a-4984-a1c5-c066045e860f.png">

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [x] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [x] I have updated the documentation accordingly, included in this PR