### PR TITLE
reviewpad: only summarize pull requests once

### DIFF
--- a/reviewpad.yml
+++ b/reviewpad.yml
@@ -16,6 +16,10 @@ labels:
     description: Pull request is large
     color: "#c90076"
 
+groups:
+  - name: all-reviewers
+    spec: $append($reviewers(), $requestedReviewers())
+
 # Define the list of workflows to be run by Reviewpad.
 # A workflow is a list of actions that will be executed based on the defined rules.
 # For more details see https://docs.reviewpad.com/guides/syntax#workflow.
@@ -33,7 +37,7 @@ workflows:
     description: Assign a random reviewer to pull requests
     run:
       # Automatically assign reviewer when the pull request is ready for review;
-      - if: $isDraft() == false
+      - if: $isDraft() == false && $group("all-reviewers") == []
         then: $assignReviewer($team("developers-current"), 1, "reviewpad")
 
   # This workflow labels pull requests based on the total number of lines changed.

--- a/reviewpad.yml
+++ b/reviewpad.yml
@@ -24,8 +24,8 @@ workflows:
   - name: summarize
     description: Summarize the pull request
     run:
-      # Summarize the pull request on pull request synchronization.
-      - if: ($eventType() == "synchronize" || $eventType() == "opened") && $state() == "open"
+      # Summarize the pull request on pull request creation;
+      - if: $eventType() == "opened"
         then: $summarize()
 
   # This workflow assigns a random current developer as a reviewer

--- a/reviewpad.yml
+++ b/reviewpad.yml
@@ -59,4 +59,5 @@ workflows:
       # Label pull requests with `waiting-for-review` if there are no approvals;
       - if: $isDraft() == false && $approvalsCount() < 1
         then: $addLabel("waiting-for-review")
+        else: $removeLabel("waiting-for-review")
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Only summarize pull requests once (when PR opened)
- Remove "waiting-for-review" label once an approval has been received
- Only assign reviewers when none exist

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Currently, pull requests are summarized on every update, which is noisy. This PR makes it so that pull requests are only summarized once, when they're initially opened. Note that summaries can be requested at any time via `/reviewpad summarize`.

Furthermore, the "waiting-for-review" label is always added, but never removed, which makes it pointless. Now, the label is removed once an approval is received.

Finally, this PR adds checks to ensure that reviewers are only requested if none already exist.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Go to playground and run reviewpad: https://play.reviewpad.com/8tXZ4i
- Observe output: there is an action `$removeLabel("waiting-for-review")`
- Observe output: there is no action `$assignReviewer($team("developers-current"), 1, "reviewpad")`