### PR TITLE
Sort scoreboard beyond third column, improve CUD validations

### DIFF
--- a/app/assets/javascripts/course_user_data_edit.js
+++ b/app/assets/javascripts/course_user_data_edit.js
@@ -1,28 +1,18 @@
 function formvalidation(form){
     function DoubleByte(str) {
       for (var i = 0, n = str.length; i < n; i++) {
-        if (str[i].charCodeAt() > 127) { return true; }
+        if (str.charCodeAt(i) > 127) { return true; }
       }
       return false;
     }
-    var formlog = 'Your nickname ';
-    function flag(msg, nickname){
+    var nickname = document.getElementById('course_user_datum_nickname');
+
+    if (DoubleByte(nickname.value)){
       nickname.setAttribute('style','background-color:#FFF352');
-      if (formlog!= 'Your nickname '){formlog+=' and ';}
-      formlog +=msg;
-
       nickname.focus();
-    }
-    var nickname = document.getElementById('user_nickname');
-    var approve = true;
-
-    if (nickname.value.length>20){approve = false; flag('is too long',nickname);}
-    if (DoubleByte(nickname.value)===true){approve = false; flag('has non-ASCII characters',nickname);}
-
-    if (approve){
-      form.submit();
+      alert("Your nickname has non-ASCII characters");
     } else {
-      alert(formlog);
+      form.submit();
     }
 }
 

--- a/app/controllers/course_user_data_controller.rb
+++ b/app/controllers/course_user_data_controller.rb
@@ -160,7 +160,9 @@ class CourseUserDataController < ApplicationController
     else
       COURSE_LOGGER.log(@editCUD.errors.full_messages.join(", "))
       # error details are shown separately in the view
-      flash[:error] = "Update failed. Check all fields"
+      flash[:error] = "Update failed.<br>"
+      flash[:error] += @editCUD.errors.full_messages.join("<br>")
+      flash[:html_safe] = true
       redirect_to(action: :edit) && return
     end
   end

--- a/app/controllers/course_user_data_controller.rb
+++ b/app/controllers/course_user_data_controller.rb
@@ -72,7 +72,7 @@ class CourseUserDataController < ApplicationController
         redirect_to([:users, @course]) && return
       end
     else
-      error_msg = "Adding user failed:"
+      error_msg = "Creation failed."
       if !@newCUD.valid?
         @newCUD.errors.full_messages.each do |msg|
           error_msg += "<br>#{msg}"

--- a/app/controllers/scoreboards_controller.rb
+++ b/app/controllers/scoreboards_controller.rb
@@ -208,7 +208,7 @@ private
         str += " | "
       end
       str += hash["hdr"].to_s.upcase
-      str += hash["asc"] ? " [asc]" : " [desc]" if i < 3
+      str += hash["asc"] ? " [asc]" : " [desc]"
       i += 1
     end
     str
@@ -318,46 +318,23 @@ private
       # in descending order. Lab authors can modify the default
       # direction with the "asc" key in the column spec.
     else
-      a0 = a[:entry][0].to_f
-      a1 = a[:entry][1].to_f
-      a2 = a[:entry][2].to_f
-      b0 = b[:entry][0].to_f
-      b1 = b[:entry][1].to_f
-      b2 = b[:entry][2].to_f
-
       begin
         parsed = ActiveSupport::JSON.decode(@scoreboard.colspec)
       rescue StandardError => e
         Rails.logger.error("Error in scoreboards controller updater: #{e.message}")
       end
 
-      if a0 != b0
-        if parsed && parsed["scoreboard"] &&
-           !parsed["scoreboard"].empty? &&
-           parsed["scoreboard"][0]["asc"]
-          a0 <=> b0 # ascending order
-        else
-          b0 <=> a0 # descending order
+      if parsed && parsed["scoreboard"] && !parsed["scoreboard"].empty?
+        parsed["scoreboard"].each_with_index do |v, i|
+          ai = a[:entry][i].to_f
+          bi = b[:entry][i].to_f
+          next unless ai != bi
+          return ai <=> bi if v["asc"] # ascending
+
+          return bi <=> ai # descending otherwise
         end
-      elsif a1 != b1
-        if parsed && parsed["scoreboard"] &&
-           parsed["scoreboard"].size > 1 &&
-           parsed["scoreboard"][1]["asc"]
-          a1 <=> b1 # ascending order
-        else
-          b1 <=> a1 # descending order
-        end
-      elsif a2 != b2
-        if parsed && parsed["scoreboard"] &&
-           parsed["scoreboard"].size > 2 &&
-           parsed["scoreboard"][2]["asc"]
-          a2 <=> b2 # ascending order
-        else
-          b2 <=> a2 # descending order
-        end
-      else
-        a[:time] <=> b[:time] # ascending by submission time
       end
+      a[:time] <=> b[:time] # ascending by submission time to tiebreak
     end
   end
 end

--- a/app/controllers/scoreboards_controller.rb
+++ b/app/controllers/scoreboards_controller.rb
@@ -324,15 +324,14 @@ private
         Rails.logger.error("Error in scoreboards controller updater: #{e.message}")
       end
 
-      if parsed && parsed["scoreboard"] && !parsed["scoreboard"].empty?
-        parsed["scoreboard"].each_with_index do |v, i|
-          ai = a[:entry][i].to_f
-          bi = b[:entry][i].to_f
-          next unless ai != bi
-          return ai <=> bi if v["asc"] # ascending
+      # Validations ensure that colspec is of the correct format
+      parsed["scoreboard"].each_with_index do |v, i|
+        ai = a[:entry][i].to_f
+        bi = b[:entry][i].to_f
+        next unless ai != bi
+        return ai <=> bi if v["asc"] # ascending
 
-          return bi <=> ai # descending otherwise
-        end
+        return bi <=> ai # descending otherwise
       end
       a[:time] <=> b[:time] # ascending by submission time to tiebreak
     end

--- a/app/models/course_user_datum.rb
+++ b/app/models/course_user_datum.rb
@@ -63,17 +63,13 @@ class CourseUserDatum < ApplicationRecord
   end
 
   def valid_nickname?
-    if !nickname
-      true
-    elsif nickname.length > 32
+    if nickname.length > 32
       errors.add("nickname", "is too long (maximum is 32 characters)")
-      false
-    elsif !nickname.ascii_only?
-      errors.add("nickname", "can only contain ASCII characters")
-      false
-    else
-      true
     end
+
+    return if nickname.ascii_only?
+
+    errors.add("nickname", "can only contain ASCII characters")
   end
 
   ##

--- a/app/models/course_user_datum.rb
+++ b/app/models/course_user_datum.rb
@@ -63,6 +63,8 @@ class CourseUserDatum < ApplicationRecord
   end
 
   def valid_nickname?
+    return if nickname.nil?
+
     if nickname.length > 32
       errors.add("nickname", "is too long (maximum is 32 characters)")
     end

--- a/app/models/scoreboard.rb
+++ b/app/models/scoreboard.rb
@@ -60,12 +60,6 @@ protected
           errors.add "colspec", "unknown key('#{k}') in scoreboard[#{i}]"
           return
         end
-
-        next unless k == "asc" && i > 2
-
-        errors.add "colspec",
-                   "'asc' key in col #{i} ignored because only the first",
-                   "three columns are sorted."
       end
     end
   end

--- a/app/models/scoreboard.rb
+++ b/app/models/scoreboard.rb
@@ -24,11 +24,14 @@ protected
 
     # The parse will throw an exception if the string has a JSON syntax error
     begin
-      # Quote JSON keys and values if they are not already quoted
-      quoted = colspec.gsub(/([a-zA-Z0-9]+):/, '"\1":').gsub(/:([a-zA-Z0-9]+)/, ':"\1"')
-      parsed = ActiveSupport::JSON.decode(quoted)
+      parsed = ActiveSupport::JSON.decode(colspec)
     rescue StandardError => e
       errors.add "colspec", e.to_s
+      return
+    end
+
+    unless parsed.is_a? Hash
+      errors.add "colspec", "must be a hash object"
       return
     end
 

--- a/app/views/course_user_data/_fields.html.erb
+++ b/app/views/course_user_data/_fields.html.erb
@@ -7,7 +7,7 @@
 
   <% end %>
 
-  <%= f.text_field :nickname, help_text: "Anonymous nickname to display on the public scoreboards (maxlength: 32)", placeholder: "droh", maxlength: 32 %>
+  <%= f.text_field :nickname, help_text: "Anonymous nickname to display on the public scoreboards (max length: 32)", placeholder: "droh", maxlength: 32 %>
 
   <%= f.text_field :course_number, help_text: "The course number", placeholder: "15213", disabled: !@cud.instructor? %>
 

--- a/app/views/course_user_data/_fields.html.erb
+++ b/app/views/course_user_data/_fields.html.erb
@@ -7,7 +7,7 @@
 
   <% end %>
 
-  <%= f.text_field :nickname, help_text: "Anonymous nickname to display on the public scoreboards", placeholder: "droh" %>
+  <%= f.text_field :nickname, help_text: "Anonymous nickname to display on the public scoreboards (maxlength: 32)", placeholder: "droh", maxlength: 32 %>
 
   <%= f.text_field :course_number, help_text: "The course number", placeholder: "15213", disabled: !@cud.instructor? %>
 

--- a/app/views/course_user_data/edit.html.erb
+++ b/app/views/course_user_data/edit.html.erb
@@ -11,6 +11,6 @@
   <%= render partial: "fields", locals: {f: f, cud: @editCUD, edit: true} %>
 
   <br>
-  <input id="user_submit" name="commit" type="submit" class="btn primary" value="Save Changes" onclick="formvalidation(this.parentNode); return false;">
+  <input id="user_submit" name="commit" type="submit" class="btn primary" value="Save Changes" onclick="formvalidation(this.closest('form')); return false;">
 
 <% end %>

--- a/app/views/course_user_data/edit.html.erb
+++ b/app/views/course_user_data/edit.html.erb
@@ -4,7 +4,6 @@
   <%= javascript_include_tag "course_user_data_edit" %>
 <% end %>
 
-<br>
 <h4>Editing <%= @editCUD.user.full_name %>'s Enrollment in <%= @course.display_name %></h4>
 
 <%= form_for @editCUD, url: course_course_user_datum_path(@course, @editCUD), builder: FormBuilderWithDateTimeInput do |f| %>

--- a/app/views/course_user_data/edit.html.erb
+++ b/app/views/course_user_data/edit.html.erb
@@ -8,25 +8,10 @@
 <h4>Editing <%= @editCUD.user.full_name %>'s Enrollment in <%= @course.display_name %></h4>
 
 <%= form_for @editCUD, url: course_course_user_datum_path(@course, @editCUD), builder: FormBuilderWithDateTimeInput do |f| %>
-<% if @editCUD.errors.any? %>
-	<div id="error_explanation">
-		<h2><%= pluralize(@editCUD.errors.count, "error") %>
-      prohibited the data from being saved:</h2>
-
-		<ul>
-			<% @editCUD.errors.full_messages.each do |msg| %>
-			<li><%= msg %></li>
-			<% end %>
-		</ul>
-	</div>
-<% end %>
-
-  <br><br>
+  <br>
   <%= render partial: "fields", locals: {f: f, cud: @editCUD, edit: true} %>
 
   <br>
-  <br>
   <input id="user_submit" name="commit" type="submit" class="btn primary" value="Save Changes" onclick="formvalidation(this.parentNode); return false;">
-  <!--<%= f.submit 'Save Changes' , {:class=>""} %>-->
 
-<%end %>
+<% end %>

--- a/app/views/course_user_data/new.html.erb
+++ b/app/views/course_user_data/new.html.erb
@@ -31,25 +31,11 @@
 
 <% @title="Enroll User" %>
 
-<h2>Enroll User in <%= @course.display_name %></h2>
-
-<br>
+<h4>Enroll User in <%= @course.display_name %></h4>
 
 <%= form_for @newCUD, url: course_course_user_data_path, builder: FormBuilderWithDateTimeInput do |f| %>
 
-<% if @newCUD.errors.any? %>
-	<div id="error_explanation">
-		<h2><%= pluralize(@newCUD.errors.count, "error") %>
-      prohibited the data from being saved:</h2>
-
-		<ul>
-			<% @newCUD.errors.full_messages.each do |msg| %>
-			<li><%= msg %></li>
-			<% end %>
-		</ul>
-	</div>
-<% end %>
-
+  <br>
   <%= render partial: "fields", locals: {f: f, cud: @newCUD, edit: false} %>
 
   <br>

--- a/app/views/course_user_data/new.html.erb
+++ b/app/views/course_user_data/new.html.erb
@@ -1,4 +1,5 @@
 <% content_for :javascripts do %>
+  <%= javascript_include_tag "course_user_data_edit" %>
   <script type="application/javascript">
     $("#course_user_datum_user_attributes_email").on('change', user_lookup);
     $("#course_user_datum_user_attributes_email").on('input', user_lookup);
@@ -39,6 +40,6 @@
   <%= render partial: "fields", locals: {f: f, cud: @newCUD, edit: false} %>
 
   <br>
-  <input id="user_submit" class="btn primary"name="commit" type="submit" value="Save Changes" onclick="formvalidation(this.parentNode); return false;">
+  <input id="user_submit" class="btn primary" name="commit" type="submit" value="Save Changes" onclick="formvalidation(this.closest('form')); return false;">
 
 <% end %>

--- a/app/views/scoreboards/show.html.erb
+++ b/app/views/scoreboards/show.html.erb
@@ -80,7 +80,7 @@
   <hr>
   <div class="row valign-wrapper">
     <div class="col s6">
-      <%= f.text_field :nickname, help_text: "Anonymous nickname to display on the public scoreboards (maxlength: 32)", maxlength: 32 %>
+      <%= f.text_field :nickname, help_text: "Anonymous nickname to display on the public scoreboards (max length: 32)", maxlength: 32 %>
     </div>
     <div class="col s6">
       <input id="user_submit" name="commit" type="submit" class="btn" value="Update" onclick="formvalidation(this.closest('form')); return false;">

--- a/app/views/scoreboards/show.html.erb
+++ b/app/views/scoreboards/show.html.erb
@@ -78,10 +78,10 @@
 <%= form_for @cud, url: course_course_user_datum_path(@course, @cud), builder: FormBuilderWithDateTimeInput do |f| %>
   <hr>
   <div class="row valign-wrapper">
-    <div class="col s4">
-      <%= f.text_field :nickname %>
+    <div class="col s6">
+      <%= f.text_field :nickname, help_text: "Anonymous nickname to display on the public scoreboards (maxlength: 32)", maxlength: 32 %>
     </div>
-    <div class="col s8">
+    <div class="col s6">
       <input id="user_submit" name="commit" type="submit" class="btn" value="Update" onclick="formvalidation(this.parentNode); return false;">
     </div>
   </div>

--- a/app/views/scoreboards/show.html.erb
+++ b/app/views/scoreboards/show.html.erb
@@ -16,7 +16,6 @@
       <%= sanitize @scoreboard.banner %>
     <% end %>
   </strong>
-  <hr>
 
   <table class="sortable prettyBorder">
     <thead>
@@ -77,16 +76,6 @@
 
 
 <%= form_for @cud, url: course_course_user_datum_path(@course, @cud), builder: FormBuilderWithDateTimeInput do |f| %>
-  <% if @cud.errors.any? %>
-    <div id="error_explanation">
-      <h2><%= pluralize(@cud.errors.count, "error") %> prohibited the data from being saved:</h2>
-      <ul>
-        <% @cud.errors.full_messages.each do |msg| %>
-          <li><%= msg %></li>
-        <% end %>
-      </ul>
-    </div>
-  <% end %>
   <hr>
   <div class="row valign-wrapper">
     <div class="col s4">

--- a/app/views/scoreboards/show.html.erb
+++ b/app/views/scoreboards/show.html.erb
@@ -1,6 +1,7 @@
 <% @title = "Scoreboard" %>
 
 <% content_for :javascripts do %>
+  <%= javascript_include_tag "course_user_data_edit" %>
   <%= javascript_include_tag "sorttable" %>
 <% end %>
 
@@ -82,7 +83,7 @@
       <%= f.text_field :nickname, help_text: "Anonymous nickname to display on the public scoreboards (maxlength: 32)", maxlength: 32 %>
     </div>
     <div class="col s6">
-      <input id="user_submit" name="commit" type="submit" class="btn" value="Update" onclick="formvalidation(this.parentNode); return false;">
+      <input id="user_submit" name="commit" type="submit" class="btn" value="Update" onclick="formvalidation(this.closest('form')); return false;">
     </div>
   </div>
 <% end %>

--- a/app/views/scoreboards/show.html.erb
+++ b/app/views/scoreboards/show.html.erb
@@ -4,16 +4,19 @@
   <%= javascript_include_tag "sorttable" %>
 <% end %>
 
+<h4>Scoreboard</h4>
+
 <% if @grades.values.empty? %>
-  <h3>No submissions yet.</h3>
+  <strong>There are currently no submissions.</strong>
 <% else %>
-  <h3>
+  <strong>
     <% if @scoreboard.banner.blank? %>
       Here are the most recent scores for the class.
     <% else %>
       <%= sanitize @scoreboard.banner %>
     <% end %>
-  </h3>
+  </strong>
+  <hr>
 
   <table class="sortable prettyBorder">
     <thead>
@@ -73,19 +76,24 @@
 <% end %>
 
 
-<%= form_for @cud, url: course_course_user_datum_path(@course, @cud) do |f| %>
-<% if @cud.errors.any? %>
-  <div id="error_explanation">
-    <h2><%= pluralize(@cud.errors.count, "error") %> prohibited the data from being saved:</h2>
-    <ul>
-      <% @cud.errors.full_messages.each do |msg| %>
-        <li><%= msg %></li>
-      <% end %>
-    </ul>
+<%= form_for @cud, url: course_course_user_datum_path(@course, @cud), builder: FormBuilderWithDateTimeInput do |f| %>
+  <% if @cud.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= pluralize(@cud.errors.count, "error") %> prohibited the data from being saved:</h2>
+      <ul>
+        <% @cud.errors.full_messages.each do |msg| %>
+          <li><%= msg %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+  <hr>
+  <div class="row valign-wrapper">
+    <div class="col s4">
+      <%= f.text_field :nickname %>
+    </div>
+    <div class="col s8">
+      <input id="user_submit" name="commit" type="submit" class="btn" value="Update" onclick="formvalidation(this.parentNode); return false;">
+    </div>
   </div>
-<% end %>
-<hr>
-  <table width=50% class="verticalTable" >
-  <tr><th><h3>Nickname:</h3> </th><td><%= f.text_field :nickname %>  <input id="user_submit" name="commit" type="submit" class="btn" value="Update Nickname" onclick="formvalidation(this.parentNode); return false;"></td></tr>
-  </table>
 <% end %>

--- a/docs/features/scoreboards.md
+++ b/docs/features/scoreboards.md
@@ -24,7 +24,7 @@ The column spec consists of a "scoreboard" object, which is an array of JSON obj
 }
 ```
 
-A custom scoreboard sorts the first three columns, from left to right, in descending order. You can change the default sort order for a particular column by adding an optional "asc:1" element to its hash.
+A custom scoreboard sorts the columns from left to right in descending order, and tiebreaks by submission time. You can change the default sort order for a particular column by adding an optional "asc:1" element to its hash.
 
 **Example:** Scoreboard with two columns, "Score" and "Ops", with "Score" sorted descending, and then "Ops" ascending:
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Summary
<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 21 Jun 23 18:44 UTC
This pull request includes changes to several files. The file 'scoreboards.md' has a minor change, sorting all columns in descending order and tie-breaking by submission time. The view file 'app/views/course_user_data/new.html.erb' has several updates, including adding a javascript_include_tag and modifying the onclick function of the submit button. The Scoreboard view has also been updated in the 'scoreboard.rb' file in the 'app/models' directory, including a validation check for the column specification and refactored code to handle all scoreboard columns. Changes have been made to the `CourseUserDataController` in the Rails application, including modifying error messages and allowing for HTML in the flash[:error] message. The form validation function and nickname validation method have also been updated.
<!-- reviewpad:summarize:end -->

## Description
<!--- Describe your changes in detail -->
- Refresh scoreboard#show page
- Scoreboard now sorts all columns, not just up to the third column
- Update docs to reflect change
- Fix CUD form validation
- Remove unnecessary error display code: they basically don't work because errors (during create / update) are cleared during redirects, so this PR uses flashes instead. A user would not be able to load the scoreboard if they had errors in their CUD because they would have been redirected to the edit page.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Currently, only the first three columns of any scoreboard is sorted (when using a custom column specification). This PR remedies that so all columns are now sorted.

Note: I don't expect this to break any scoreboard code, since scoreboards generally consist of numeric data. Even if they contain string data, `to_f` casts non-numeric strings to `0.0`, which is as good as not sorting.

Closes #970

Furthermore, the custom form validation for the nickname fields is currently broken and does not work. Validation errors are also not shown since a redirect takes place.

This PR fixes the validation code, shows errors in flashes instead, and adds more visual cues (e.g. set `maxlength` = 32, indicate in help text)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Install the following assessment (after unzipping): 
[randomlab_20230616.tar.zip](https://github.com/autolab/Autolab/files/11767997/randomlab_20230616.tar.zip)

Submit any file using three different student accounts. View scoreboard.

### Before
Specification: `{"scoreboard": [ {"hdr":"Problem 1"}, {"hdr":"Problem 2"}, {"hdr":"Problem 3"}, {"hdr":"Problem 4"}, {"hdr":"Problem 5"}, {"hdr":"Problem 6"} ] }`
Observe: `PROBLEM 6` (no `asc` or `desc`)
<img width="1030" alt="Screenshot 2023-06-16 at 15 16 20" src="https://github.com/autolab/Autolab/assets/9074856/e4f3b075-ca9e-4ff9-8f49-c6a48ef01624">

Observe: last column not sorted (tiebreak by time)
<img width="1047" alt="Screenshot 2023-06-16 at 15 16 28" src="https://github.com/autolab/Autolab/assets/9074856/15efc322-4568-436c-8191-e171ca46684f">

### After (Descending)
Specification: `{"scoreboard": [ {"hdr":"Problem 1"}, {"hdr":"Problem 2"}, {"hdr":"Problem 3"}, {"hdr":"Problem 4"}, {"hdr":"Problem 5"}, {"hdr":"Problem 6"} ] }`
Observe: `PROBLEM 6 [desc]`
<img width="1070" alt="Screenshot 2023-06-16 at 15 14 11" src="https://github.com/autolab/Autolab/assets/9074856/8177e228-d6b3-418d-bdb7-a1ed6f36807d">

Observe: last column sorted in descending order
<img width="1032" alt="Screenshot 2023-06-16 at 16 27 52" src="https://github.com/autolab/Autolab/assets/9074856/fe22325b-ed43-492a-a57f-7b401b3c40f4">


### After (Ascending)
Specification:  `{"scoreboard": [ {"hdr":"Problem 1"}, {"hdr":"Problem 2"}, {"hdr":"Problem 3"}, {"hdr":"Problem 4"}, {"hdr":"Problem 5"}, {"hdr":"Problem 6", "asc": 1} ] }`
Observe: `PROBLEM 6 [asc]`
<img width="1041" alt="Screenshot 2023-06-16 at 15 14 43" src="https://github.com/autolab/Autolab/assets/9074856/3b6ac973-55df-40bd-aef2-050ca776abc0">

Observe: last column sorted in ascending order
<img width="1044" alt="Screenshot 2023-06-16 at 16 28 11" src="https://github.com/autolab/Autolab/assets/9074856/ffe39bd9-43a7-4d9d-bf9e-59659a144876">

### Others
- Check documentation

Column specification
- Try saving a specification of `true` -> get error `Colspec must be a hash object`
- Try saving a specification which is missing quotes around one of the strings -> get error (similar to) `Colspec 451: unexpected token at '{hdr:"Problem 6"} ] }'`

Form validation
- Test form validation on scoreboard page, edit CUD, new CUD pages: attempt to save nickname with non-ascii characters (e.g. 你好) -> observe alert, and highlighting + focusing of nickname field
<img width="1066" alt="Screenshot 2023-06-16 at 16 24 11" src="https://github.com/autolab/Autolab/assets/9074856/eae4a684-526d-4418-8f9c-5e380fca3513">
<img width="646" alt="Screenshot 2023-06-16 at 16 24 14" src="https://github.com/autolab/Autolab/assets/9074856/1db1b827-8e03-4924-9d5e-8d31fac7058a">

- Observe helptext additionally states "(maxlength: 32)"
<img width="1064" alt="Screenshot 2023-06-16 at 16 28 35" src="https://github.com/autolab/Autolab/assets/9074856/f3429b15-a37b-4f12-ab89-3d2bb6c44927">

<img width="1050" alt="Screenshot 2023-06-16 at 16 28 49" src="https://github.com/autolab/Autolab/assets/9074856/96b9310f-22e3-4d67-afdb-08439e47e080">

- You can also disable frontend validation and try saving a nickname of length > 32 and with non-ascii characters (e.g. `12345678123456781234567812345678你好`)

**Updating via Scoreboard or Edit page**

<img width="1074" alt="Screenshot 2023-06-16 at 16 35 07" src="https://github.com/autolab/Autolab/assets/9074856/421d7016-a719-4a6b-9d08-576bdbd6e922">

**Creation**

<img width="428" alt="Screenshot 2023-06-22 at 02 43 08" src="https://github.com/autolab/Autolab/assets/9074856/ff93a960-f07e-40f2-a854-2ae8d80093bc">


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [x] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [x] I have updated the documentation accordingly, included in this PR