### PR TITLE
Fix hovering over top navbar to be colored white instead of blue for Metrics page

### DIFF
--- a/app/assets/stylesheets/metrics.scss
+++ b/app/assets/stylesheets/metrics.scss
@@ -235,3 +235,7 @@ span.instances .segment {
   display: flex;
   align-items: center;
 }
+
+a:hover {
+  color: $autolab-white;
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When in the metrics page, hovering over the top navbar changes the color of the items' text to turn blue, when it should stay white:
![Screen Shot 2023-04-21 at 15 37 29](https://user-images.githubusercontent.com/25730111/233721471-a619f0bd-0665-433e-b1f7-740ee7198960.png)

Developer console shows that this color originates from the metrics scss file, but no such definition can be found in the file itself, so I believe this is a side-effect of `semantic-ui`, which gets imported in `metrics.scss`.

![Screen Shot 2023-04-21 at 15 37 51](https://user-images.githubusercontent.com/25730111/233721529-572655cf-4bb8-433e-9f04-db202bc18ec4.png)

To fix, set the hover color for `a` to be white in `metrics.scss`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Hover over top navbar and see that items' text color stays white
- browse through rest of page to see that other hover colors stay the same

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
