### PR TITLE
Avoid rounding final score during bulk grade export

### DIFF
--- a/app/helpers/assessment_helper.rb
+++ b/app/helpers/assessment_helper.rb
@@ -97,12 +97,7 @@ private
 
     # add AUD status (see AUD.status method) as final column
     final = aud.status as_seen_by
-    row << case final
-      when Symbol
-        final
-      when Float
-        round final
-    end
+    row << final
 
     row
   end


### PR DESCRIPTION
## Description
Remove `round`ing of floats when computing total score during bulk grade export.

## Motivation and Context
Currently, the `total` column is rounded to 1 decimal digit. This means that the total and hence the student's semester grade might be incorrect.

Closes #1859

## How Has This Been Tested?
Make a student submission, annotate it with e.g. `0.12345`. Bulk export grades.

**Before**
![Screenshot 2023-03-28 at 23 52 57](https://user-images.githubusercontent.com/9074856/228422507-0aca6a0f-4b72-43cb-8dc9-25ae0cff6e00.png)

**After**
![Screenshot 2023-03-28 at 23 52 41](https://user-images.githubusercontent.com/9074856/228422473-46cadca1-228e-4a0d-9651-f4734dfaad37.png)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR