### PR TITLE
Correctly display PDF annotations on viewFeedback page

### DIFF
--- a/app/views/assessments/_remarks_panel.html.erb
+++ b/app/views/assessments/_remarks_panel.html.erb
@@ -33,10 +33,13 @@
               <span> 
                 <b><%= annotation.value? ? sprintf("(%+.2f)", annotation.value.round(2)) : "" %></b>
                 <% if annotation.global_comment? %>
-                  <%= link_to "Global Annotation", [:view, @course, @assessment, @submission] %>
+                  <%= link_to "Global Annotation", view_course_assessment_submission_path(@course, @assessment, @submission) %>
+                <% elsif annotation.coordinate.present? %>
+                  <%# note: does not have a line number %>
+                  <%= link_to filename.to_s, view_course_assessment_submission_path(@course, @assessment, @submission, header_position: annotation.position) %>
                 <% else %>
                   <%# line + 1 because line numbers start from 1 %>
-                  <%= link_to filename.to_s + ":" + (annotation.line + 1).to_s, [:view, @course, @assessment, @submission, header_position: annotation.position] %>
+                  <%= link_to filename.to_s + ":" + (annotation.line + 1).to_s, view_course_assessment_submission_path(@course, @assessment, @submission, header_position: annotation.position) %>
                 <% end %>
               </span>
             </li>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Add special handling for PDF annotations
- Update `link_to` to use modern path helpers

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Currently, making a PDF annotation results in viewFeedback pages becoming unloadable, since `annotation.line` is `nil` 
<img width="1440" alt="Screenshot 2023-05-10 at 16 07 02" src="https://github.com/autolab/Autolab/assets/9074856/70a52b47-6349-4402-b2e5-85b9e97ca130">

This PR modifies the logic to not display the line number for PDF annotations, by checking if `annotation.coordinate` is present.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Create the following assessment (after unzipping): [hello.tar.zip](https://github.com/autolab/Autolab/files/11439528/hello.tar.zip)
Make the following submission (after unzipping): [pdf.tar.zip](https://github.com/autolab/Autolab/files/11439533/pdf.tar.zip)
- Add a new problem, e.g. "test"
- Make the following annotations
  - Global annotation
  - PDF annotation on pdf
  - Normal annotation on c file
- Ensure that viewFeedback page now loads (without PR: error)
- Check the URLs of the annotations
<img width="224" alt="Screenshot 2023-05-10 at 16 10 41" src="https://github.com/autolab/Autolab/assets/9074856/ab8f605c-2aa1-4e80-9b7f-659653b65469">

  - Global annotation: no `header_position`
  - PDF annotation: `header_position=0`
  - Normal annotation: `header_position=1`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR