### PR TITLE
Fix placeholder for DEVISE_SECRET_KEY

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -11,7 +11,7 @@ LOCKBOX_MASTER_KEY=<LOCKBOX_MASTER_KEY_REPLACE_ME>
 
 # Run [bundle exec rake secret] to generate DEVISE_SECRET_KEY
 # Used for generating user authentication tokens
-DEVISE_SECRET_KEY=<LOCKBOX_MASTER_KEY_REPLACE_ME>
+DEVISE_SECRET_KEY=<DEVISE_SECRET_KEY_REPLACE_ME>
 
 # Used for Github integration
 # See https://docs.autolabproject.com/installation/github_integration


### PR DESCRIPTION
## Description
Fix placeholder for `DEVISE_SECRET_KEY` in `.env.template`, from `<LOCKBOX_MASTER_KEY_REPLACE_ME>` to `<DEVISE_SECRET_KEY_REPLACE_ME>`.

## Motivation and Context
Currently, the same placeholder is used in `.env.template` for both `LOCKBOX_MASTER_KEY` and `DEVISE_SECRET_KEY`. Thus, when `initialize_secrets.sh` is run, both are initialized to the same secret.

## How Has This Been Tested?
Set `DEVISE_SECRET_KEY=<DEVISE_SECRET_KEY_REPLACE_ME>` in `.env` and run `initialize_secrets.sh`. Ensure that it is initialized.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR