### PR TITLE
Fix 500 error from going to users/id for non-existent user-id

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -33,7 +33,7 @@ class UsersController < ApplicationController
   # based on current user's role
   action_auth_level :show, :student
   def show
-    user = User.find(params[:id])
+    user = User.find_by id: params[:id]
     if user.nil?
       flash[:error] = "User does not exist"
       redirect_to(users_path) && return


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Currently, navigating to `users/:id` with a non-existent user-id results in a `ActiveRecord::RecordNotFound` error because the users controller uses `User.find(params[:id])` instead of finding by id specifically. 
![Screenshot 2023-05-01 at 2 54 48 PM](https://user-images.githubusercontent.com/25730111/235512172-d950b67c-fd67-4ad7-9a5e-5d1072c122cf.png)


This PR changes this line to use `User.find_by id: params[:id]` so that the nil check afterwards works correctly and the user is redirected to the user path correctly.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Navigate to `users/:id` with a non-existent user-id on nightly/cmu deployment, see 500 error

![Screenshot 2023-05-01 at 2 54 32 PM](https://user-images.githubusercontent.com/25730111/235512124-2ff17a63-1cc0-4246-913f-cb97e0ab5f94.png)

On this branch, navigate to `users/:id` with a non-existent user-id, see that you are redirected to `/users` and a error flash pops up

![Screenshot 2023-05-01 at 3 04 50 PM](https://user-images.githubusercontent.com/25730111/235512323-bb85f90f-4b94-4871-84df-29bac1424984.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
