### PR TITLE
Prevent failing import from file system from deleting assessment files

### DIFF
--- a/app/controllers/assessments_controller.rb
+++ b/app/controllers/assessments_controller.rb
@@ -115,7 +115,7 @@ class AssessmentsController < ApplicationController
         # add line break if adding to existing error message
         flash.now[:error] = flash.now[:error] ? "#{flash.now[:error]} <br>" : ""
         flash.now[:error] += "An error occurred while trying to display an existing assessment " \
-            "on file directory #{filename}: assessment file names must only contain lowercase " \
+            "from file directory #{filename}: assessment file names must only contain lowercase " \
             "letters and digits with no spaces"
         flash.now[:html_safe] = true
         next
@@ -129,8 +129,8 @@ class AssessmentsController < ApplicationController
                                ))
         unless props["general"] && (props["general"]["name"] == filename)
           flash.now[:error] = flash.now[:error] ? "#{flash.now[:error]} <br>" : ""
-          flash.now[:error] += "An error occurred while trying to display an existing assessment" \
-          "on file directory #{filename}: Name in yaml (#{props['general']['name']}) " \
+          flash.now[:error] += "An error occurred while trying to display an existing assessment " \
+          "from file directory #{filename}: Name in yaml (#{props['general']['name']}) " \
           "doesn't match #{filename}"
           flash.now[:html_safe] = true
           next
@@ -138,7 +138,7 @@ class AssessmentsController < ApplicationController
       else
         flash.now[:error] = flash.now[:error] ? "#{flash.now[:error]} <br>" : ""
         flash.now[:error] += "An error occurred while trying to display an existing assessment " \
-          "on file directory #{filename}: #{filename}.yml does not exist"
+          "from file directory #{filename}: #{filename}.yml does not exist"
         flash.now[:html_safe] = true
         next
       end
@@ -232,7 +232,7 @@ class AssessmentsController < ApplicationController
     end
 
     params[:assessment_name] = asmt_name
-    params[:isTarImport] = true
+    params[:cleanup_on_failure] = true
     importAssessment && return
   end
 
@@ -242,7 +242,7 @@ class AssessmentsController < ApplicationController
   action_auth_level :importAssessment, :instructor
 
   def importAssessment
-    isTarImport = params[:isTarImport]
+    cleanup_on_failure = params[:cleanup_on_failure]
     @assessment = @course.assessments.new(name: params[:assessment_name])
     assessment_path = Rails.root.join("courses/#{@course.name}/#{@assessment.name}")
     # not sure if this check is 100% necessary anymore, but is a last resort
@@ -254,9 +254,7 @@ class AssessmentsController < ApplicationController
       destroy_no_redirect
       # delete files explicitly b/c the paths don't match ONLY if
       # import was from tarball
-      if isTarImport
-        FileUtils.rm_rf(assessment_path)
-      end
+      FileUtils.rm_rf(assessment_path) if cleanup_on_failure
       redirect_to(install_assessment_course_assessments_path(@course)) && return
     end
 
@@ -267,9 +265,7 @@ class AssessmentsController < ApplicationController
       destroy_no_redirect
       # delete files explicitly b/c the paths don't match ONLY if
       # import was from tarball
-      if isTarImport
-        FileUtils.rm_rf(assessment_path)
-      end
+      FileUtils.rm_rf(assessment_path) if cleanup_on_failure
       redirect_to(install_assessment_course_assessments_path(@course)) && return
     end
     @assessment.load_embedded_quiz # this will check and load embedded quiz
@@ -281,9 +277,7 @@ class AssessmentsController < ApplicationController
       destroy_no_redirect
       # delete files explicitly b/c the paths don't match ONLY if
       # import was from tarball
-      if isTarImport
-        FileUtils.rm_rf(assessment_path)
-      end
+      FileUtils.rm_rf(assessment_path) if cleanup_on_failure
       redirect_to(install_assessment_course_assessments_path(@course)) && return
     end
     flash[:success] = "Successfully imported #{@assessment.name}"

--- a/app/controllers/assessments_controller.rb
+++ b/app/controllers/assessments_controller.rb
@@ -121,8 +121,8 @@ class AssessmentsController < ApplicationController
         next
       end
 
-      # each assessment must have an associated yaml file, and it must have a name field that matches
-      # its filename
+      # each assessment must have an associated yaml file,
+      # and it must have a name field that matches its filename
       if File.exist?(File.join(dir_path, filename, "#{filename}.yml"))
         props = YAML.safe_load(File.open(
                                  File.join(dir_path, filename, "#{filename}.yml"), "r", &:read

--- a/app/controllers/assessments_controller.rb
+++ b/app/controllers/assessments_controller.rb
@@ -121,8 +121,21 @@ class AssessmentsController < ApplicationController
         next
       end
 
-      # each assessment must have an associated yaml file
-      unless File.exist?(File.join(dir_path, filename, "#{filename}.yml"))
+      # each assessment must have an associated yaml file, and it must have a name field that matches
+      # its filename
+      if File.exist?(File.join(dir_path, filename, "#{filename}.yml"))
+        props = YAML.safe_load(File.open(
+                                 File.join(dir_path, filename, "#{filename}.yml"), "r", &:read
+                               ))
+        unless props["general"] && (props["general"]["name"] == filename)
+          flash.now[:error] = flash.now[:error] ? "#{flash.now[:error]} <br>" : ""
+          flash.now[:error] += "An error occurred while trying to display an existing assessment" \
+          "on file directory #{filename}: Name in yaml (#{props['general']['name']}) " \
+          "doesn't match #{filename}"
+          flash.now[:html_safe] = true
+          next
+        end
+      else
         flash.now[:error] = flash.now[:error] ? "#{flash.now[:error]} <br>" : ""
         flash.now[:error] += "An error occurred while trying to display an existing assessment " \
           "on file directory #{filename}: #{filename}.yml does not exist"
@@ -219,6 +232,7 @@ class AssessmentsController < ApplicationController
     end
 
     params[:assessment_name] = asmt_name
+    params[:isTarImport] = true
     importAssessment && return
   end
 
@@ -228,6 +242,7 @@ class AssessmentsController < ApplicationController
   action_auth_level :importAssessment, :instructor
 
   def importAssessment
+    isTarImport = params[:isTarImport]
     @assessment = @course.assessments.new(name: params[:assessment_name])
     assessment_path = Rails.root.join("courses/#{@course.name}/#{@assessment.name}")
     # not sure if this check is 100% necessary anymore, but is a last resort
@@ -237,8 +252,11 @@ class AssessmentsController < ApplicationController
                        but assessment file name is #{params[:assessment_name]}"
       # destroy model
       destroy_no_redirect
-      # need to delete explicitly b/c the paths don't match
-      FileUtils.rm_rf(assessment_path)
+      # delete files explicitly b/c the paths don't match ONLY if
+      # import was from tarball
+      if isTarImport
+        FileUtils.rm_rf(assessment_path)
+      end
       redirect_to(install_assessment_course_assessments_path(@course)) && return
     end
 
@@ -247,8 +265,11 @@ class AssessmentsController < ApplicationController
     rescue StandardError => e
       flash[:error] = "Error loading yaml: #{e}"
       destroy_no_redirect
-      # need to delete explicitly b/c the paths don't match
-      FileUtils.rm_rf(assessment_path)
+      # delete files explicitly b/c the paths don't match ONLY if
+      # import was from tarball
+      if isTarImport
+        FileUtils.rm_rf(assessment_path)
+      end
       redirect_to(install_assessment_course_assessments_path(@course)) && return
     end
     @assessment.load_embedded_quiz # this will check and load embedded quiz
@@ -258,8 +279,11 @@ class AssessmentsController < ApplicationController
     rescue StandardError => e
       flash[:error] = "Error loading config module: #{e}"
       destroy_no_redirect
-      # need to delete explicitly b/c the paths don't match
-      FileUtils.rm_rf(assessment_path)
+      # delete files explicitly b/c the paths don't match ONLY if
+      # import was from tarball
+      if isTarImport
+        FileUtils.rm_rf(assessment_path)
+      end
       redirect_to(install_assessment_course_assessments_path(@course)) && return
     end
     flash[:success] = "Successfully imported #{@assessment.name}"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Summary
<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 25 Jul 23 04:32 UTC
This pull request includes three patches. 

The first patch (PATCH 1/3) makes changes to the assessments_controller.rb file. It adds a check to ensure that each assessment has an associated yaml file with a name field that matches the filename. It also handles errors when displaying existing assessments.

The second patch (PATCH 2/3) also modifies the assessments_controller.rb file. It updates the comments to clarify the requirements for each assessment's associated yaml file, and it fixes some formatting issues.

The third patch (PATCH 3/3) addresses comments from a previous pull request. It renames the isTarImport parameter to cleanup_on_failure and updates the corresponding code. It also improves error handling and removes unnecessary code.

Overall, these patches enhance the functionality and error handling of the assessments_controller.rb file.
<!-- reviewpad:summarize:end -->

## Description
<!--- Describe your changes in detail -->
- use `isTarImport` parameter to`importAssessment` to determine whether import is from tarball (aka from `importAsmtTar`) or from file system
- delete assessment files only is import was from a tarball import, otherwise leave files as-is
- Add pre-check in `install_assessment` to check for invalid name field in yaml to prevent installation of invalid assessment (and thus prevent yaml from getting wiped out, which happens if the error was only caught during deserialization)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- Closes #1944

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Delete existing assessment (go to "Edit Assessment"->"Delete Assessment")
- Find assessment in file system, navigate to yaml, change `name` field to not match filename
- Go to "Install Assessment," see following error appears and that assessment doesn't show up under "Import from File System"
  <img width="1512" alt="Screenshot 2023-07-17 at 9 43 24 PM" src="https://github.com/autolab/Autolab/assets/25730111/949d3221-ce20-48a8-9fb2-f17bdf7e311c">
- Fix the yaml name, then change config rb module name so that it doesn't match the filename / assessment name
- Try installing the assessment, see following error:
  <img width="1511" alt="Screenshot 2023-07-17 at 9 46 42 PM" src="https://github.com/autolab/Autolab/assets/25730111/fa90fa0c-7455-4bbc-83b1-d1327d5dbbe2">
- verify that assessment directory is still there


Regression:
- import from tarball a buggy assessment (such as `spec/fixtures/assessments/homework02-yaml-name-field-wrong.tar`), and try importing it
- see error is displayed and that assessment directory is deleted from course directory
- Upload a normal tarball / import from file system a normal directory and see that import succeeds
- Run `bundle exec rake spec` multiple times and see that tests pass

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
