### PR TITLE
Make problem names be unique within assessments

### DIFF
--- a/app/models/problem.rb
+++ b/app/models/problem.rb
@@ -11,6 +11,7 @@ class Problem < ApplicationRecord
   has_many :annotations, dependent: :destroy
 
   validates :name, :max_score, presence: true
+  validates :name, uniqueness: { case_sensitive: false, scope: :assessment_id }
   validates_associated :assessment
 
   after_commit -> { assessment.dump_yaml }

--- a/db/migrate/20230707161335_make_problem_name_unique.rb
+++ b/db/migrate/20230707161335_make_problem_name_unique.rb
@@ -1,0 +1,6 @@
+class MakeProblemNameUnique < ActiveRecord::Migration[6.0]
+  def change
+     add_index :problems, [:assessment_id, :name], unique: true, name: 'problem_uniq'
+
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_06_25_131325) do
+ActiveRecord::Schema.define(version: 2023_07_07_161335) do
 
   create_table "annotations", force: :cascade do |t|
     t.integer "submission_id"
@@ -263,6 +263,7 @@ ActiveRecord::Schema.define(version: 2023_06_25_131325) do
     t.datetime "updated_at"
     t.float "max_score", default: 0.0
     t.boolean "optional", default: false
+    t.index ["assessment_id", "name"], name: "problem_uniq", unique: true
   end
 
   create_table "risk_conditions", force: :cascade do |t|


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Summary
<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 07 Jul 23 19:00 UTC
This pull request makes problem names unique within assessments. Problem names are used as lookup keys, so it is important for them to have the uniqueness property of a key in both the model and the database. The patch adds a validation to ensure the uniqueness of problem names in the Problem model, and creates a migration to add a unique index on the `problems` table in the database. This ensures that each problem name within an assessment is unique.
<!-- reviewpad:summarize:end -->

## Description
Update the problem model and database schema to apply a uniqueness constraint on the names of Problem objects (within the scope of an assessment)
<!--- Describe your changes in detail -->

## Motivation and Context
Problem names are used as lookup keys, and so should have the uniqueness property of a key. Duplicate problem names could result in multiple scoreboard columns with the same name and different values, or some submissions having a value in one column and others using a different one.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Unit tests have been run with this patch applied
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR

## Other issues / help required
<!--- Do you have any other relevant issues / questions? --->
<!--- For example, if you require assistance for a certain part of your PR --->
<!--- or are facing specific issues while creating the pull request that you would like to highlight --->
If an existing installation already has duplicate problem names, the database migration will fail.