### PR TITLE
Fix styling of create course form

### DIFF
--- a/app/assets/stylesheets/style.css.scss
+++ b/app/assets/stylesheets/style.css.scss
@@ -925,8 +925,8 @@ input[type="password"]:focus {
 }
 
 // To remove line for file-field
-input[type="text"].validate,
-input[type="text"].validate.valid, {
+.file-field input[type="text"].validate,
+.file-field input[type="text"].validate.valid, {
   border-bottom: none;
   box-shadow: none;
 }

--- a/app/views/courses/new.html.erb
+++ b/app/views/courses/new.html.erb
@@ -13,7 +13,7 @@
 
   <div class="input-field">
     <label class="control-label" for="instructor_email">Instructor Email</label>
-    <%= text_field_tag :instructor_email, nil, class: "validate", placeholder: "", required: true %>
+    <%= email_field_tag :instructor_email, nil, class: "validate", placeholder: "", required: true %>
 	<p class="help-block">Email of an Instructor, they will set up the course from here!</p>
   </div>
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Use input type email instead of text for instructor email field on create course page
- Increase specificity of CSS selector that removes line from fields

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In #1883, CSS was added to remove the line from file selectors. Unfortunately, the style applied to the following form:

<img width="1053" alt="Screenshot 2023-05-17 at 12 34 34" src="https://github.com/autolab/Autolab/assets/9074856/64ebe519-e493-4587-a538-c0cb4ee3e3e4">

This PR remedies the issue, and also improves validation by changing input type to email.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

<img width="1065" alt="Screenshot 2023-05-17 at 12 35 13" src="https://github.com/autolab/Autolab/assets/9074856/f2c9dbdc-0884-4bd5-9008-a4fde8d415e6">

Check that there is now basic validation for the instructor email field:
- typing `a` and clicking away, the line stays red
- typing `a@b.com` and clicking away, the line turns green (regex seems to be along the lines of `[a-zA-Z]@[a-zA-Z]`)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR