### PR TITLE
Eager load course_user_datum for the index submission view

### DIFF
--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -16,7 +16,8 @@ class SubmissionsController < ApplicationController
   # this page loads.  links/functionality may be/are off
   action_auth_level :index, :instructor
   def index
-    @submissions = @assessment.submissions.order("created_at DESC")
+    @submissions = @assessment.submissions.includes({ course_user_datum: :user })
+                              .order("created_at DESC")
     @autograded = @assessment.has_autograder?
   end
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Summary
Eager loads course_user_datum and user in the submissions controller index action.

## Motivation and Context
The Manage Submissions page is slow because it loads all submissions and paginates on the frontend. This should help a little bit, but hopefully I will get time to work on backend pagination later.

## How Has This Been Tested?
Tested locally on the latest docker image.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR