### PR TITLE
Make moss page for current course only

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -492,8 +492,7 @@ class CoursesController < ApplicationController
   end
 
   action_auth_level :moss, :instructor
-  def moss
-  end
+  def moss; end
 
   LANGUAGE_WHITELIST = %w[c cc java ml pascal ada lisp scheme haskell fortran ascii vhdl perl
                           matlab python mips prolog spice vb csharp modula2 a8086 javascript plsql

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -493,11 +493,6 @@ class CoursesController < ApplicationController
 
   action_auth_level :moss, :instructor
   def moss
-    @courses = Course.all.select do |course|
-      @cud.user.administrator ||
-        !course.course_user_data.joins(:user).find_by(users: { email: @cud.user.email },
-                                                      instructor: true).nil?
-    end
   end
 
   LANGUAGE_WHITELIST = %w[c cc java ml pascal ada lisp scheme haskell fortran ascii vhdl perl

--- a/app/views/courses/moss.html.erb
+++ b/app/views/courses/moss.html.erb
@@ -6,7 +6,7 @@
 	<ul class="collection" style="text-align: center; font-size: 18px;">
 		<li class="collection-item add">
 			<p>You do not seem to have any assessments in this course to be able to run the Cheat Checker</p>
-			<a title="Install an assessment" class="btn btn-large red darken-3" href=<%= install_assessment_course_assessments_path(@course) %> style="font-size: 18px;">Add an Assessment</a>
+			<%= link_to "<i class='material-icons left'>assignment</i> Install Assessment".html_safe, install_assessment_course_assessments_path(@course), { title: "Install Assessment", class: "btn btn-large red darken-3" } %>
 		</li>
 
 	</ul>
@@ -77,7 +77,7 @@
 							<span> Language </span>
 						</label>
 						<br>
-						<div id='<%= a.id %>OptionsDiv' style="margin-right: 10px;" >
+						<div style="margin-right: 10px;" >
 							<div class="input-field">
 								<%= select_tag :language_selection, options_for_select([
 																																				 ["ASCII", "ascii"],
@@ -116,7 +116,7 @@
 							<span>Max Lines </span>
 						</label>
 						<br>
-						<div id='<%= a.id %>OptionsDiv' style="padding-left:10px;" >
+						<div style="padding-left:10px;" >
 							<%= number_field_tag "max_lines", "10", placeholder: "If you don't know what this is please read the Moss documentation before altering this value.", min: 1 %>
 						</div>
 					</li>
@@ -125,7 +125,7 @@
 							<%= check_box_tag "box_basefile", "1",false, :class => "filled-in" %>
 							<span>Base File Tar </span>
 						</label>
-						<div id='<%= a.id %>OptionsDiv' style="padding-left:10px;" >
+						<div style="padding-left:10px;" >
 							<div class="file-field input-field">
 								<div class="btn">
 									<span>Base File</span>

--- a/app/views/courses/moss.html.erb
+++ b/app/views/courses/moss.html.erb
@@ -1,177 +1,158 @@
 <% @title = "Moss Cheat Checker" %>
 
 <% content_for :javascripts do %>
-  <script type="text/javascript">
-    /**
-     * toggles the "style.display" of the element with the given id.
-     **/
-    function toggleOptions(id) {
-      var show = document.getElementById(id);
-      show.style.display = (show.style.display == "none")? "block" : "none";
-    }
+	<script type="text/javascript">
+		/**
+		 * toggles the "style.display" of the element with the given id.
+		 **/
+		function toggleOptions(id) {
+			var show = document.getElementById(id);
+			show.style.display = (show.style.display == "none")? "block" : "none";
+		}
 
-    function filterCourses(name) {
-      $(".filterableCourse").each( function() {
-        var course = this;
-        var keywords = name.split(" ");
-        var toShow = true;
-        for (var i=0; i<keywords.length; i++) {
-          if (course.id.toLowerCase().indexOf(keywords[i]) == -1)
-            toShow = false;
-        }
-        $(this).toggle(toShow);
-      });
-    }
-  
-  </script>
+	</script>
 <% end %>
 
 <h2>Run the Moss Cheat Checker</h2>
 
 <h4>Step 1:</h4>
-<p>Click on course names to see their assessments, then check box all of the assessments you want Moss to compare against. </br> If a course doesn't appear, ensure you are an instructor.</p>
+<p>Check the box of all the assessments you want to send to Moss for plagiarism checking.</p>
 
-<h5 style="display:inline">Filter Courses (Keywords Separated by Space): </h5>
-<div class="input-field">
-	<input placeholder="Course Name" type="text" onkeyup="filterCourses(this.value.toLowerCase())" style="margin-bottom: 10px;">
-</div>
 <%= form_tag([:run_moss, @course], multipart: true) do %>
-  <ul class="moss-list">
-  <% for course in @courses %>
-    <li class="filterableCourse" id="<%= course.display_name %>">
-      <h5 onclick="toggleOptions('<%= course.id %>Assessments')"> 
-        <%= course.full_name %>
-      </h5>
-      <ul id="<%= course.id %>Assessments" class="moss-inner-list" style="display:none" >
-      <% for a in course.assessments do %>
-		<li>
-		  <label>
-          	<%= check_box_tag "assessments[#{a.id}]","1",false, :class => "filled-in" %> 
-          	<span> <%= a.display_name %> </span>
-		  </label> 
-		  <br>
-          <div id='<%= a.id %>OptionsDiv' style="padding-left:10px;" >
-			<!-- <b>Is Archive:</b> -->
-			<label>
-				<%= check_box_tag "isArchive[#{a.id}]", :class => "filled-in" %>
-				<span>Is Archive: </span> 
-			</label>
-			</br>
-            <i>Check this if the submissions will need to be extracted. (The handin filename was: <%= a.handin_filename %>)</i>
-            <br>
-            <b>Files to send to Moss:</b>
-						<%= text_field_tag "files[#{a.id}]", "*hello.c *.c", required: true %>
-            <i>This can be file names (foo.c) or patterns(*.c), space-separated</i>
-            <br>
-          </div>
-        </li>
-      <% end %>
-      </ul>
-    </li>
-  <% end %>
-  </ul>
+	<ul class="moss-list">
+		<li class="filterableCourse" id="<%= @course.display_name %>">
+			<h5 onclick="toggleOptions('<%= @course.id %>Assessments')">
+				<%= @course.full_name %>
+			</h5>
+			<ul id="<%= @course.id %>Assessments" class="moss-inner-list">
+				<% for a in @course.assessments do %>
+					<li>
+						<label>
+							<%= check_box_tag "assessments[#{a.id}]","1",false, :class => "filled-in" %>
+							<span> <%= a.display_name %> </span>
+						</label>
+						<br>
+						<div id='<%= a.id %>OptionsDiv' style="padding-left:10px;" >
+							<!-- <b>Is Archive:</b> -->
+							<label>
+								<%= check_box_tag "isArchive[#{a.id}]", :class => "filled-in" %>
+								<span>Is Archive: </span>
+							</label>
+							</br>
+							<i>Check this if the submissions will need to be extracted. (The handin filename was: <%= a.handin_filename %>)</i>
+							<br>
+							<b>Files to send to Moss:</b>
+							<%= text_field_tag "files[#{a.id}]", "*hello.c *.c", required: true %>
+							<i>This can be file names (foo.c) or patterns(*.c), space-separated</i>
+							<br>
+						</div>
+					</li>
+				<% end %>
+			</ul>
+		</li>
+	</ul>
 
-  <br>
+	<br>
 
 	<h4>Step 2:</h4>
 	<p>(Optional) Add flags that will be run with moss.</p>
-  <ul class="moss-list">
-    <li class="filterableCourse" id="Moss Flags">
-    <h5 onclick="toggleOptions('flags')"> 
-	  	Moss Flags
-	  </h5>
-      <ul id="flags" class="moss-inner-list" style="display:none" >
-        <li>
+	<ul class="moss-list">
+		<li class="filterableCourse" id="Moss Flags">
+			<h5 onclick="toggleOptions('flags')">
+				Moss Flags
+			</h5>
+			<ul id="flags" class="moss-inner-list" style="display:none" >
+				<li>
 					<label>
-					<%= check_box_tag "box_language","1",false, :class => "filled-in" %> 
-					<span> Language </span>
+						<%= check_box_tag "box_language","1",false, :class => "filled-in" %>
+						<span> Language </span>
 					</label>
 					<br>
-					<div id='OptionsDiv' style="margin-right: 10px;" >
+					<div id='<%= a.id %>OptionsDiv' style="margin-right: 10px;" >
 						<div class="input-field">
 							<%= select_tag :language_selection, options_for_select([
-								["ASCII", "ascii"],
-								["Ada", "ada"],
-								["C", "c"],
-								["C#", "csharp"],
-								["C++", "cc"],
-								["FORTRAN", "fortran"],
-								["Haskell", "haskell"],
-								["Java", "java"],
-								["Javascript", "javascript"],
-								["Lisp", "lisp"],
-								["MIPS Assembly", "mips"],
-								["ML", "ml"],
-								["Matlab", "matlab"],
-								["Modula2", "modula2"],
-								["Pascal", "pascal"],
-								["Perl", "perl"],
-								["PL/SQL", "plsql"],
-								["Prolog", "prolog"],
-								["Python", "python"],
-								["Scheme", "scheme"],
-								["Spice", "spice"],
-								["VHDL", "vhdl"],
-								["Verilog", "verilog"],
-								["Visual Basic", "vb"],
-								["a8086 Assembly", "a8086"]
-							], "c") %>
+																																			 ["ASCII", "ascii"],
+																																			 ["Ada", "ada"],
+																																			 ["C", "c"],
+																																			 ["C#", "csharp"],
+																																			 ["C++", "cc"],
+																																			 ["FORTRAN", "fortran"],
+																																			 ["Haskell", "haskell"],
+																																			 ["Java", "java"],
+																																			 ["Javascript", "javascript"],
+																																			 ["Lisp", "lisp"],
+																																			 ["MIPS Assembly", "mips"],
+																																			 ["ML", "ml"],
+																																			 ["Matlab", "matlab"],
+																																			 ["Modula2", "modula2"],
+																																			 ["Pascal", "pascal"],
+																																			 ["Perl", "perl"],
+																																			 ["PL/SQL", "plsql"],
+																																			 ["Prolog", "prolog"],
+																																			 ["Python", "python"],
+																																			 ["Scheme", "scheme"],
+																																			 ["Spice", "spice"],
+																																			 ["VHDL", "vhdl"],
+																																			 ["Verilog", "verilog"],
+																																			 ["Visual Basic", "vb"],
+																																			 ["a8086 Assembly", "a8086"]
+																																		 ], "c") %>
 							<label>Language Options</label>
 						</div>
 					</div>
 				</li>
 				<li>
 					<label>
-					<%= check_box_tag "box_max","1",false, :class => "filled-in" %> 
-					<span>Max Lines </span>
+						<%= check_box_tag "box_max","1",false, :class => "filled-in" %>
+						<span>Max Lines </span>
 					</label>
 					<br>
-					<div id='OptionsDiv' style="padding-left:10px;" >
+					<div id='<%= a.id %>OptionsDiv' style="padding-left:10px;" >
 						<%= number_field_tag "max_lines", "10", placeholder: "If you don't know what this is please read the Moss documentation before altering this value.", min: 1 %>
 					</div>
 				</li>
 				<li>
 					<label>
-						<%= check_box_tag "box_basefile", "1",false, :class => "filled-in" %> 
+						<%= check_box_tag "box_basefile", "1",false, :class => "filled-in" %>
 						<span>Base File Tar </span>
 					</label>
-					<div id='OptionsDiv' style="padding-left:10px;" >
+					<div id='<%= a.id %>OptionsDiv' style="padding-left:10px;" >
 						<div class="file-field input-field">
-						  <div class="btn">
-					      <span>Base File</span>
-						    <%= file_field_tag 'base_tar' %>
-					    </div>
-					    <div class="file-path-wrapper">
-					      <input class="file-path validate" type="text" placeholder="Additional files archive">
-					    </div>
+							<div class="btn">
+								<span>Base File</span>
+								<%= file_field_tag 'base_tar' %>
+							</div>
+							<div class="file-path-wrapper">
+								<input class="file-path validate" type="text" placeholder="Additional files archive">
+							</div>
 						</div>
 						<br>
 						<i>This if used must be an non-nested TAR. Contents of which will not be run against the assignments. Perfect for example code, or stubbed out functions that were given out.</i>
 					</div>
 				</li>
 			</ul>
-    </li>
-  </ul>
+		</li>
+	</ul>
 
-  <br>
+	<br>
 
 	<h4>Step 3:</h4>
 	<p> (Optional) Upload an archive containing additional files you'd like Moss to compare against.</p>
-  <p>(Note: the archive must contain only regular files.  Nested archives wil not be extracted.)</p>
-   
-  <div class="file-field input-field">
-    <div class="btn">
-      <span>Archive</span>
-      <%= file_field_tag 'external_tar' %>
-    </div>
-    <div class="file-path-wrapper">
-      <input class="file-path validate" type="text" placeholder="Additional files archive">
-    </div>
-  </div> 
-  <br>
+	<p>(Note: the archive must contain only regular files.  Nested archives wil not be extracted.)</p>
+
+	<div class="file-field input-field">
+		<div class="btn">
+			<span>Archive</span>
+			<%= file_field_tag 'external_tar' %>
+		</div>
+		<div class="file-path-wrapper">
+			<input class="file-path validate" type="text" placeholder="Additional files archive">
+		</div>
+	</div>
+	<br>
 
 	<h4>Step 4:</h4>
 	<p> Click "Go!" once to run Moss. This may take up to a minute, so be patient...</p>
 
-  <p><%= submit_tag "Go!", data: { disable_with: "Please wait..." }, class: "btn primary" %></p>
+	<p><%= submit_tag "Go!", data: { disable_with: "Please wait..." }, class: "btn primary" %></p>
 <% end %>

--- a/app/views/courses/moss.html.erb
+++ b/app/views/courses/moss.html.erb
@@ -8,7 +8,6 @@
 			<p>You do not seem to have any assessments in this course to be able to run the Cheat Checker</p>
 			<%= link_to "<i class='material-icons left'>assignment</i> Install Assessment".html_safe, install_assessment_course_assessments_path(@course), { title: "Install Assessment", class: "btn btn-large red darken-3" } %>
 		</li>
-
 	</ul>
 <% else %>
 	<% content_for :javascripts do %>
@@ -29,7 +28,7 @@
 
 	<%= form_tag([:run_moss, @course], multipart: true) do %>
 		<ul class="moss-list">
-			<li class="filterableCourse" id="<%= @course.display_name %>">
+			<li id="<%= @course.display_name %>">
 				<h5 onclick="toggleOptions('<%= @course.id %>Assessments')">
 					<%= @course.full_name %>
 				</h5>
@@ -41,8 +40,7 @@
 								<span> <%= a.display_name %> </span>
 							</label>
 							<br>
-							<div id='<%= a.id %>OptionsDiv' style="padding-left:10px;" >
-								<!-- <b>Is Archive:</b> -->
+							<div style="padding-left:10px;" >
 								<label>
 									<%= check_box_tag "isArchive[#{a.id}]", :class => "filled-in" %>
 									<span>Is Archive: </span>
@@ -66,7 +64,7 @@
 		<h4>Step 2:</h4>
 		<p>(Optional) Add flags that will be run with moss.</p>
 		<ul class="moss-list">
-			<li class="filterableCourse" id="Moss Flags">
+			<li id="Moss Flags">
 				<h5 onclick="toggleOptions('flags')">
 					Moss Flags
 				</h5>

--- a/app/views/courses/moss.html.erb
+++ b/app/views/courses/moss.html.erb
@@ -24,7 +24,7 @@
 	<% end %>
 
 	<h4>Step 1:</h4>
-	<p>Check the box of all the assessments you want to send to Moss for cheat checking.</p>
+	<p>Check the box for each assessment you want to send to Moss for cheat checking.</p>
 
 	<%= form_tag([:run_moss, @course], multipart: true) do %>
 		<ul class="moss-list">
@@ -145,7 +145,7 @@
 
 		<h4>Step 3:</h4>
 		<p> (Optional) Upload an archive containing additional files you'd like Moss to compare against.</p>
-		<p>(Note: the archive must contain only regular files.  Nested archives wil not be extracted.)</p>
+		<p>(Note: the archive must contain only regular files. Nested archives will not be extracted.)</p>
 
 		<div class="file-field input-field">
 			<div class="btn">

--- a/app/views/courses/moss.html.erb
+++ b/app/views/courses/moss.html.erb
@@ -87,7 +87,7 @@
 					<span> Language </span>
 					</label>
 					<br>
-					<div id='<%= a.id %>OptionsDiv' style="margin-right: 10px;" >
+					<div id='OptionsDiv' style="margin-right: 10px;" >
 						<div class="input-field">
 							<%= select_tag :language_selection, options_for_select([
 								["ASCII", "ascii"],
@@ -126,7 +126,7 @@
 					<span>Max Lines </span>
 					</label>
 					<br>
-					<div id='<%= a.id %>OptionsDiv' style="padding-left:10px;" >
+					<div id='OptionsDiv' style="padding-left:10px;" >
 						<%= number_field_tag "max_lines", "10", placeholder: "If you don't know what this is please read the Moss documentation before altering this value.", min: 1 %>
 					</div>
 				</li>
@@ -135,7 +135,7 @@
 						<%= check_box_tag "box_basefile", "1",false, :class => "filled-in" %> 
 						<span>Base File Tar </span>
 					</label>
-					<div id='<%= a.id %>OptionsDiv' style="padding-left:10px;" >
+					<div id='OptionsDiv' style="padding-left:10px;" >
 						<div class="file-field input-field">
 						  <div class="btn">
 					      <span>Base File</span>

--- a/app/views/courses/moss.html.erb
+++ b/app/views/courses/moss.html.erb
@@ -1,158 +1,168 @@
 <% @title = "Moss Cheat Checker" %>
 
-<% content_for :javascripts do %>
-	<script type="text/javascript">
-		/**
-		 * toggles the "style.display" of the element with the given id.
-		 **/
-		function toggleOptions(id) {
-			var show = document.getElementById(id);
-			show.style.display = (show.style.display == "none")? "block" : "none";
-		}
-
-	</script>
-<% end %>
-
 <h2>Run the Moss Cheat Checker</h2>
 
-<h4>Step 1:</h4>
-<p>Check the box of all the assessments you want to send to Moss for plagiarism checking.</p>
+<% if @course.assessments.empty? %>
+	<ul class="collection" style="text-align: center; font-size: 18px;">
+		<li class="collection-item add">
+			<p>You do not seem to have any assessments in this course to be able to run the Cheat Checker</p>
+			<a title="Install an assessment" class="btn btn-large red darken-3" href=<%= install_assessment_course_assessments_path(@course) %> style="font-size: 18px;">Add an Assessment</a>
+		</li>
 
-<%= form_tag([:run_moss, @course], multipart: true) do %>
-	<ul class="moss-list">
-		<li class="filterableCourse" id="<%= @course.display_name %>">
-			<h5 onclick="toggleOptions('<%= @course.id %>Assessments')">
-				<%= @course.full_name %>
-			</h5>
-			<ul id="<%= @course.id %>Assessments" class="moss-inner-list">
-				<% for a in @course.assessments do %>
+	</ul>
+<% else %>
+	<% content_for :javascripts do %>
+		<script type="text/javascript">
+			/**
+			 * toggles the "style.display" of the element with the given id.
+			 **/
+			function toggleOptions(id) {
+				var show = document.getElementById(id);
+				show.style.display = (show.style.display == "none")? "block" : "none";
+			}
+
+		</script>
+	<% end %>
+
+	<h4>Step 1:</h4>
+	<p>Check the box of all the assessments you want to send to Moss for cheat checking.</p>
+
+	<%= form_tag([:run_moss, @course], multipart: true) do %>
+		<ul class="moss-list">
+			<li class="filterableCourse" id="<%= @course.display_name %>">
+				<h5 onclick="toggleOptions('<%= @course.id %>Assessments')">
+					<%= @course.full_name %>
+				</h5>
+				<ul id="<%= @course.id %>Assessments" class="moss-inner-list">
+					<% for a in @course.assessments do %>
+						<li>
+							<label>
+								<%= check_box_tag "assessments[#{a.id}]","1",false, :class => "filled-in" %>
+								<span> <%= a.display_name %> </span>
+							</label>
+							<br>
+							<div id='<%= a.id %>OptionsDiv' style="padding-left:10px;" >
+								<!-- <b>Is Archive:</b> -->
+								<label>
+									<%= check_box_tag "isArchive[#{a.id}]", :class => "filled-in" %>
+									<span>Is Archive: </span>
+								</label>
+								</br>
+								<i>Check this if the submissions will need to be extracted. (The handin filename was: <%= a.handin_filename %>)</i>
+								<br>
+								<b>Files to send to Moss:</b>
+								<%= text_field_tag "files[#{a.id}]", "*hello.c *.c", required: true %>
+								<i>This can be file names (foo.c) or patterns(*.c), space-separated</i>
+								<br>
+							</div>
+						</li>
+					<% end %>
+				</ul>
+			</li>
+		</ul>
+
+		<br>
+
+		<h4>Step 2:</h4>
+		<p>(Optional) Add flags that will be run with moss.</p>
+		<ul class="moss-list">
+			<li class="filterableCourse" id="Moss Flags">
+				<h5 onclick="toggleOptions('flags')">
+					Moss Flags
+				</h5>
+				<ul id="flags" class="moss-inner-list" style="display:none" >
 					<li>
 						<label>
-							<%= check_box_tag "assessments[#{a.id}]","1",false, :class => "filled-in" %>
-							<span> <%= a.display_name %> </span>
+							<%= check_box_tag "box_language","1",false, :class => "filled-in" %>
+							<span> Language </span>
+						</label>
+						<br>
+						<div id='<%= a.id %>OptionsDiv' style="margin-right: 10px;" >
+							<div class="input-field">
+								<%= select_tag :language_selection, options_for_select([
+																																				 ["ASCII", "ascii"],
+																																				 ["Ada", "ada"],
+																																				 ["C", "c"],
+																																				 ["C#", "csharp"],
+																																				 ["C++", "cc"],
+																																				 ["FORTRAN", "fortran"],
+																																				 ["Haskell", "haskell"],
+																																				 ["Java", "java"],
+																																				 ["Javascript", "javascript"],
+																																				 ["Lisp", "lisp"],
+																																				 ["MIPS Assembly", "mips"],
+																																				 ["ML", "ml"],
+																																				 ["Matlab", "matlab"],
+																																				 ["Modula2", "modula2"],
+																																				 ["Pascal", "pascal"],
+																																				 ["Perl", "perl"],
+																																				 ["PL/SQL", "plsql"],
+																																				 ["Prolog", "prolog"],
+																																				 ["Python", "python"],
+																																				 ["Scheme", "scheme"],
+																																				 ["Spice", "spice"],
+																																				 ["VHDL", "vhdl"],
+																																				 ["Verilog", "verilog"],
+																																				 ["Visual Basic", "vb"],
+																																				 ["a8086 Assembly", "a8086"]
+																																			 ], "c") %>
+								<label>Language Options</label>
+							</div>
+						</div>
+					</li>
+					<li>
+						<label>
+							<%= check_box_tag "box_max","1",false, :class => "filled-in" %>
+							<span>Max Lines </span>
 						</label>
 						<br>
 						<div id='<%= a.id %>OptionsDiv' style="padding-left:10px;" >
-							<!-- <b>Is Archive:</b> -->
-							<label>
-								<%= check_box_tag "isArchive[#{a.id}]", :class => "filled-in" %>
-								<span>Is Archive: </span>
-							</label>
-							</br>
-							<i>Check this if the submissions will need to be extracted. (The handin filename was: <%= a.handin_filename %>)</i>
-							<br>
-							<b>Files to send to Moss:</b>
-							<%= text_field_tag "files[#{a.id}]", "*hello.c *.c", required: true %>
-							<i>This can be file names (foo.c) or patterns(*.c), space-separated</i>
-							<br>
+							<%= number_field_tag "max_lines", "10", placeholder: "If you don't know what this is please read the Moss documentation before altering this value.", min: 1 %>
 						</div>
 					</li>
-				<% end %>
-			</ul>
-		</li>
-	</ul>
-
-	<br>
-
-	<h4>Step 2:</h4>
-	<p>(Optional) Add flags that will be run with moss.</p>
-	<ul class="moss-list">
-		<li class="filterableCourse" id="Moss Flags">
-			<h5 onclick="toggleOptions('flags')">
-				Moss Flags
-			</h5>
-			<ul id="flags" class="moss-inner-list" style="display:none" >
-				<li>
-					<label>
-						<%= check_box_tag "box_language","1",false, :class => "filled-in" %>
-						<span> Language </span>
-					</label>
-					<br>
-					<div id='<%= a.id %>OptionsDiv' style="margin-right: 10px;" >
-						<div class="input-field">
-							<%= select_tag :language_selection, options_for_select([
-																																			 ["ASCII", "ascii"],
-																																			 ["Ada", "ada"],
-																																			 ["C", "c"],
-																																			 ["C#", "csharp"],
-																																			 ["C++", "cc"],
-																																			 ["FORTRAN", "fortran"],
-																																			 ["Haskell", "haskell"],
-																																			 ["Java", "java"],
-																																			 ["Javascript", "javascript"],
-																																			 ["Lisp", "lisp"],
-																																			 ["MIPS Assembly", "mips"],
-																																			 ["ML", "ml"],
-																																			 ["Matlab", "matlab"],
-																																			 ["Modula2", "modula2"],
-																																			 ["Pascal", "pascal"],
-																																			 ["Perl", "perl"],
-																																			 ["PL/SQL", "plsql"],
-																																			 ["Prolog", "prolog"],
-																																			 ["Python", "python"],
-																																			 ["Scheme", "scheme"],
-																																			 ["Spice", "spice"],
-																																			 ["VHDL", "vhdl"],
-																																			 ["Verilog", "verilog"],
-																																			 ["Visual Basic", "vb"],
-																																			 ["a8086 Assembly", "a8086"]
-																																		 ], "c") %>
-							<label>Language Options</label>
-						</div>
-					</div>
-				</li>
-				<li>
-					<label>
-						<%= check_box_tag "box_max","1",false, :class => "filled-in" %>
-						<span>Max Lines </span>
-					</label>
-					<br>
-					<div id='<%= a.id %>OptionsDiv' style="padding-left:10px;" >
-						<%= number_field_tag "max_lines", "10", placeholder: "If you don't know what this is please read the Moss documentation before altering this value.", min: 1 %>
-					</div>
-				</li>
-				<li>
-					<label>
-						<%= check_box_tag "box_basefile", "1",false, :class => "filled-in" %>
-						<span>Base File Tar </span>
-					</label>
-					<div id='<%= a.id %>OptionsDiv' style="padding-left:10px;" >
-						<div class="file-field input-field">
-							<div class="btn">
-								<span>Base File</span>
-								<%= file_field_tag 'base_tar' %>
+					<li>
+						<label>
+							<%= check_box_tag "box_basefile", "1",false, :class => "filled-in" %>
+							<span>Base File Tar </span>
+						</label>
+						<div id='<%= a.id %>OptionsDiv' style="padding-left:10px;" >
+							<div class="file-field input-field">
+								<div class="btn">
+									<span>Base File</span>
+									<%= file_field_tag 'base_tar' %>
+								</div>
+								<div class="file-path-wrapper">
+									<input class="file-path validate" type="text" placeholder="Additional files archive">
+								</div>
 							</div>
-							<div class="file-path-wrapper">
-								<input class="file-path validate" type="text" placeholder="Additional files archive">
-							</div>
+							<br>
+							<i>This if used must be an non-nested TAR. Contents of which will not be run against the assignments. Perfect for example code, or stubbed out functions that were given out.</i>
 						</div>
-						<br>
-						<i>This if used must be an non-nested TAR. Contents of which will not be run against the assignments. Perfect for example code, or stubbed out functions that were given out.</i>
-					</div>
-				</li>
-			</ul>
-		</li>
-	</ul>
+					</li>
+				</ul>
+			</li>
+		</ul>
 
-	<br>
+		<br>
 
-	<h4>Step 3:</h4>
-	<p> (Optional) Upload an archive containing additional files you'd like Moss to compare against.</p>
-	<p>(Note: the archive must contain only regular files.  Nested archives wil not be extracted.)</p>
+		<h4>Step 3:</h4>
+		<p> (Optional) Upload an archive containing additional files you'd like Moss to compare against.</p>
+		<p>(Note: the archive must contain only regular files.  Nested archives wil not be extracted.)</p>
 
-	<div class="file-field input-field">
-		<div class="btn">
-			<span>Archive</span>
-			<%= file_field_tag 'external_tar' %>
+		<div class="file-field input-field">
+			<div class="btn">
+				<span>Archive</span>
+				<%= file_field_tag 'external_tar' %>
+			</div>
+			<div class="file-path-wrapper">
+				<input class="file-path validate" type="text" placeholder="Additional files archive">
+			</div>
 		</div>
-		<div class="file-path-wrapper">
-			<input class="file-path validate" type="text" placeholder="Additional files archive">
-		</div>
-	</div>
-	<br>
+		<br>
 
-	<h4>Step 4:</h4>
-	<p> Click "Go!" once to run Moss. This may take up to a minute, so be patient...</p>
+		<h4>Step 4:</h4>
+		<p> Click "Go!" once to run Moss. This may take up to a minute, so be patient...</p>
 
-	<p><%= submit_tag "Go!", data: { disable_with: "Please wait..." }, class: "btn primary" %></p>
+		<p><%= submit_tag "Go!", data: { disable_with: "Please wait..." }, class: "btn primary" %></p>
+	<% end %>
 <% end %>


### PR DESCRIPTION
## Description
1. Remove usages of undefined `a` variable in `views/courses/moss.html.erb`.
2. If the course does not have any assessments, block the moss page with a message and a link to install an assessment.
3. Do not show all courses and their assessments in this page, only the current course and its assessments.

## Motivation and Context
Fixes #1861 in addition to making the page for the current course only, which makes more sense as the page is opened within a course's context.

## How Has This Been Tested?
Tested locally on the latest docker images.

Here is how the page looks when there is at least 1 assessment:

<img width="1680" alt="Screenshot 2023-03-31 at 3 26 50 AM" src="https://user-images.githubusercontent.com/30433769/228993739-be644d4a-94f4-4033-b17f-685944a7ac08.png">


And here is how it looks when there are no assessments:

<img width="1680" alt="Screenshot 2023-03-31 at 3 26 20 AM" src="https://user-images.githubusercontent.com/30433769/228993747-3f71314b-917b-4659-b574-887d7b2012c0.png">

I also submitted a few submissions to moss confirm nothing broke there.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)