### PR TITLE
Use omniauthv2-shibboleth for omniauth v2 compat

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,7 +59,7 @@ gem 'devise', '>=4.5.0'
 gem 'omniauth', '>=1.2.2'
 gem 'omniauth-facebook', '>=2.0.0'
 gem 'omniauth-google-oauth2', '>=0.2.5'
-gem 'omniauth-shibboleth', '>=1.1.2'
+gem 'omniauth-shibboleth-redux', '~> 2.0', require: 'omniauth-shibboleth'
 
 # OAuth2 authentication
 gem 'oauth2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -250,8 +250,8 @@ GEM
     omniauth-oauth2 (1.7.3)
       oauth2 (>= 1.4, < 3)
       omniauth (>= 1.9, < 3)
-    omniauth-shibboleth (1.3.0)
-      omniauth (>= 1.0.0)
+    omniauth-shibboleth-redux (2.0.0)
+      omniauth (>= 2.0.0)
     orm_adapter (0.5.0)
     overcommit (0.59.1)
       childprocess (>= 0.6.3, < 5)
@@ -272,7 +272,7 @@ GEM
       pdf-reader (~> 1.2)
       ruby-rc4
       ttfunk (~> 1.0.3)
-    psych (4.0.4)
+    psych (5.1.0)
       stringio
     public_suffix (4.0.7)
     racc (1.7.0)
@@ -394,7 +394,7 @@ GEM
     sqlite3 (1.5.1-arm64-darwin)
     sqlite3 (1.5.1-x86_64-darwin)
     sqlite3 (1.5.1-x86_64-linux)
-    stringio (3.0.2)
+    stringio (3.0.7)
     terser (1.1.11)
       execjs (>= 0.3.0, < 3)
     thin (1.8.1)
@@ -478,7 +478,7 @@ DEPENDENCIES
   omniauth (>= 1.2.2)
   omniauth-facebook (>= 2.0.0)
   omniauth-google-oauth2 (>= 0.2.5)
-  omniauth-shibboleth (>= 1.1.2)
+  omniauth-shibboleth-redux (~> 2.0)
   overcommit
   populator (>= 1.0.0)
   prawn (= 0.13.0)
@@ -509,4 +509,4 @@ RUBY VERSION
    ruby 2.7.7p221
 
 BUNDLED WITH
-   2.4.12
+   2.4.14


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Summary
<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 29 Jun 23 14:07 UTC
This pull request updates the usage of the `omniauth-shibboleth` gem to version `1.3.2` in the Gemfile, replacing the previous version `1.1.2`. This change allows for compatibility with `omniauth` version 2.0.0 or higher. The Gemfile.lock has been updated accordingly.
<!-- reviewpad:summarize:end -->

## Description
Swap out the omniauth-shibboleth gem for omniauthv2-shibboleth (from https://github.com/lukaskoenen/omniauth-shibboleth)
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The original omniauth-shibboleth gem has been unmaintained since 2018, and is not compatible with omniauth 2.x and ruby 3.x. A possibly unintended consequence of #1380 was that omniauth 2.0 was introduced.

The omniauth-shibboleth gem was forked and updated so that gitlab could use shibboleth with omniauth 2.0 (https://gitlab.com/gitlab-org/gitlab/-/merge_requests/121235). Autolab can also make use of it!
This change does NOT obsolete #1593. There are use cases for both generic SAML authentication and shibboleth


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR

## Other issues / help required
<!--- Do you have any other relevant issues / questions? --->
<!--- For example, if you require assistance for a certain part of your PR --->
<!--- or are facing specific issues while creating the pull request that you would like to highlight --->

I will run tests shortly and update here.
