### PR TITLE
Center checkbox in manage submission table

### DIFF
--- a/app/assets/stylesheets/style.css.scss
+++ b/app/assets/stylesheets/style.css.scss
@@ -800,6 +800,14 @@ table.prettyBorder {
     padding: 5px 0 5px 0;
   }
 
+  .submissions-cbox-label {
+    display: flex;
+    justify-content: center;
+    span::before {
+      left: 6px;
+    }
+  }
+
   tr.selected {
     background-color: $autolab-subtle-gray;
   }
@@ -1499,6 +1507,9 @@ table.sub td, th {
 
 .buttons-spacing {
   margin-right: 10px;
+  a {
+    overflow-y: hidden;
+  }
 }
 
 .submissions-checkbox {

--- a/app/views/submissions/index.html.erb
+++ b/app/views/submissions/index.html.erb
@@ -26,12 +26,11 @@
 
 <%# Main buttons %>
 <div class="row buttons-row">
-  <% if @autograded then %>
     <div class="buttons-spacing">
-    <%= link_to "<i class='material-icons left submissions-icons'>add</i>Create Submission".html_safe,
-        new_course_assessment_submission_path(@course, @assessment),
-        {:title=>"Create a new submission for a student, with an option to submit a handin file on their behalf",
-         :class=>"btn submissions disabled"} %>
+      <%= link_to "<i class='material-icons left submissions-icons'>add</i>Create Submission".html_safe,
+          new_course_assessment_submission_path(@course, @assessment),
+          {:title=>"Create a new submission for a student, with an option to submit a handin file on their behalf",
+          :class=>"btn submissions disabled"} %>
     </div>
 
     <div class="buttons-spacing">
@@ -52,7 +51,6 @@
         [@course, @assessment, :extensions],
         {:class=>"btn submissions"} %>
     </div>
-  <% end %>
 </div>
 
 
@@ -79,8 +77,9 @@
       <%# Checkbox %>
       <td class="submissions-td submissions-checkbox">
         <div>
-          <label>
-            <input class="cbox" type="checkbox" id="cbox-<%= submission.id %>"><span/>
+          <label class="submissions-cbox-label">
+            <input class="cbox" type="checkbox" id="cbox-<%= submission.id %>">
+            <span><span/>
           </label>
         </div>
       </td>


### PR DESCRIPTION
## Description
Centers checkbox:
![image](https://user-images.githubusercontent.com/50491000/230790267-79978d2e-81e1-4035-8af9-3ca30c5334ad.png)

## Motivation and Context
Make sure checkbox is aligned properly

## How Has This Been Tested?
On an assignment with submissions, visit courses/<coursename>/assessments/<assessmentname>/submissions, and view the table to see that the checkboxes are aligned. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR
