### PR TITLE
Tango error flash: remove dead code and fix newline

### DIFF
--- a/app/controllers/assessment/autograde.rb
+++ b/app/controllers/assessment/autograde.rb
@@ -199,7 +199,6 @@ module AssessmentAutograde
           flash[:error] += " Please contact your instructor."
         end
       when :tango_open
-        link = "<a href=\"#{url_for(controller: 'jobs')}\">Jobs</a>"
         flash[:error] = "There was an error submitting your autograding job. We are likely down for maintenance if issues persist, please contact #{Rails.configuration.school['support_email']}"
       when :tango_upload
         flash[:error] = "There was an error uploading the submission file."
@@ -207,7 +206,7 @@ module AssessmentAutograde
         flash[:error] = "Submission was rejected by autograder."
         if @cud.instructor?
           link = (view_context.link_to "Autograder Settings", [:edit, course, assessment, :autograder])
-          flash[:error] += " (Verify the autograding properties at #{link}.)\nErrorMsg: " + e.additional_data
+          flash[:error] += " Verify the autograding properties at #{link}.<br>ErrorMsg: " + e.additional_data
           flash[:html_safe] = true
         end
       when :missing_autograder_file


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Summary
<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 11 Jun 23 18:33 UTC
This pull request removes dead code and fixes a newline in the app/controllers/assessment/autograde.rb file.
<!-- reviewpad:summarize:end -->

## Description
- Delete dead code
- Replace `\n` with `<br>` for a flash

## Motivation and Context
Addresses incidental issues found while investigating #1664.

## How Has This Been Tested?
Submit to an autograded assessment while docker is not running. Observe that newline works properly.

<img width="1239" alt="Screenshot 2023-06-12 at 02 30 58" src="https://github.com/autolab/Autolab/assets/9074856/ac044a87-6a41-459d-9a7d-267a3304944d">


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR

