### PR TITLE
Add student emails to downloadAll archives

### DIFF
--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -623,6 +623,18 @@ private
                                        tweak_attributes: %i[_destroy kind value])
   end
 
+  # Given the path to a file, return the filename to use when the user downloads it
+  # path should be of the form .../<ver>_<handin> or .../annotated_<ver>_<handin>
+  # returns <email>_<asmt>_<ver>_<handin> or annotated_<email>_<asmt>_<ver>_<handin>
+  def download_filename(path, asmt_name = nil, student_email = nil)
+    basename = File.basename path
+    basename_parts = basename.split("_")
+    basename_parts.insert(-3, student_email) if student_email
+    basename_parts.insert(-3, asmt_name) if asmt_name
+
+    basename_parts.join("_")
+  end
+
   def get_submission_file
     unless @submission.filename
       flash[:error] = "No file associated with submission."
@@ -630,20 +642,13 @@ private
     end
 
     @filename = @submission.handin_file_path
-    basename = File.basename @filename
-    basename_parts = basename.split("_")
-    basename_parts.prepend(@assessment.name)
-    basename_parts.prepend(@submission.course_user_datum.user.email)
-    @basename = basename_parts.join("_")
+    @basename = download_filename(@filename, @assessment.name,
+                                  @submission.course_user_datum.user.email)
 
     unless @submission.handin_annotated_file_path.nil?
       @filename_annotated = @submission.handin_annotated_file_path
-      basename_annotated = File.basename @filename_annotated
-      basename_parts_annotated = basename_annotated.split("_")
-      # Preserve first element as "annotated"
-      basename_parts_annotated.insert(-3, @assessment.name)
-      basename_parts_annotated.insert(-4, @submission.course_user_datum.user.email)
-      @basename_annotated = basename_parts_annotated.join("_")
+      @basename_annotated = download_filename(@filename_annotated, @assessment.name,
+                                              @submission.course_user_datum.user.email)
     end
 
     unless File.exist? @filename

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -634,11 +634,10 @@ private
     end
 
     @filename = @submission.handin_file_path
-    @basename = File.basename @filename
-
-    basename_parts = @basename.split("_")
-    basename_parts.insert(-3, @assessment.name)
-
+    basename = File.basename @filename
+    basename_parts = basename.split("_")
+    basename_parts.prepend(@assessment.name)
+    basename_parts.prepend(@submission.course_user_datum.user.email)
     @basename = basename_parts.join("_")
 
     unless File.exist? @filename

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -625,12 +625,11 @@ private
 
   # Given the path to a file, return the filename to use when the user downloads it
   # path should be of the form .../<ver>_<handin> or .../annotated_<ver>_<handin>
-  # returns <email>_<asmt>_<ver>_<handin> or annotated_<email>_<asmt>_<ver>_<handin>
-  def download_filename(path, asmt_name = nil, student_email = nil)
+  # returns <email>_<ver>_<handin> or annotated_<email>_<ver>_<handin>
+  def download_filename(path, student_email = nil)
     basename = File.basename path
     basename_parts = basename.split("_")
     basename_parts.insert(-3, student_email) if student_email
-    basename_parts.insert(-3, asmt_name) if asmt_name
 
     basename_parts.join("_")
   end
@@ -642,12 +641,11 @@ private
     end
 
     @filename = @submission.handin_file_path
-    @basename = download_filename(@filename, @assessment.name,
-                                  @submission.course_user_datum.user.email)
+    @basename = download_filename(@filename, @submission.course_user_datum.user.email)
 
     unless @submission.handin_annotated_file_path.nil?
       @filename_annotated = @submission.handin_annotated_file_path
-      @basename_annotated = download_filename(@filename_annotated, @assessment.name,
+      @basename_annotated = download_filename(@filename_annotated,
                                               @submission.course_user_datum.user.email)
     end
 

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -658,25 +658,4 @@ private
 
     true
   end
-
-  # Extract the andrewID from a filename.
-  # Filename format is andrewID_version_assessment.ext
-  def extractAndrewID(filename)
-    underscoreInd = filename.index("_")
-    return filename[0...underscoreInd] unless underscoreInd.nil?
-
-    nil
-  end
-
-  # Extract the version from a filename
-  # Filename format is andrewID_version_assessment.ext
-  def extractVersion(filename)
-    firstUnderscoreInd = filename.index("_")
-    return nil if firstUnderscoreInd.nil?
-
-    secondUnderscoreInd = filename.index("_", firstUnderscoreInd + 1)
-    return nil if secondUnderscoreInd.nil?
-
-    filename[firstUnderscoreInd + 1...secondUnderscoreInd].to_i
-  end
 end

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -631,10 +631,10 @@ private
   # Given the path to a file, return the filename to use when the user downloads it
   # path should be of the form .../<ver>_<handin> or .../annotated_<ver>_<handin>
   # returns <email>_<ver>_<handin> or annotated_<email>_<ver>_<handin>
-  def download_filename(path, student_email = nil)
+  def download_filename(path, student_email)
     basename = File.basename path
     basename_parts = basename.split("_")
-    basename_parts.insert(-3, student_email) if student_email
+    basename_parts.insert(-3, student_email)
 
     basename_parts.join("_")
   end

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -213,10 +213,6 @@ class SubmissionsController < ApplicationController
                 disposition: "inline"
 
     elsif params[:annotated]
-
-      @filename_annotated = @submission.handin_annotated_file_path
-      @basename_annotated = File.basename @filename_annotated
-
       @problems = @assessment.problems.to_a
       @problems.sort! { |a, b| a.id <=> b.id }
 
@@ -639,6 +635,16 @@ private
     basename_parts.prepend(@assessment.name)
     basename_parts.prepend(@submission.course_user_datum.user.email)
     @basename = basename_parts.join("_")
+
+    unless @submission.handin_annotated_file_path.nil?
+      @filename_annotated = @submission.handin_annotated_file_path
+      basename_annotated = File.basename @filename_annotated
+      basename_parts_annotated = basename_annotated.split("_")
+      # Preserve first element as "annotated"
+      basename_parts_annotated.insert(-3, @assessment.name)
+      basename_parts_annotated.insert(-4, @submission.course_user_datum.user.email)
+      @basename_annotated = basename_parts_annotated.join("_")
+    end
 
     unless File.exist? @filename
       flash[:error] = "Could not find submission file."

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -161,9 +161,9 @@ class SubmissionsController < ApplicationController
     if @assessment.disable_handins
       flash[:error] = "There are no submissions to download."
       if @cud.course_assistant
-        redirect_to([@course, @assessment])
+        redirect_to course_assessment_path(@course, @assessment)
       else
-        redirect_to([@course, @assessment, :submissions])
+        redirect_to course_assessment_submissions_path(@course, @assessment)
       end
       return
     end
@@ -189,9 +189,9 @@ class SubmissionsController < ApplicationController
     if result.nil?
       flash[:error] = "There are no submissions to download."
       if @cud.course_assistant
-        redirect_to([@course, @assessment])
+        redirect_to course_assessment_path(@course, @assessment)
       else
-        redirect_to([@course, @assessment, :submissions])
+        redirect_to course_assessment_submissions_path(@course, @assessment)
       end
       return
     end
@@ -211,7 +211,7 @@ class SubmissionsController < ApplicationController
       file, pathname = Archive.get_nth_file(@filename, params[:header_position].to_i)
       unless file && pathname
         flash[:error] = "Could not read archive."
-        redirect_to [@course, @assessment] and return false
+        redirect_to course_assessment_path(@course, @assessment) and return
       end
 
       send_data file,
@@ -269,7 +269,6 @@ class SubmissionsController < ApplicationController
       send_file @filename,
                 filename: @basename,
                 disposition: "inline"
-      #  :type => mime
     end
   end
 

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -635,7 +635,6 @@ private
     basename = File.basename path
     basename_parts = basename.split("_")
     basename_parts.insert(-3, student_email)
-
     basename_parts.join("_")
   end
 

--- a/lib/archive.rb
+++ b/lib/archive.rb
@@ -210,16 +210,17 @@ module Archive
   end
 
   ##
-  # returns a zip archive containing every file in the given path array
+  # returns a zip archive containing every file in the given filedata array
+  # each entry in the filedata array is of the form [filepath, filename]
   #
-  def self.create_zip(paths)
-    return nil if paths.nil? || paths.empty?
+  def self.create_zip(filedata)
+    return nil if filedata.nil? || filedata.empty?
 
     # don't create a tempfile, just stream it to client for download
     zip_stream = Zip::OutputStream.write_buffer do |zos|
-      paths.each do |filepath|
+      filedata.each do |(filepath, filename)|
         ctimestamp = Zip::DOSTime.at(File.open(filepath,"r").ctime) # use creation time of submitted file
-        zip_entry = Zip::Entry.new(zos, "#{File.basename(filepath)}", nil, nil, nil, nil, nil, nil,
+        zip_entry = Zip::Entry.new(zos, filename, nil, nil, nil, nil, nil, nil,
                     ctimestamp)
         zos.put_next_entry(zip_entry)
         zos.print File.read(filepath)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Summary
<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 27 Jun 23 16:06 UTC
This pull request refactors the downloadAll method in submissions_controller, modifying the way it selects and zips the submissions for download. The zip archive now uses the student's email and the original filename for each submission. Additionally, it changes Archive.create_zip to take in a list of tuples representing the submission file path and the filename to be used for that submission.
<!-- reviewpad:summarize:end -->

## Description
<!--- Describe your changes in detail -->
- Replace old-style paths with path helpers (`course_assessment_path`, `course_assessment_submissions_path`)
- Refactor `downloadAll` and `create_zip` to include student emails for files in the resultant archive
- Moved definition of `@filename_annotated` and `@basename_annotated` to `get_submission_file` where it logically belongs
- Extracted filename logic into `download_filename`. Also made the filenames of downloaded files consistent. 
  - Normal files: `<asmt>_<ver>_<handin>` -> `<email>_<ver>_<handin>`
  - Annotated files: `annotated_<ver>_<handin>` -> `annotated_<email>_<ver>_<handin>`
  - Files in `downloadAll` archive: `<ver>_<handin>` -> `<email>_<ver>_<handin>` 
 - Remove unused methods `extractAndrewID` and `extractVersion`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

In #1831, the handin directory was refactored by creating subdirectories for each student. As a side effect, the base filename of files were changed from `<email>_<ver>_<handin name>` to `<ver>_<handin name>`. Thus, there is a name collision when downloadAll is called, causing the archive to only include one copy of each version.

This PR updates the `create_zip` method to take in filenames as well, which will contain student emails.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Normal downloads
Create an assessment that accepts PDF, and submit a PDF. View the submission.
- Ensure that "download file" button yields file with correct filename format (e.g. `xho@andrew.cmu.edu_1_handin.pdf`)
- Ensure that "download annotated" button yields file with correct filename format (e.g. `annotated_xho@andrew.cmu.edu_1_handin.pdf`)

You can use right click > save link as to force a download.

### downloadAll
Create an assessment and submit several times with different users.
- Ensure that "download all submissions" yields all submissions
<img width="492" alt="Screenshot 2023-06-25 at 02 36 00" src="https://github.com/autolab/Autolab/assets/9074856/369e3fb5-8107-4e02-998c-31e31d408088">

- Ensure that "download final submissions" only yield final submissions
<img width="481" alt="Screenshot 2023-06-25 at 02 36 10" src="https://github.com/autolab/Autolab/assets/9074856/d9bfebe0-ee09-436e-95a8-c8fed76be00f">

### Sanity Checks
- Ensured that `course_assessment_path` and `course_assessment_submissions_path` are the correct path helpers to use, by looking at the list of routes (visit a non-existent route to see the list) and also calling `downloadAll` on submission-less assessments
- Ensured that `extractAndrewID` and `extractVersion` are not used anywhere
- Ensured that `create_zip` isn't used anywhere besides `downloadAll`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR
