### PR TITLE
Send Tango unambiguous filenames for user handins

### DIFF
--- a/app/helpers/assessment_autograde_core.rb
+++ b/app/helpers/assessment_autograde_core.rb
@@ -331,6 +331,7 @@ module AssessmentAutogradeCore
     # of files needed by the autograder. Can be overridden in the
     # lab config file.
     local_handin = submission.handin_file_path
+    remote_handin = submission.handin_file_long_filename
     local_makefile = File.join(ass_dir, "autograde-Makefile")
     local_autograde = File.join(ass_dir, "autograde.tar")
 
@@ -338,7 +339,9 @@ module AssessmentAutogradeCore
     dest_handin = assessment.handin_filename
 
     # Construct the array of input files.
-    handin = { "localFile" => local_handin, "destFile" => dest_handin }
+    handin = { "localFile" => local_handin,
+               "remoteFile" => remote_handin,
+               "destFile" => dest_handin }
     makefile = { "localFile" => local_makefile, "destFile" => "Makefile" }
     autograde = { "localFile" => local_autograde, "destFile" => "autograde.tar" }
 

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -164,6 +164,10 @@ class Submission < ApplicationRecord
     "#{version}_#{assessment.handin_filename}"
   end
 
+  def handin_file_long_filename
+    "#{course_user_datum.email}_#{version}_#{assessment.handin_filename}"
+  end
+
   def handin_file_path
     return nil unless filename
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Summary
<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 18 Jul 23 17:15 UTC
This pull request includes three patches:

1. The first patch exports a new method `handin_file_long_filename` in the `Submission` model, which generates a long filename for the handin file by including the student's email address.

2. The second patch allows the `autogradeInputFiles` method in the `assessment_autograde_core` helper to provide a `remoteFile` attribute for autograding file uploads to the Tango server. If `remoteFile` is not provided, the value of `localFile` will be used instead.

3. The third patch updates the `autogradeInputFiles` method in the `assessment_autograde_core` helper to use the full filename (including the student's email address) for handin file uploads to the Tango server.

Please review these patches for implementation correctness and possible improvements.
<!-- reviewpad:summarize:end -->

## Description
Tango handin filenames need to be unique per user/version (and also course/assessment) so that grading always applies to the student's work and not someone elses. This patch restores the upload filename to &lt;email&gt;\_&lt;version&gt;\_&lt;handin&gt;.&lt;ext&gt; from &lt;version&gt;\_&lt;handin&gt;.&lt;ext&gt;
<!--- Describe your changes in detail -->

## Motivation and Context
Since #1831 , autolab has been sending tango filenames of the form &lt;version&gt;_&lt;handin&gt;.&lt;ext&gt;. This means that if multiple students submit near-simultaneously, and they are at the the same version number, it is likely that the grade both receive will be based on only one of their handins.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Deployed to autolab-dev.andrew.cmu.edu
Submitted new handin for https://autolab-dev.andrew.cmu.edu/courses/TestCourse-s23/assessments/hello
Verified that the files uploaded to tango had the email address in them for both new handins and regrades.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR

## Other issues / help required
<!--- Do you have any other relevant issues / questions? --->
<!--- For example, if you require assistance for a certain part of your PR --->
<!--- or are facing specific issues while creating the pull request that you would like to highlight --->

If someone is working on an alternative approach, feel free to reject this PR