### PR TITLE
Fix importAsmtFromTar error handling

### DIFF
--- a/app/controllers/assessments_controller.rb
+++ b/app/controllers/assessments_controller.rb
@@ -169,6 +169,8 @@ class AssessmentsController < ApplicationController
       redirect_to(action: "install_assessment") && return
     rescue StandardError => e
       flash[:error] = "Error while reading the tarball -- #{e.message}."
+      puts("ERRRR")
+      puts(e.backtrace)
       redirect_to(action: "install_assessment") && return
     end
 
@@ -991,11 +993,19 @@ private
       pathname.chomp!("/") if entry.directory?
       # nested directories are okay
       if entry.directory? && pathname.count("/") == 0
-        return false if asmt_name
+        if asmt_name
+          flash[:error] = "Error in tarball: Found root directory #{asmt_name}
+                           but also encountered root directory #{pathname} folder. Ensure
+                           there is only one root directory in the tar."
+          return false
+        end
 
         asmt_name = pathname
       else
-        return false unless asmt_name
+        if !asmt_name
+          flash[:error] = "Error in tarball: No root directory found"
+          return false
+        end
 
         if pathname == "#{asmt_name}/#{asmt_name}.rb"
           # We only ever read once, so no need to rewind after

--- a/app/controllers/assessments_controller.rb
+++ b/app/controllers/assessments_controller.rb
@@ -169,8 +169,6 @@ class AssessmentsController < ApplicationController
       redirect_to(action: "install_assessment") && return
     rescue StandardError => e
       flash[:error] = "Error while reading the tarball -- #{e.message}."
-      puts("ERRRR")
-      puts(e.backtrace)
       redirect_to(action: "install_assessment") && return
     end
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Summary
reviewpad:summary

## Description
<!--- Describe your changes in detail -->
- fixes issue where an invalid assessment structure for a tarball is found in `valid_asmt_tar`, but the error displayed is wrong, due to a bug in the error flashing code
- Gives more detailed feedback regarding the two buggy errors

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #1938 

When trying to import an invalid assessment that falls under the buggy error code, users will see the following error, which isn't accurate:
![image](https://github.com/autolab/Autolab/assets/25730111/df580520-e86d-4b2a-b4bb-97806f69c3fa)

This occurs because Line 157 in assessments controller (`importAsmtFromTar`)  contains `flash[:error] += ` when `valid_asmt_tar` (validating tar and extracted structure matches what is expected ) returns false. However, there are certain conditions in `valid_asmt_tar `that cause it to short circuit return without setting `flash[:error]`  so then this causes a `nil` exception.

This short circuiting happens when there are multiple root directories or no root directories found in an assessment tarball.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Use the following tars:
[two_root_directories.tar.zip](https://github.com/autolab/Autolab/files/12024059/two_root_directories.tar.zip)
[no_root_directory.tar.zip](https://github.com/autolab/Autolab/files/12024060/no_root_directory.tar.zip)

- Try importing the `two_root_directories.tar`, see the following error is properly displayed:
<img width="1185" alt="Screenshot 2023-07-11 at 10 09 53 PM" src="https://github.com/autolab/Autolab/assets/25730111/15476b29-44dd-4115-83cb-63e0073a131e">
- Try importing the `no_root_directory.tar`, see the following error is properly displayed:
<img width="1219" alt="Screenshot 2023-07-11 at 10 10 08 PM" src="https://github.com/autolab/Autolab/assets/25730111/a911ba29-ec94-4061-942c-49da8524d794">

## Types of changes


<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting