### PR TITLE
Lock passenger-ruby27 to v2.5.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@
 #     https://github.com/phusion/passenger-docker
 #
 #
-FROM phusion/passenger-ruby27
+FROM phusion/passenger-ruby27:2.5.0
 
 MAINTAINER Autolab Development Team "autolab-dev@andrew.cmu.edu"
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Summary
<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 21 Jun 23 19:02 UTC
This pull request locks passenger-ruby27 to v2.5.0 in the Dockerfile.
<!-- reviewpad:summarize:end -->

## Description
<!--- Describe your changes in detail -->
Lock the version of passenger-ruby27 in the Dockerfile to v2.5.0.

(Essentially https://github.com/UB-CSE-IT/Autolab/commit/1730a507eb6ed7e442e01e102053566ec6ff0ae2)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
With passenger-docker v2.5.1 ([changelog](https://github.com/phusion/passenger-docker/blob/master/CHANGELOG.md)), the version of ruby 2.7.x used was bumped to 2.7.8.

This is at odds with the Gemfile, preventing the image from building.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Run `docker compose build` before and after checking out this PR in the Autolab submodule of `autolab-docker`.

**BEFORE**
<img width="794" alt="Screenshot 2023-06-22 at 02 54 19" src="https://github.com/autolab/Autolab/assets/9074856/4f33d43a-a963-49e5-bd4e-4eb2933f0380">

**AFTER**
<img width="794" alt="Screenshot 2023-06-22 at 02 58 56" src="https://github.com/autolab/Autolab/assets/9074856/c08928e5-fc04-4582-a6cb-727cf4a95ee2">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR
