### PR TITLE
Use communityinviter for slack invites

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ This will build the site using the branch you are currently in (hopefully `maste
 ## Contributing
 
 We encourage you to contribute to Autolab! Please check out the
-[Contributing to Autolab Guide](https://github.com/autolab/Autolab/blob/master/CONTRIBUTING.md) for guidelines about how to proceed. You can reach out to us on [Slack](https://join.slack.com/t/autolab/shared_invite/zt-1maodn5ti-jdLHUnm5sZkuLn4PJNaTbw) as well.
+[Contributing to Autolab Guide](https://github.com/autolab/Autolab/blob/master/CONTRIBUTING.md) for guidelines about how to proceed. You can reach out to us on [Slack](https://communityinviter.com/apps/autolab/autolab-project) as well.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Since 2010, Autolab has had a transformative impact on education at CMU. Each se
 
 
 <p>
-<a href="https://join.slack.com/t/autolab/shared_invite/zt-1maodn5ti-jdLHUnm5sZkuLn4PJNaTbw" style="float:left">
+<a href="https://communityinviter.com/apps/autolab/autolab-project" style="float:left">
   <img src="public/images/join_slack.svg" width="170px" height="44px">
 </a>
 

--- a/docs/installation/docker-compose.md
+++ b/docs/installation/docker-compose.md
@@ -2,7 +2,7 @@
 
 The Autolab Docker Compose installation is a fast and easy production-ready installation and deployment method. It uses a MySQL database for the Autolab deployment, and comes with TLS/SSL support. This is now the preferred way of installing Autolab due to its ease of use.
 
-If you are stuck or find issues with the installation process you can either file an issue on our Github repository, or join our Slack <a href="https://join.slack.com/t/autolab/shared_invite/zt-1maodn5ti-jdLHUnm5sZkuLn4PJNaTbw">here</a> and let us know and we will try our best to help. Also see the [debugging](#debugging-your-deployment) section for tips on how to diagnose problems and check out the [troubleshooting](#troubleshooting) section if you run into any issues.
+If you are stuck or find issues with the installation process you can either file an issue on our Github repository, or join our Slack [here](https://communityinviter.com/apps/autolab/autolab-project) and let us know and we will try our best to help. Also see the [debugging](#debugging-your-deployment) section for tips on how to diagnose problems and check out the [troubleshooting](#troubleshooting) section if you run into any issues.
 
 ## Installation
 First ensure that you have Docker and Docker Compose installed on your machine. See the official <a href="https://docs.docker.com/install/" target="_blank">Docker docs</a> for the installation steps.
@@ -159,7 +159,7 @@ There are three options for TLS: using Let's Encrypt (for free TLS certificates)
         docker compose up
 
 ## Debugging your Deployment
-In the (very likely) event that you run into problems during setup, hopefully these steps will help you to help identify and diagnose the issue. If you continue to face difficulties or believe you discovered issues with the setup process please join our Slack [here](https://join.slack.com/t/autolab/shared_invite/zt-1maodn5ti-jdLHUnm5sZkuLn4PJNaTbw) and let us know and we will try our best to help.
+In the (very likely) event that you run into problems during setup, hopefully these steps will help you to help identify and diagnose the issue. If you continue to face difficulties or believe you discovered issues with the setup process please join our Slack [here](https://communityinviter.com/apps/autolab/autolab-project) and let us know and we will try our best to help.
 
 ### Better logging output for Docker Compose
 By default, `docker compose up -d` runs in detached state and it is not easy to immediately see errors:

--- a/docs/installation/tango-troubleshoot.md
+++ b/docs/installation/tango-troubleshoot.md
@@ -1,5 +1,5 @@
 This is a general list of Tango-related issues that we get often. If you are encountering or find a solution to an issue not mentioned here,
-please let us know on our [Slack](https://join.slack.com/t/autolab/shared_invite/zt-1maodn5ti-jdLHUnm5sZkuLn4PJNaTbw).
+please let us know on our [Slack](https://communityinviter.com/apps/autolab/autolab-project).
 
 ## Clearing Tango job queue
 Due to faulty configs or other reasons, you may have a large backlog of jobs waiting to run that are stuck. 


### PR DESCRIPTION
## Description
Update slack invite link to use communityinviter. (https://communityinviter.com/apps/autolab/autolab-project)

## Motivation and Context
Currently, the slack invite link only works for users with `@andrew.cmu.edu` email addresses. This precludes users from other universities from easily joining the slack, unless we manually send invites to them.

By using communityinviter, anyone can now join the slack, and we can easily monitor the list of join requests.

## How Has This Been Tested?
Click on "Join our slack!" button.

![Screenshot 2023-04-09 at 15 26 25](https://user-images.githubusercontent.com/9074856/230792615-98f36be9-48ab-4f04-83dc-bd937769438e.png)

Test with an email, ensure you get an invite.

![Screenshot 2023-04-09 at 15 29 39](https://user-images.githubusercontent.com/9074856/230792757-9c255e29-e1cf-46f2-8eca-d8b825952215.png)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR