### PR TITLE
Remove unused errors column from submission history table

### DIFF
--- a/app/controllers/assessments_controller.rb
+++ b/app/controllers/assessments_controller.rb
@@ -560,6 +560,14 @@ class AssessmentsController < ApplicationController
     @autograded = @assessment.has_autograder?
 
     @repos = GithubIntegration.find_by(user_id: @cud.user.id)&.repositories
+
+    return unless @assessment.invalid?
+
+    # On the off-chance that the assessment has validation errors, let the user know
+    # as otherwise submissions would silently fail
+    flash.now[:error] = "This assessment is invalid due to the following error(s):<br/>"
+    flash.now[:error] += @assessment.errors.full_messages.join("<br/>")
+    flash.now[:html_safe] = true
   end
 
   action_auth_level :history, :student

--- a/app/views/assessments/_submission_history_row.html.erb
+++ b/app/views/assessments/_submission_history_row.html.erb
@@ -87,9 +87,5 @@
       <%= link_to '(Destroy)', [:destroyConfirm, @course, @assessment, submission] %>
       <%= link_to '(Edit)', [:edit, @course, @assessment, submission] %>
     </td>
-
-    <% if @cud.instructor? %>
-      <td style="color: red;"><%= submission.errors.full_messages.join("<br />") %></td>
-    <% end %>
   <% end %>
 </tr>

--- a/app/views/assessments/_submission_history_table.html.erb
+++ b/app/views/assessments/_submission_history_table.html.erb
@@ -27,7 +27,6 @@
         <% if @cud.instructor? %>
           <th>Tweak</th>
           <th>Instructor Actions</th>
-          <th>Errors</th>
         <% end %>
 
       </tr>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Summary
<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 02 Jun 23 13:49 UTC
This pull request removes the "Errors" column from the table displayed in submission history, and instead displays validation errors in the flash message, if present.
<!-- reviewpad:summarize:end -->

## Description
<!--- Describe your changes in detail -->
- Remove unused errors column from submission history table
- Display assessment validation errors, if any

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Currently, the submission history table contains an "errors" column, which is meant to display any validation errors. However,
1. `.validate` is not run before displaying the errors, meaning that there would never be errors displayed
2. there should essentially never be validation errors, given that we do not skip validations when creating submissions

Thus, this PR removes the unused errors column.

Closes #1646

----
However, on very rare occasions, a submission might actually have errors. For unknown reasons, I had some assessments become invalid due to the grading deadline being set before the due date, which caused the submissions to be invalid as well. This is possibly due to timezone changes as I traveled.

<img width="1440" alt="Screenshot 2023-06-02 at 20 34 34" src="https://github.com/autolab/Autolab/assets/9074856/43e85804-066d-45c4-a29a-8059db56f9d3">

This is not a major issue, since the dates can simply be updated. However, until an instructor uncovers the root cause, any submissions to the assessment silently fail. Thus, this PR adds a warning mechanism to alert instructors when an assessment is invalid.

<img width="1059" alt="Screenshot 2023-06-02 at 21 46 00" src="https://github.com/autolab/Autolab/assets/9074856/03644534-283d-438b-9f63-26cc39614984">

This is preferable to simply adding `.validate` (below) since it provides a more specific error message.

<img width="1046" alt="Screenshot 2023-06-02 at 20 37 43" src="https://github.com/autolab/Autolab/assets/9074856/ebe6c7cb-ad69-4ab8-96fe-7014c15ee230">


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
View table on assessment handin page, as well as the pop-up when clicking on a name from the manage submissions page.

**Before**
<img width="1035" alt="Screenshot 2023-06-02 at 20 38 08" src="https://github.com/autolab/Autolab/assets/9074856/3dee1f93-b1b1-4ffb-b7a3-b892e7eb08b4">
<img width="1012" alt="Screenshot 2023-06-02 at 20 38 16" src="https://github.com/autolab/Autolab/assets/9074856/6a06f913-b60d-4f99-8575-0fbcd8f94caf">

**After**
<img width="1033" alt="Screenshot 2023-06-02 at 20 38 53" src="https://github.com/autolab/Autolab/assets/9074856/d59b69b8-6cff-45a0-89a7-0ddb51e35df7">
<img width="1011" alt="Screenshot 2023-06-02 at 20 38 46" src="https://github.com/autolab/Autolab/assets/9074856/4607214c-3439-48d3-ae2b-d9cb74c66314">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR
