### PR TITLE
Add sorting icons to new manage submissions

### DIFF
--- a/app/assets/stylesheets/style.css.scss
+++ b/app/assets/stylesheets/style.css.scss
@@ -798,6 +798,27 @@ table.prettyBorder {
     }
   }
 
+  .sorting_desc {
+    .sort-icon__both, .sort-icon__up {
+      display: none;
+    }
+    .sort-icon__down {
+      display: inline;
+    }
+  }
+  .sorting_asc {
+    .sort-icon__both, .sort-icon__down {
+      display: none;
+    }
+    .sort-icon__up {
+      display: inline;
+    }
+  }
+
+  .sort-icon__up, .sort-icon__down {
+    display: none;
+  }
+
   td {
     border: 1px solid #ddd;
     padding: 0 5px;

--- a/app/assets/stylesheets/style.css.scss
+++ b/app/assets/stylesheets/style.css.scss
@@ -787,6 +787,15 @@ table.prettyBorder {
 
   .submissions-th {
     padding: 25px 0 25px 0;
+    div {
+      display: flex;
+      align-items: center;
+    }
+    p {
+      margin: 0;
+      float: left;
+      padding-right: 3px;
+    }
   }
 
   td {

--- a/app/views/submissions/index.html.erb
+++ b/app/views/submissions/index.html.erb
@@ -7,7 +7,7 @@
 
 <% content_for :javascripts do %>
   <%= external_javascript_include_tag "lodash" %>
-  <%= javascript_include_tag "sorttable" %> 
+  <%= javascript_include_tag "sorttable" %>
   <%= external_javascript_include_tag "jquery.dataTables" %>
   <%= external_javascript_include_tag "datatables-buttons" %>
   <%= javascript_include_tag "manage_submissions" %>
@@ -58,11 +58,13 @@
     <tr>
       <th class="submissions-th"></th>
       <% for header in headers %>
-        <th class="submissions-th">
+        <th class="submissions-th sorting">
           <div>
             <p><%= header %></p>
             <% if header != "File" && header != "Actions" then %>
-              <i class="material-icons tiny sort-icon" aria-hidden="true">swap_vert</i>
+              <i class="material-icons tiny sort-icon sort-icon__both" aria-hidden="true">swap_vert</i>
+              <i class="material-icons tiny sort-icon sort-icon__up" aria-hidden="true">arrow_upward</i>
+              <i class="material-icons tiny sort-icon sort-icon__down" aria-hidden="true">arrow_downward</i>
             <% end %>
           </div>
         </th>

--- a/app/views/submissions/index.html.erb
+++ b/app/views/submissions/index.html.erb
@@ -58,7 +58,14 @@
     <tr>
       <th class="submissions-th"></th>
       <% for header in headers %>
-        <th class="submissions-th"><%= header %></th>
+        <th class="submissions-th">
+          <div>
+            <p><%= header %></p>
+            <% if header != "File" && header != "Actions" then %>
+              <i class="material-icons tiny sort-icon" aria-hidden="true">swap_vert</i>
+            <% end %>
+          </div>
+        </th>
       <% end %>
     </tr>
   </thead>


### PR DESCRIPTION
## Description
* Adds sorting icons to the manage submissions table headers
* Arrow up on ascending, arrow down on descending, double arrow when unsorted
![image](https://user-images.githubusercontent.com/50491000/233858527-9643ccd1-2fb1-4403-9e56-fd6ae8e8717e.png)


## Motivation and Context
Adds clear indicators of sort status

## How Has This Been Tested?
Click on the arrows, ensuring that they match the sort status

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR

## Other issues / help required
<!--- Do you have any other relevant issues / questions? --->
<!--- For example, if you require assistance for a certain part of your PR --->
<!--- or are facing specific issues while creating the pull request that you would like to highlight --->

If unsure, feel free to submit first and we'll help you along.
