### PR TITLE
Exclude current assignments

### DIFF
--- a/app/assets/stylesheets/metrics.scss
+++ b/app/assets/stylesheets/metrics.scss
@@ -48,7 +48,7 @@
 }
 
 .select_all {
-  margin-top: 2px; 
+  margin-top: 2px;
   margin-right: -5px;
 }
 
@@ -58,13 +58,13 @@
 
 span.padded-span:before {
   content:" ";
-  display:inline-block; 
+  display:inline-block;
   width:10px;
 }
 
 span.padded-span:after {
-  content:" "; 
-  display:inline-block; 
+  content:" ";
+  display:inline-block;
   width:10px;
 }
 
@@ -97,6 +97,10 @@ input[type="text"] {
 
 .error {
   color: black;
+}
+
+.ui.form input[type="text"] {
+  vertical-align: baseline;
 }
 
 .ui.form .inline.fields .field .calendar:not(.popup), .ui.form .inline.field .calendar:not(.popup) {
@@ -170,7 +174,7 @@ i.external.alternate {
   // color, font-weight needed here for non checkbox label
   color: black;
   font-weight: 300;
-  display: inline-block !important; 
+  display: inline-block !important;
   vertical-align: middle !important;
   -webkit-touch-callout: default !important; /* iOS Safari */
   -webkit-user-select: auto !important; /* Safari */
@@ -185,7 +189,7 @@ i.external.alternate {
   color: black;
   font-weight: 300;
 }
-.ui.checkbox.select_single label:before, 
+.ui.checkbox.select_single label:before,
 .ui.checkbox.select_single label:after {
   top: 6.5px;
 }
@@ -234,8 +238,4 @@ span.instances .segment {
 .select-all-chip {
   display: flex;
   align-items: center;
-}
-
-a:hover {
-  color: $autolab-white;
 }

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -270,6 +270,11 @@ class Course < ApplicationRecord
     asmts.where("due_at < ?", date)
   end
 
+  def asmts_after_date(date)
+    asmts = assessments.ordered
+    asmts.where("due_at > ?", date)
+  end
+
   # Used by manage extensions, create submission, and sudo
   def get_autocomplete_data
     users = {}
@@ -295,8 +300,8 @@ private
 
   def saved_change_to_grade_related_fields?
     (saved_change_to_late_slack? or saved_change_to_grace_days? or
-            saved_change_to_version_threshold? or saved_change_to_late_penalty_id? or
-            saved_change_to_version_penalty_id?)
+      saved_change_to_version_threshold? or saved_change_to_late_penalty_id? or
+      saved_change_to_version_penalty_id?)
   end
 
   def grace_days_or_late_slack_changed?


### PR DESCRIPTION
## Description
Previously, metrics (except grace day usage) included both previous and current submissions. This filters out assignments that are not yet due and only includes assignments that are already due.

## How Has This Been Tested?
Testing in autopopulated:
- Select certain conditions in metrics.
- Check that there were students populated in watchlist.
- Hover over each student to see a list of assignments.
- Change one of the assignments due date to a date in the future
- Select conditions in the metrics, click save, and check that the assignment has disappeared.
- Change the assignment due date to a date that has already passed and select the metric again.
- Click save, refresh the watchlist, and check that can see the assignment when hovering over a student.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR
