### PR TITLE
Update "Bulk Email Instructors" to work with MySQL's ONLY_FULL_GROUP_BY

### DIFF
--- a/app/controllers/admins_controller.rb
+++ b/app/controllers/admins_controller.rb
@@ -6,7 +6,7 @@ class AdminsController < ApplicationController
 
   action_auth_level :email_instructors, :administrator
   def email_instructors
-    @cuds = CourseUserDatum.select(:user_id).distinct.joins(:course).joins(:user)
+    @cuds = CourseUserDatum.select([:user_id, :email]).distinct.joins(:course).joins(:user)
                            .where(instructor: true)
                            .order("users.email ASC")
 

--- a/app/controllers/admins_controller.rb
+++ b/app/controllers/admins_controller.rb
@@ -6,9 +6,9 @@ class AdminsController < ApplicationController
 
   action_auth_level :email_instructors, :administrator
   def email_instructors
-    @cuds = CourseUserDatum.select([:user_id, :email]).distinct.joins(:course).joins(:user)
-                           .where(instructor: true)
-                           .order("users.email ASC")
+    @users = User.select(:email).joins(:course_user_data).distinct
+                 .where(course_user_data: { instructor: true })
+                 .order('email ASC')
 
     return unless request.post?
 

--- a/app/views/admins/email_instructors.html.erb
+++ b/app/views/admins/email_instructors.html.erb
@@ -38,8 +38,8 @@
 
   <h3>This email will be sent to the following users:</h3>
   <ul>
-    <% @cuds.each do |cud| %>
-      <li><%= cud.email %></li>
+    <% @users.each do |user| %>
+      <li><%= user.email %></li>
     <% end %>
   </ul>
 <% end %>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Summary
<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 07 Jul 23 19:17 UTC
This pull request updates the query in the admins_controller.rb file to work with MySQL's default ONLY_FULL_GROUP_BY mode. The query used when doing a bulk email to instructors now selects both the user ID and email, and orders the results by email in ascending order.
<!-- reviewpad:summarize:end -->

## Description
Update the query used when doing a bulk email to instructors to work with MySQL's default ONLY_FULL_GROUP_BY mode
<!--- Describe your changes in detail -->

## Motivation and Context
In newer versions of MySQL, the default SQL_MODE includes ONLY_FULL_GROUP_BY.
Among other things, this means that a query that has DISTINCT and ORDER BY is rejected as invalid if any ORDER BY expression includes columns not in the select list (see https://dev.mysql.com/doc/refman/8.0/en/group-by-handling.html for a more precise statement of the restrictions)
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
This problem was discovered while running unit tests against MySQL 8.0 and fixes an exception that occurred when testing AdminsController#email_instructors
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR

## Other issues / help required
<!--- Do you have any other relevant issues / questions? --->
<!--- For example, if you require assistance for a certain part of your PR --->
<!--- or are facing specific issues while creating the pull request that you would like to highlight --->
This query probably could be simplified. At the very least, I don't see why the :courses table is joined.