### PR TITLE
Improve viewFeedback output parsing, error robustness

### DIFF
--- a/app/controllers/assessments_controller.rb
+++ b/app/controllers/assessments_controller.rb
@@ -692,7 +692,11 @@ class AssessmentsController < ApplicationController
     end
     @total = 0
     score_hash.keys.each do |k|
-      @total += score_hash[k]
+      @total += score_hash[k].to_f
+    rescue TypeError
+      flash.now[:error] ||= ""
+      flash.now[:error] += "The score for #{k} could not be parsed.<br>"
+      flash.now[:html_safe] = true
     end
     score_hash["_total"] = @total
     score_hash

--- a/app/controllers/assessments_controller.rb
+++ b/app/controllers/assessments_controller.rb
@@ -677,6 +677,9 @@ class AssessmentsController < ApplicationController
     end
   end
 
+  # TODO: Take into account any modifications by :parseAutoresult and :modifySubmissionScores
+  # We should probably read the final scores directly
+  # See: assessment_autograde_core.rb's saveAutograde
   def parseScore(feedback)
     return if feedback.nil?
 

--- a/app/controllers/assessments_controller.rb
+++ b/app/controllers/assessments_controller.rb
@@ -693,7 +693,7 @@ class AssessmentsController < ApplicationController
     @total = 0
     score_hash.keys.each do |k|
       @total += score_hash[k].to_f
-    rescue TypeError
+    rescue TypeError, NoMethodError
       flash.now[:error] ||= ""
       flash.now[:error] += "The score for #{k} could not be parsed.<br>"
       flash.now[:html_safe] = true

--- a/app/controllers/assessments_controller.rb
+++ b/app/controllers/assessments_controller.rb
@@ -683,7 +683,7 @@ class AssessmentsController < ApplicationController
     lines = feedback.rstrip.lines
     feedback = lines[lines.length - 1]
 
-    return unless valid_json?(feedback)
+    return unless valid_json_hash?(feedback)
 
     score_hash = JSON.parse(feedback)
     score_hash = score_hash["scores"]
@@ -716,7 +716,7 @@ class AssessmentsController < ApplicationController
     lines = feedback.rstrip.lines
     feedback = lines[lines.length - 2]
 
-    return unless valid_json?(feedback)
+    return unless valid_json_hash?(feedback)
 
     jsonFeedbackHash = JSON.parse(feedback)
     if jsonFeedbackHash.key?("_presentation") == false
@@ -726,8 +726,9 @@ class AssessmentsController < ApplicationController
     end
   end
 
-  def valid_json?(json)
-    JSON.parse(json)
+  def valid_json_hash?(json)
+    parsed = JSON.parse(json)
+    parsed.is_a? Hash
   rescue JSON::ParserError, TypeError
     false
   end

--- a/app/controllers/assessments_controller.rb
+++ b/app/controllers/assessments_controller.rb
@@ -696,7 +696,7 @@ class AssessmentsController < ApplicationController
     @total = 0
     score_hash.keys.each do |k|
       @total += score_hash[k].to_f
-    rescue TypeError, NoMethodError
+    rescue NoMethodError
       flash.now[:error] ||= ""
       flash.now[:error] += "The score for #{k} could not be parsed.<br>"
       flash.now[:html_safe] = true

--- a/app/controllers/assessments_controller.rb
+++ b/app/controllers/assessments_controller.rb
@@ -680,8 +680,8 @@ class AssessmentsController < ApplicationController
   def parseScore(feedback)
     return if feedback.nil?
 
-    lines = feedback.lines
-    feedback = lines[lines.length - 1].chomp
+    lines = feedback.rstrip.lines
+    feedback = lines[lines.length - 1]
 
     return unless valid_json?(feedback)
 
@@ -713,8 +713,8 @@ class AssessmentsController < ApplicationController
   def parseFeedback(feedback)
     return if feedback.nil?
 
-    lines = feedback.lines
-    feedback = lines[lines.length - 2]&.chomp
+    lines = feedback.rstrip.lines
+    feedback = lines[lines.length - 2]
 
     return unless valid_json?(feedback)
 

--- a/app/views/assessments/_results_panel.html.erb
+++ b/app/views/assessments/_results_panel.html.erb
@@ -11,7 +11,13 @@
           <% @scoreHash.except("_total").each do |key, value| %>
             <tr>
               <td><%= key %>:</td>
-              <td><%= value.to_f.round(1) %></td>
+              <td><%=
+                begin
+                  value.to_f.round(1)
+                rescue
+                  value
+                end
+              %></td>
             </tr>
           <% end %>
           <tr style="border-bottom: none">

--- a/app/views/assessments/_semantic.html.erb
+++ b/app/views/assessments/_semantic.html.erb
@@ -78,28 +78,31 @@
 
   <% end %>
 
+  <% unless @scoreHash.nil? %>
   <h2>Score</h2>
   <table class="ui unstackable table">
     <tbody>
-    <% @jsonFeedback["_scores_order"].each do |key| %>
-      <% if key[0] != '_' %>
+      <%# If @scoreHash is not nil, then _scores_order will necessarily have been defined %>
+      <% @jsonFeedback["_scores_order"].each do |key| %>
+        <% if key[0] != '_' %>
+          <tr>
+            <td><%= key %>:</td>
+            <td><%= @scoreHash[key] %></td>
+          </tr>
+        <% end %>
+      <% end %>
+      <tr>
+        <td>Autograding Total:</td>
+        <td><%= @scoreHash["_total"] %></td>
+      </tr>
+      <% if @score.grader&.user%>
         <tr>
-          <td><%= key %>:</td>
-          <td><%= @scoreHash[key] %></td>
+          <td>Graded By:</td>
+          <td><%= @score.grader.user.email %></td>
         </tr>
       <% end %>
-    <% end %>
-    <tr>
-      <td>Autograding Total:</td>
-      <td><%= @scoreHash["_total"] %></td>
-    </tr>
-    <% if @score.grader && @score.grader.user%>
-      <tr>
-        <td>Graded By:</td>
-        <td><%= @score.grader.user.email %></td>
-      </tr>
-    <% end %>
     </tbody>
   </table>
+  <% end %>
 </div>
 

--- a/app/views/assessments/_semantic.html.erb
+++ b/app/views/assessments/_semantic.html.erb
@@ -82,7 +82,7 @@
   <h2>Score</h2>
   <table class="ui unstackable table">
     <tbody>
-      <%# If @scoreHash is not nil, then _scores_order will necessarily have been defined %>
+      <%# If @scoreHash is not nil, then _scores_order would have been defined by parseScore %>
       <% @jsonFeedback["_scores_order"].each do |key| %>
         <% if key[0] != '_' %>
           <tr>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Summary
<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 02 Jun 23 11:14 UTC
This pull request modifies `app/controllers/assessments_controller.rb` and `app/views/assessments` directory. It adds a TODO comment in a method and refactors another method to use `rstrip` instead of `chomp`. Moreover, it modifies `app/views/assessments/_results_panel.html.erb` to handle score values that cannot be parsed and `app/views/assessments/_semantic.html.erb` to check if `@scoreHash` is nil before accessing it.
<!-- reviewpad:summarize:end -->

## Description
<!--- Describe your changes in detail -->
- Strip trailing lines before parsing score and feedback on viewFeedback page
- Rename `valid_json?` to `valid_json_hash?`, add check that we parsed a hash
- Cast scores to float, add error handling
- Hide Score section for semantic feedback if score JSON could not be parsed

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
**Issue 1**: If the Autograder output has trailing newlines, semantic feedback options / score JSON are not parsed.
Consequence: Semantic feedback is not triggered when it should be, and results panel does not show all scores (it falls back to showing the current problem's score)

**Issue 2**: `valid_json?` does not check that we parsed a hash
Consequence: A scalar like `2` or `true` would pass the check, and we get an error when we try to perform hash operations on it afterwards.

**Issue 3**: Insufficient casting / error handling for scores
Consequence: Scores in strings are not opportunistically cast to floats. Scores of non-numeric types prevent the page from loading.

Fixes #1718 
Fixes #1877
Incorporates https://github.com/cg2v/Autolab/commit/f112dba0e1d8d7c623105d4b7ab9c7a6f5a02bd9 (with a bugfix)
Obsoletes https://github.com/cg2v/Autolab/commit/3b4fc3ac075bd0f61d10601896f8eff4572ccc25 (since feedback would simply be `nil` if OOB)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Import the following assessment: [randomlab_20230602.tar.zip](https://github.com/autolab/Autolab/files/11634413/randomlab_20230602.tar.zip)

For each of the following tests, you can submit any file, it simply assigns 6 random scores from 0 to 99.

For each test, the new output code will be provided. Update `driver.sh` and recompile `autograde.tar` accordingly (e.g. expand `autograde.tar`, edit `random/driver.sh`, run `gtar -cvf autograde.tar random`), and upload it to the assessment. `gtar` is gnu-tar, available via brew.

### Test 1: Normal Case
**Before + After**
<img width="1301" alt="Screenshot 2023-06-02 at 18 32 38" src="https://github.com/autolab/Autolab/assets/9074856/884f87b0-4016-46ed-adce-f56225746de3">

### Test 2: Semantic UI + Trailing new lines
```
echo "{\"_presentation\": \"semantic\"}"
echo "{\"scores\": {\"Problem 1\": $rand1, \"Problem 2\": $rand2, \"Problem 3\": $rand3, \"Problem 4\": $rand4, \"Problem 5\": $rand5, \"Problem 6\": $rand6}}"
echo ""
```
**Before**
<img width="1322" alt="Screenshot 2023-06-02 at 18 39 40" src="https://github.com/autolab/Autolab/assets/9074856/1c6735b2-fe2b-4d31-ab1b-e869c368b35d">
**After**
<img width="1041" alt="Screenshot 2023-06-02 at 18 40 23" src="https://github.com/autolab/Autolab/assets/9074856/2fbb604f-a5eb-4bfe-abbf-d6027b1a7f18">

### Test 3: Scalars
```
echo "2"
echo "{\"scores\": {\"Problem 1\": $rand1, \"Problem 2\": $rand2, \"Problem 3\": $rand3, \"Problem 4\": $rand4, \"Problem 5\": $rand5, \"Problem 6\": $rand6}}"
```
**Before**
<img width="1437" alt="Screenshot 2023-06-02 at 18 42 24" src="https://github.com/autolab/Autolab/assets/9074856/4139e7f5-c510-42b1-8af9-05960447e50f">
**After**
<img width="1297" alt="Screenshot 2023-06-02 at 18 42 56" src="https://github.com/autolab/Autolab/assets/9074856/b94f50a2-4911-4322-8d58-19568711e444">

### Test 4: Score JSON with strings
```
echo "{\"scores\": {\"Problem 1\": \"$rand1\", \"Problem 2\": $rand2, \"Problem 3\": $rand3, \"Problem 4\": $rand4, \"Problem 5\": $rand5, \"Problem 6\": $rand6}}"
```
**Before**
<img width="1423" alt="Screenshot 2023-06-02 at 18 44 45" src="https://github.com/autolab/Autolab/assets/9074856/88b6d54f-f369-4201-9493-bc8ab4e3716f">

**After**
<img width="1302" alt="Screenshot 2023-06-02 at 18 44 20" src="https://github.com/autolab/Autolab/assets/9074856/424f9de1-1d43-4022-a0bc-206e7768666b">

### Test 5: Score JSON with non-numeric
```
echo "{\"scores\": {\"Problem 1\": true, \"Problem 2\": $rand2, \"Problem 3\": $rand3, \"Problem 4\": $rand4, \"Problem 5\": $rand5, \"Problem 6\": $rand6}}"
```
**Before**
<img width="1433" alt="Screenshot 2023-06-02 at 18 45 36" src="https://github.com/autolab/Autolab/assets/9074856/d5067f78-95a3-4550-bc4d-46d9efeb4485">
**After**
<img width="1306" alt="Screenshot 2023-06-02 at 18 47 22" src="https://github.com/autolab/Autolab/assets/9074856/87bf1622-a09f-45ad-b87f-85304ad36d88">

### Test 6: Invalid Score JSON
```
echo "{\"scores\": {\"Problem 1\": invalid, \"Problem 2\": $rand2, \"Problem 3\": $rand3, \"Problem 4\": $rand4, \"Problem 5\": $rand5, \"Problem 6\": $rand6}}"
```
**Before + After**
<img width="1297" alt="Screenshot 2023-06-02 at 18 49 54" src="https://github.com/autolab/Autolab/assets/9074856/ef026f75-a438-4fc2-a3e8-058e0ee4825f">

### Test 7: Score JSON with non-numeric + Semantic UI
```
echo "{\"_presentation\": \"semantic\"}"
echo "{\"scores\": {\"Problem 1\": true, \"Problem 2\": $rand2, \"Problem 3\": $rand3, \"Problem 4\": $rand4, \"Problem 5\": $rand5, \"Problem 6\": $rand6}}"
```
**Before**
<img width="1432" alt="Screenshot 2023-06-02 at 18 53 07" src="https://github.com/autolab/Autolab/assets/9074856/8f76e084-f113-46dd-9cc1-9e936221be3e">
**After**
<img width="1052" alt="Screenshot 2023-06-02 at 18 53 30" src="https://github.com/autolab/Autolab/assets/9074856/63129c17-12b2-4287-b358-6f76cfcf046f">

### Test 8: Invalid Score JSON + Semantic UI
```
echo "{\"_presentation\": \"semantic\"}"
echo "{\"scores\": {\"Problem 1\": invalid, \"Problem 2\": $rand2, \"Problem 3\": $rand3, \"Problem 4\": $rand4, \"Problem 5\": $rand5, \"Problem 6\": $rand6}}"
```
**Before**
<img width="1427" alt="Screenshot 2023-06-02 at 18 55 51" src="https://github.com/autolab/Autolab/assets/9074856/cf54176a-a69d-476a-9193-227fa3f9b288">
**After**
<img width="1062" alt="Screenshot 2023-06-02 at 18 55 28" src="https://github.com/autolab/Autolab/assets/9074856/d5004f2b-a0ef-47e8-8933-50d64b6a0827">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR

## Other issues / help required
<!--- Do you have any other relevant issues / questions? --->
<!--- For example, if you require assistance for a certain part of your PR --->
<!--- or are facing specific issues while creating the pull request that you would like to highlight --->

Currently, the viewFeedback page re-parses the score JSON, which could display the wrong score if the `parseAutoresult` or `modifySubmissionScores` hooks were used by the lab author.

In another PR, we ought to make use of the scores directly, rather than parsing them again.
