### PR TITLE
Handin improvements

### DIFF
--- a/app/assets/javascripts/git_submission.js
+++ b/app/assets/javascripts/git_submission.js
@@ -98,7 +98,9 @@ $(document).on("click", "input[type='submit']", function (e) {
     var branch_name = $("#branch-dropdown input[name='branch']").val();
     var commit_sha = $("#commit-dropdown input[name='commit']").val();
     var token = $("meta[name=csrf-token]").attr("content");
-    var params = {repo: repo_name, branch: branch_name, commit: commit_sha, authenticity_token: token};
+    var params = {
+      repo: repo_name, branch: branch_name, commit: commit_sha, authenticity_token: token, github_submission: true
+    };
     var assessment_nav = $(".sub-navigation").find(".item").last();
     var assessment_url = assessment_nav.find("a").attr("href");
     var url = assessment_url + "/handin"

--- a/app/assets/javascripts/handin.js
+++ b/app/assets/javascripts/handin.js
@@ -140,14 +140,10 @@ function enableSubmit() {
         $("#fake-submit").removeClass("disabled");
       }  
     } else if (tab === "github_tab") {
-      var repoSelected = $("#repo-dropdown .noselection").length === 0;
-      var branchSelected = $("#branch-dropdown .noselection").length === 0;
-      // if there's no repos
-      if (!repoSelected || !branchSelected) {
-        $("#fake-submit").addClass("disabled");
-      } else {
-        $("#fake-submit").removeClass("disabled");
-      }
+      const repoSelected= $("#repo-dropdown .noselection").length === 0;
+      const branchSelected= $("#branch-dropdown .noselection").length === 0;
+      const commitSelected= $("#commit-dropdown .noselection").length === 0;
+      $("#fake-submit").toggleClass("disabled", !repoSelected || !branchSelected || !commitSelected);
     }
   }
 

--- a/app/assets/javascripts/handin.js
+++ b/app/assets/javascripts/handin.js
@@ -122,9 +122,6 @@ function enableSubmit() {
   var tab = $(".submission-panel .ui.tab.active").attr('id');
   var fileSelector = $("#handin_show_assessment input[type='file']").get(0);
   if (tab === "github_tab") {
-    fileSelector.value = null;
-    $(".handin-row").show();
-    $(".handedin-row").hide();
     // hide file type check text
     $("#filename-check").hide();
   } else {

--- a/app/assets/javascripts/handin.js
+++ b/app/assets/javascripts/handin.js
@@ -137,9 +137,9 @@ function enableSubmit() {
         $("#fake-submit").removeClass("disabled");
       }  
     } else if (tab === "github_tab") {
-      const repoSelected= $("#repo-dropdown .noselection").length === 0;
-      const branchSelected= $("#branch-dropdown .noselection").length === 0;
-      const commitSelected= $("#commit-dropdown .noselection").length === 0;
+      const repoSelected = $("#repo-dropdown .noselection").length === 0;
+      const branchSelected = $("#branch-dropdown .noselection").length === 0;
+      const commitSelected = $("#commit-dropdown .noselection").length === 0;
       $("#fake-submit").toggleClass("disabled", !repoSelected || !branchSelected || !commitSelected);
     }
   }

--- a/app/controllers/assessment/handin.rb
+++ b/app/controllers/assessment/handin.rb
@@ -32,7 +32,7 @@ module AssessmentHandin
       out_file = Tempfile.new('out.txt-')
       out_file.puts(contents)
       params[:submission]["file"] = out_file
-    elsif @assessment.github_submission_enabled && params["repo"].present? && params["branch"].present?
+    elsif @assessment.github_submission_enabled && params["github_submission"].present?
       # get code from Github
       github_integration = current_user.github_integration
 

--- a/app/views/assessments/_handin_form.html.erb
+++ b/app/views/assessments/_handin_form.html.erb
@@ -70,9 +70,9 @@
             <div class="row" style="padding-top: 10px">
               <div id = "submission_error" style = "color:red" class="col s6 m8 center-align"></div>
               <% if @aud.past_due_at? then %>
-                  <div class="col s6 m4 center-align"><%= f.submit("Submit Late", id:"fake-submit",  class: "btn primary handin-btn disabled") %></div>
+                  <div class="col s6 m4 center-align"><%= f.submit("Submit Late", id: "fake-submit", class: "btn primary handin-btn disabled") %></div>
               <% else %>
-                  <div class="col s6 m4 center-align"><%= f.submit("Submit", id:"fake-submit", class: "btn primary handin-btn disabled") %></div>
+                  <div class="col s6 m4 center-align"><%= f.submit("Submit", id: "fake-submit", class: "btn primary handin-btn disabled") %></div>
               <% end %>
             </div>
             <div class="row">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
See Motivation and Context section.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

**Issue 1**: Github submission is performed as long as the fields are set, even if the user ultimately performs an upload

Now, only a submit from the github tab will perform a github submission.

Resolves #1882

**Issue 2**: Submit button is not disabled when commit was not selected

Now, submit button is disabled when commit is not selected

**Issue 3**: Handin file is lost when switching to github tab and back

Now, handin file is preserved across tab switches

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ensure that github integration is set up. For testing, use a small repo like `Autolab/keys`

Test 1 (Issue 2)
- Switch to github tab and start filling in fields
- Ensure that submit button is only enabled once all 3 fields are filled

Test 2 (Issue 1 + issue 3)
- Fill up all 3 fields on github tab
- Switch back and forth a few times
- Click submit from upload tab, make sure that file was correctly uploaded

Test 3 (Issue 1 + issue 3)
- Fill up all 3 fields on github tab
- Switch back and forth a few times
- Click submit from GitHub tab, make sure that repo contents was correctly uploaded

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR
