### PR TITLE
Exclude current assignments

### DIFF
--- a/app/assets/javascripts/metrics.js
+++ b/app/assets/javascripts/metrics.js
@@ -11,7 +11,6 @@ const metrics_endpoints = {
 Object.freeze(metrics_endpoints);
 
 $(document).ready(function(){
-
 	// Initializing Fomantic UI elements
 	$('.tabular.menu .item').tab();	
 	$('.ui.dropdown').dropdown();
@@ -23,6 +22,7 @@ $(document).ready(function(){
 	$('.ui.calendar').calendar({type: 'date', initialDate: new Date()});
 	$('.ui.dropdown').dropdown('set selected',1);
 	$('#grade_drop_consecutive_counts').dropdown('set selected',2);
+	$('#extension_requests_selection').dropdown('set selected','greater than');
 });
 
 // Updates form validation based on checked
@@ -103,8 +103,13 @@ $.getJSON(metrics_endpoints['get'],function(data, status){
 					$('#low_grades_percentage')
 					.val(_.get(condition,'parameters.grade_threshold',1));
 					break;
+				case "extension_requests":
+					$('#extension_requests_checkbox').checkbox('check');
+					$('#extensions_requests_count')
+					.val(_.get(condition,'parameters.extension_count',1));
+					break;
 				default:
-					console.error(_.get(condition,'condition_type') +" is not valid");
+					console.error(_.get(condition,'condition_type') + " is not valid");
 					return;
 			}
 		})
@@ -164,8 +169,14 @@ $('#save').click(function(){
 		};
 	}
 
+	if($('#extension_requests_checkbox').checkbox('is checked')){
+		new_conditions['extension_requests'] = {
+			extension_count: $('#extension_requests_count').val()
+		};
+	}
+
 	$.ajax({
-		url:metrics_endpoints['update'],
+		url: metrics_endpoints['update'],
 		dataType: "json",
 		contentType:'application/json',
 		data: JSON.stringify(new_conditions),

--- a/app/assets/javascripts/metrics.js
+++ b/app/assets/javascripts/metrics.js
@@ -22,7 +22,6 @@ $(document).ready(function(){
 	$('.ui.calendar').calendar({type: 'date', initialDate: new Date()});
 	$('.ui.dropdown').dropdown('set selected',1);
 	$('#grade_drop_consecutive_counts').dropdown('set selected',2);
-	$('#extension_requests_selection').dropdown('set selected','greater than');
 });
 
 // Updates form validation based on checked

--- a/app/assets/javascripts/metrics.js
+++ b/app/assets/javascripts/metrics.js
@@ -52,6 +52,18 @@ $('.checkbox.conditions').change(function(){
 			]
 		};
 	}
+
+	if($('#extension_requests_checkbox').checkbox('is checked')){
+		fields['extension_requests_count'] = {
+			identifier: 'extension_requests_count',
+			rules: [
+				{
+					type   : 'integer[1..]',
+					prompt : 'Please enter an integer greater or equal to 1 for count'
+				}
+			]
+		};
+	}
 	
 	$('.ui.form').form({inline: true, fields});
 

--- a/app/assets/javascripts/watchlist.js
+++ b/app/assets/javascripts/watchlist.js
@@ -97,6 +97,16 @@ function get_condition_html(condition_types) {
         condition_string = `${num_grace_days_used} grace days used`;
         violation_string = violation_list.join(" | ");
         break;
+      case "extension_requests":
+        var extension_count = 0;
+        var violation_list = [];
+        $.each(violations, function( lab, val ) {
+          violation_list.push(`${lab}: ${val}`);
+          extension_count += val;
+        });
+        condition_string = `${extension_count} extension requests made`;
+        violation_string = violation_list.join(" | ");
+        break;
       default:
         console.log(`${condition} is not valid`);
         return;

--- a/app/assets/stylesheets/metrics.scss
+++ b/app/assets/stylesheets/metrics.scss
@@ -99,6 +99,10 @@ input[type="text"] {
   color: black;
 }
 
+.ui.form input[type="text"] {
+  vertical-align: baseline;
+}
+
 .ui.form .inline.fields .field .calendar:not(.popup), .ui.form .inline.field .calendar:not(.popup) {
   display: inline-flex;
 }

--- a/app/controllers/metrics_controller.rb
+++ b/app/controllers/metrics_controller.rb
@@ -285,6 +285,9 @@ private
                                    no_submissions: [:no_submissions_threshold],
                                    low_grades: %i[
                                      grade_threshold count_threshold
+                                   ],
+                                   extension_requests: %i[
+                                     extension_count
                                    ])
   end
 

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -270,6 +270,11 @@ class Course < ApplicationRecord
     asmts.where("due_at < ?", date)
   end
 
+  def asmts_after_date(date)
+    asmts = assessments.ordered
+    asmts.where("due_at > ?", date)
+  end
+
   # Used by manage extensions, create submission, and sudo
   def get_autocomplete_data
     users = {}

--- a/app/models/risk_condition.rb
+++ b/app/models/risk_condition.rb
@@ -1,7 +1,7 @@
 class RiskCondition < ApplicationRecord
   serialize :parameters, Hash
   enum condition_type: { no_condition_selected: 0, grace_day_usage: 1, grade_drop: 2,
-                         no_submissions: 3, low_grades: 4 }
+                         no_submissions: 3, low_grades: 4, extension_requests: 5 }
 
   has_many :watchlist_instances, dependent: :destroy
   belongs_to :course
@@ -11,6 +11,7 @@ class RiskCondition < ApplicationRecord
   # :grade_drop => :percentage_drop, :consecutive_counts
   # :no_submissions => :no_submissions_threshold
   # :low_grades => :grade_threshold, :count_threshold
+  # :extension_requests => :extension_count
 
   def self.create_condition_for_course_with_type(course_id, type, params, version)
     # parameter check shouldn't surface to user and is for sanity check during development only
@@ -21,6 +22,7 @@ class RiskCondition < ApplicationRecord
        (type == 3 && (params[:no_submissions_threshold].nil? || params.length != 1)) ||
        (type == 4 && (params[:grade_threshold].nil? ||
                       params[:count_threshold].nil? || params.length != 2))
+      (type == 5 && (params[:extension_count].nil? || params.length != 1))
       raise "Invalid update parameters for risk conditions! "\
             "Make sure your request body fits the criteria!"
     end

--- a/app/models/risk_condition.rb
+++ b/app/models/risk_condition.rb
@@ -21,8 +21,8 @@ class RiskCondition < ApplicationRecord
                       params[:consecutive_counts].nil? || params.length != 2)) ||
        (type == 3 && (params[:no_submissions_threshold].nil? || params.length != 1)) ||
        (type == 4 && (params[:grade_threshold].nil? ||
-                      params[:count_threshold].nil? || params.length != 2))
-      (type == 5 && (params[:extension_count].nil? || params.length != 1))
+                      params[:count_threshold].nil? || params.length != 2)) ||
+       (type == 5 && (params[:extension_count].nil? || params.length != 1))
       raise "Invalid update parameters for risk conditions! "\
             "Make sure your request body fits the criteria!"
     end

--- a/app/models/watchlist_instance.rb
+++ b/app/models/watchlist_instance.rb
@@ -430,7 +430,7 @@ class WatchlistInstance < ApplicationRecord
 
         when "extension_requests"
           extension_count = condition.parameters["extension_count"].to_i
-          new_instance = add_new_instance_for_cud_extension_requests(course,
+          new_instance = add_new_instance_for_cud_extension_requests(course, category_blocklist,
                                                                      condition.id, cud,
                                                                      extension_count)
           cur_instances << new_instance unless new_instance.nil?
@@ -513,8 +513,9 @@ class WatchlistInstance < ApplicationRecord
                           violation_info: violation_info)
   end
 
-  def self.add_new_instance_for_cud_extension_requests(course, condition_id, cud, extension_count)
-    asmts = Assessment.where(course_id: course.id).pluck(:id)
+  def self.add_new_instance_for_cud_extension_requests(course, category_blocklist,
+                                                       condition_id, cud, extension_count)
+    asmts = Assessment.where.not(category_name: category_blocklist).pluck(:id)
     violation_info = {}
     num_of_extensions = 0
 

--- a/app/models/watchlist_instance.rb
+++ b/app/models/watchlist_instance.rb
@@ -525,10 +525,18 @@ class WatchlistInstance < ApplicationRecord
       end
     end
 
-    aud = AssessmentUserDatum.find_by(course_user_datum_id: cud.id, assessment_id: asmts[0])
-
     if num_of_extensions >= extension_count
-      violation_info[aud.assessment.display_name] = num_of_extensions
+      asmts.each do |asmt|
+        extensions = Extension.where(course_user_datum_id: cud.id, assessment_id: asmt)
+        aud = AssessmentUserDatum.find_by(course_user_datum_id: cud.id, assessment_id: asmt)
+        indiv_extensions_count = 0
+        extensions.each do
+          indiv_extensions_count += 1
+        end
+        if indiv_extensions_count >= 1
+          violation_info[aud.assessment.display_name] = indiv_extensions_count
+        end
+      end
     end
 
     return if violation_info.empty?

--- a/app/models/watchlist_instance.rb
+++ b/app/models/watchlist_instance.rb
@@ -520,19 +520,14 @@ class WatchlistInstance < ApplicationRecord
 
     asmts.each do |asmt|
       extensions = Extension.where(course_user_datum_id: cud.id, assessment_id: asmt)
-      extensions.each do
-        num_of_extensions += 1
-      end
+      num_of_extensions += extensions.count
     end
 
     if num_of_extensions >= extension_count
       asmts.each do |asmt|
         extensions = Extension.where(course_user_datum_id: cud.id, assessment_id: asmt)
         aud = AssessmentUserDatum.find_by(course_user_datum_id: cud.id, assessment_id: asmt)
-        indiv_extensions_count = 0
-        extensions.each do
-          indiv_extensions_count += 1
-        end
+        indiv_extensions_count = extensions.count
         if indiv_extensions_count >= 1
           violation_info[aud.assessment.display_name] = indiv_extensions_count
         end

--- a/app/views/metrics/index.html.erb
+++ b/app/views/metrics/index.html.erb
@@ -241,7 +241,7 @@
         </div>
         Students who have greater than or equal to
         <span class="padded-span">
-          <input type="text" placeholder="1" id='extension_requests_count'>
+          <input type="text" placeholder="0" id='extension_requests_count'>
         </span>
         extensions.
       </div>
@@ -249,7 +249,7 @@
 
     <br>
     <% if @cud.instructor? %>
-      <button class="ui submit button" id="save">SAVE</button>
+      <button class="ui disabled submit button" id="save">SAVE</button>
     <% else %>
       <button class= "ui disabled submit button">SAVE</button>
       <label> You do not have permission to edit student metrics </label>

--- a/app/views/metrics/index.html.erb
+++ b/app/views/metrics/index.html.erb
@@ -241,7 +241,7 @@
         </div>
         Students who have greater than or equal to
         <span class="padded-span">
-          <input type="text" placeholder="0" id='extension_requests_count'>
+          <input type="text" placeholder="1" id='extension_requests_count'>
         </span>
         extensions.
       </div>

--- a/app/views/metrics/index.html.erb
+++ b/app/views/metrics/index.html.erb
@@ -233,8 +233,23 @@
       </div>
     </div>
     <br>
+
+    <div class="metric">
+      <div class="inline field">
+        <div class="ui checkbox conditions" id='extension_requests_checkbox'>
+          <input type="checkbox" tabindex="0" class="hidden" name="metrics-checkbox-5">
+        </div>
+        Students who have greater than or equal to
+        <span class="padded-span">
+          <input type="text" placeholder="1" id='extension_requests_count'>
+        </span>
+        extensions.
+      </div>
+    </div>
+
+    <br>
     <% if @cud.instructor? %>
-      <button class="ui disabled submit button" id="save">SAVE</button>
+      <button class="ui submit button" id="save">SAVE</button>
     <% else %>
       <button class= "ui disabled submit button">SAVE</button>
       <label> You do not have permission to edit student metrics </label>


### PR DESCRIPTION
## Description
Previously, metrics (except grace day usage) included both previous and current submissions. This filters out assignments that are not yet due and only includes assignments that are already due.

## How Has This Been Tested?
Testing in autopopulated:
- Select certain conditions in metrics.
- Check that there were students populated in watchlist. If not, try refreshing or selecting less stringent conditions.
- Hover over each student to see a list of assignments.
- Change one of the assignments due date to a date in the future
- Select conditions in the metrics, click save, and check that the assignment has disappeared when you hover over them.
- Try changing the assignment due date to something that has already passed and select the metric again.
- Click save and check that you can see the assignment when you hover over a student in the watchlist.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR
