### PR TITLE
Add explicit import button for import asmt from tar

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -455,30 +455,6 @@ class CoursesController < ApplicationController
     send_data output, filename: "roster.csv", type: "text/csv", disposition: "inline"
   end
 
-  # install_assessment - Installs a new assessment, either by
-  # creating it from scratch, or importing it from an existing
-  # assessment directory.
-  action_auth_level :install_assessment, :instructor
-  def install_assessment
-    @assignDir = Rails.root.join("courses", @course.name)
-    @availableAssessments = []
-    begin
-      Dir.foreach(@assignDir) do |filename|
-        if File.exist?(File.join(@assignDir, filename, "#{filename}.rb"))
-          # names must be only lowercase letters and digits
-          next if filename =~ /[^a-z0-9]/
-
-          # Only list assessments that aren't installed yet
-          assessment = @course.assessments.where(name: filename).first
-          @availableAssessments << filename unless assessment
-        end
-      end
-      @availableAssessments = @availableAssessments.sort
-    rescue StandardError => e
-      render(text: "<h3>#{e}</h3>", layout: true) && return
-    end
-  end
-
   # email - The email action allows instructors to email the entire course, or
   # a single section at a time.  Sections are passed via params[:section].
   action_auth_level :email, :instructor

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -300,7 +300,7 @@ class CoursesController < ApplicationController
     user_emails = user_emails.reject(&:nil?)
 
     # check if email matches regex
-    email_regex = /\A[\w+\-.]+@[a-z\d\-]+(\.[a-z\d\-]+)*\.[a-z]+\z/i
+    email_regex = /\A[\w+\-.]+@[a-z\d-]+(\.[a-z\d-]+)*\.[a-z]+\z/i
 
     # raise error if any email is invalid and return which emails are invalid
     invalid_emails = user_emails.reject { |user| user[:email] =~ email_regex }

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -110,7 +110,7 @@ class Course < ApplicationRecord
 
   # generate course folder
   def init_course_folder
-    dir_path = @course.directory_path
+    dir_path = directory_path
     FileUtils.mkdir_p dir_path
 
     FileUtils.touch File.join(dir_path, "autolab.log")

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -42,6 +42,10 @@ class Course < ApplicationRecord
     config_file_path.sub_ext(".rb.bak")
   end
 
+  def directory_path
+    Rails.root.join("courses", name)
+  end
+
   # Create a course with name, semester, and instructor email
   # all other fields are filled in automatically
   def self.quick_create(unique_name, semester, instructor_email)
@@ -106,12 +110,12 @@ class Course < ApplicationRecord
 
   # generate course folder
   def init_course_folder
-    course_dir = Rails.root.join("courses", name)
-    FileUtils.mkdir_p course_dir
+    dir_path = @course.directory_path
+    FileUtils.mkdir_p dir_path
 
-    FileUtils.touch File.join(course_dir, "autolab.log")
+    FileUtils.touch File.join(dir_path, "autolab.log")
 
-    course_rb = File.join(course_dir, "course.rb")
+    course_rb = File.join(dir_path, "course.rb")
 
     # rubocop:disable Rails/FilePath
     default_course_rb = Rails.root.join("lib", "__defaultCourse.rb")

--- a/app/views/assessments/install_assessment.html.erb
+++ b/app/views/assessments/install_assessment.html.erb
@@ -4,7 +4,7 @@ Choose one of the following methods to install an assessment
 <div class="section">
   <h4>1. Create from scratch</h4>
   <p>Create a new assessment from scratch using our
-  	<%= link_to "Assessment Builder", new_course_assessment_path %>.</p>
+    <%= link_to "Assessment Builder", new_course_assessment_path %>.</p>
 </div>
 
 <div class="section">
@@ -46,5 +46,5 @@ Choose one of the following methods to install an assessment
   <%= form_with url: { action: :importAsmtFromTar }, builder: FormBuilderWithDateTimeInput do |f| %>
     <%= f.file_field :tarFile, name: "tarFile", button_text: "Upload Assessment Tarball" %>
     <%= f.submit "Import" %>
-	<% end %>
+  <% end %>
 </div>

--- a/app/views/assessments/install_assessment.html.erb
+++ b/app/views/assessments/install_assessment.html.erb
@@ -44,7 +44,7 @@ Choose one of the following methods to install an assessment
 <div class="section">
   <h4>3. Import from tarball</h4>
   <%= form_with url: { action: :importAsmtFromTar }, builder: FormBuilderWithDateTimeInput do |f| %>
-    <%= f.file_field :tarFile, name: "tarFile", button_text: "Upload Assessment Tarball" %>
-    <%= f.submit "Import" %>
+    <%= f.file_field :tarFile, name: "tarFile", button_text: "Choose Tarball" %>
+    <%= f.submit "Import Tarball" %>
   <% end %>
 </div>

--- a/app/views/assessments/install_assessment.html.erb
+++ b/app/views/assessments/install_assessment.html.erb
@@ -1,54 +1,33 @@
 <% @title = "Install Assessment" %>
 
-<% content_for :javascripts do %>
-  <script type="application/javascript">
-    jQuery(function() {
-      $importTarballForm = $('#import-tarball-form');
-      $tarballFilenameInput = $('#tarFile-name');
-
-      /* two-way-bind newDayField with daysField */
-      $tarballFilenameInput.on('change', function() {
-        $importTarballForm.submit();
-      });
-    });
-  </script>
-<% end %>
-
 Choose one of the following methods to install an assessment
-
 <div class="section">
-  <h4><li>Create from scratch</h4>
-  <h5>You can create a new assessment from scratch using our 
-  	<%= link_to "Assessment Builder", new_course_assessment_path %>. </h5>
+  <h4>1. Create from scratch</h4>
+  <p>Create a new assessment from scratch using our
+  	<%= link_to "Assessment Builder", new_course_assessment_path %>.</p>
 </div>
 
 <div class="section">
-  <h4>
-    <li>Import from file system
-  </h4>
-  <h5>
-    You can import an existing assessment from file system.
-  </h5>
+  <h4>2. Import from file system</h4>
   <p>
-    If you have an existing Autolab assessment from a previous course offering,
-    then you can import it into your current course:
+    Import an existing Autolab assessment from a previous course iteration.
   </p>
   <ul>
     <li>
-        Step 1: Copy the assessment from the previous course directory to the current course directory
-        (<%= File.join(Rails.root, "courses", @course.name) %>).
+        <strong>Step 1</strong>: Copy the assessment from the previous course directory to the current course directory
+        (<%= @course.directory_path %>).
     </li>
     <li>
-      Step 2: Refresh this page to cause your new assessment to appear in the list below. 
+      <strong>Step 2</strong>: Refresh this page to cause your new assessment to appear in the list below.
     </li>
     <li>
-      Step 3: Click the link on the uninstalled assessment you want to import.
+      <strong>Step 3</strong>: Click the link on the uninstalled assessment you want to import.
     </li>
-    <% if @unused_config_files.empty? then %>
+    <% if @unused_config_files.empty? %>
       <li>
-        <i>
+        <em>
           There are no uninstalled assessments available for importing.
-        </i>
+        </em>
       </li>
     <% else %>
       <ul>
@@ -62,19 +41,10 @@ Choose one of the following methods to install an assessment
   </ul>
 </div>
 
-<!-- This section is blocked off because it breaks things  -->
 <div class="section">
-  <h4><li>Import from tarball</h4>
-  <h5>You can import a tarball with the assessment directory.</h5>
-  <%= form_tag({action: :importAsmtFromTar}, multipart: true, id: "import-tarball-form") do %>
-    <div class="file-field input-field" style="margin: 1.5rem 0 !important">
-      <div class="btn">
-        <span>Browse</span>
-        <%= file_field_tag "tarFile" %>
-      </div>
-      <div class="file-path-wrapper">
-        <%= text_field_tag "tarFile-name", "Upload Assessment Tarball", class: "file-path validate" %>
-      </div>
-    </div>
+  <h4>3. Import from tarball</h4>
+  <%= form_with url: { action: :importAsmtFromTar }, builder: FormBuilderWithDateTimeInput do |f| %>
+    <%= f.file_field :tarFile, name: "tarFile", button_text: "Upload Assessment Tarball" %>
+    <%= f.submit "Import" %>
 	<% end %>
 </div>

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -21,7 +21,7 @@ ActiveRecord::Migration.maintain_test_schema!
 RSpec.configure do |config|
   config.include ActionDispatch::TestProcess
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
-  config.fixture_path = "#{::Rails.root}/spec/fixtures"
+  config.fixture_path = Rails.root.join("spec/fixtures")
 
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Summary
<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 31 May 23 18:37 UTC
This pull request includes changes to multiple files:
- Modifications to the `AssessmentsController` to use the `directory_path` method of the `Course` model.
- Removal of the `install_assessment` action from the `CoursesController`.
- Addition of a `directory_path` method to the `Course` model.
- Changes to the view for `install_assessment` that remove a broken section and replace the file input with a proper form. 
- A modification to the `fixture_path` configuration in `rails_helper.rb`.
<!-- reviewpad:summarize:end -->

## Description
<!--- Describe your changes in detail -->
- Add a `directory_path` method to Courses, which returns the path to the course directory. Used in:
  - `course.rb#init_course_folder`
  - `assessments_controller.rb#install_assessment`
  - `assessments_controller.rb#export`
  - `install_assessment.html.erb`
- Some rubocop fixes
  - Remove redundant escapes from `email_regex` in `courses_controller.rb`
  - Use `Rails.root.join` for `config.fixture_path`
- Delete unused `install_assessment` route from `courses_controller.rb`
- Refactoring of `install_assessment.html.erb`
  - Remove auto import of tarball, add explicit import button
  - Improve styling (incl. properly numbering headers, shortening / bolding text)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Currently, an uploaded assessment tarball is immediately imported without warning or indication to the user.

By adding a explicit import button, users can made an informed decision to import a tarball.

**BEFORE**
<img width="1042" alt="Screenshot 2023-05-31 at 21 55 05" src="https://github.com/autolab/Autolab/assets/9074856/5ca852ee-4616-4428-a920-0910b53ec622">

**AFTER**
<img width="1009" alt="Screenshot 2023-06-01 at 02 37 14" src="https://github.com/autolab/Autolab/assets/9074856/2d8e92e1-d5db-4b31-9512-6a4a328e5810">

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Successfully upload an assessment tarball, observe that you have to explicitly click import now. If import is clicked without providing a tarball, observe an error message.
- Successfully export the assessment
- Delete the assessment, successfully reinstall it from file system

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR