### PR TITLE
Add student info to Bulk Export Grades

### DIFF
--- a/app/helpers/assessment_helper.rb
+++ b/app/helpers/assessment_helper.rb
@@ -47,8 +47,9 @@ module AssessmentHelper
   def gradesheet_csv(asmt, as_seen_by)
     CSV.generate do |csv|
       # title row with the column names:
-      title = ["Submission Time:","Email:","Total:"]
-      asmt.problems.each { |problem| title << "#{problem.name}:" }
+      title = ["Submission Time","Email","Total"]
+      asmt.problems.each { |problem| title << problem.name }
+      title += ["First name", "Last name", "Section", "Lecture"]
       csv << title
 
       asmt.course.course_user_data.each do |cud|
@@ -97,7 +98,7 @@ private
 
     # add scores to csv row (for scores columns)
     row.concat score_cells
-
+    row += [cud.user.first_name, cud.user.last_name, cud.section, cud.lecture]
     row
   end
 


### PR DESCRIPTION
- Adds student's first name, last name, section, and lecture to the Bulk Grades Export in an assignment.
- Removes the colon after each column's title.

## Motivation and Context
We are using the course for multiple sections. We needed a fast way to know each student's section when we exported the grades, along with their names.

## How Has This Been Tested?
On the Docker setup, I downloaded an export.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR

## Other issues / help required
I appended all the new columns to the end of the export just in case someone automates pulling data out of the exports - this way their column numbers should not change. Just wanted to point that out in case you think it might cause any issues.