### PR TITLE
Handle orphaned annotations on view feedback page

### DIFF
--- a/app/views/assessments/_remarks_panel.html.erb
+++ b/app/views/assessments/_remarks_panel.html.erb
@@ -5,7 +5,7 @@
     </div>
     <% subs_by_problem = @submission.annotations.group_by(&:problem)
         subs_by_problem.each do |problem, annotations| %>
-        <b> <%= problem.name %> </b>
+        <b> <%= problem.nil? ? "Deleted Problem(s)" : problem.name %> </b>
         <ul class="collection">
         <%# use custom sort b/c using ordering doesn't work with autograder output, archived files %>
         <%


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Summary
<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 20 Jul 23 17:50 UTC
This pull request fixes a bug related to checking for nil values in the `_remarks_panel.html.erb` file. The patch updates the code to include a check for `problem.nil?`, displaying "Deleted Problem(s)" if the problem is nil. This change ensures that the code handles nil values correctly.
<!-- reviewpad:summarize:end -->

## Description
<!--- Describe your changes in detail -->
Handle orphaned annotations on the view feedback page by grouping them under the problem "Deleted Problem(s)"

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Orphaned annotations were possible in the past if the problem corresponding to an annotation is deleted. This is no longer possible as of #1629 since deleting a problem now deletes its associated annotations.

However, it is pertinent to still handle any existing orphaned annotations. #1658 handled this by adding the logic `problem.nil? ? "Deleted Problem(s)" : problem.name`, but the logic was undone in #1645.

This PR restores the required logic to handle orphaned annotations.

Closes #1949

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Under `problem.rb`, comment out the line `has_many :annotations, dependent: :destroy`

- Make a submission to an autograded problem
- Create a problem and annotate the submission
- Delete the problem
- Click on the autograded score to access the view feedback page
- Observe that page loads, annotation is under "Deleted Problem(s)"

<img width="984" alt="Screenshot 2023-07-21 at 01 55 04" src="https://github.com/autolab/Autolab/assets/9074856/73d1412d-7112-4155-800f-33ce10a03b46">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR
