### PR TITLE
Hide download handout button if assessement has no handout

### DIFF
--- a/app/controllers/assessment/handout.rb
+++ b/app/controllers/assessment/handout.rb
@@ -11,6 +11,7 @@ module AssessmentHandout
   end
 
   def handout
+    # If the logic here changes, do update assessment#has_handout?
     extend_config_module(@assessment, nil, @cud)
 
     if @assessment.overwrites_method?(:handout)

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -333,6 +333,10 @@ class Assessment < ApplicationRecord
     writeup_is_url? || writeup_is_file?
   end
 
+  def has_handout?
+    overwrites_method?(:handout) || handout_is_url? || handout_is_file?
+  end
+
   def groups
     Group.joins(:assessment_user_data).where(assessment_user_data: { assessment_id: id }).distinct
   end

--- a/app/views/assessments/show.html.erb
+++ b/app/views/assessments/show.html.erb
@@ -123,12 +123,12 @@
         <div class="collapsible-body">
           <ul class="options">
             <li><%= link_to "View handin history", {:action => 'history'}, {:title=> "View your submissions, scores, and feedback from the course staff" } %> </li>
-
             <% if @assessment.has_writeup? %>
-              <li><%= link_to "View writeup", {:action => 'writeup'}, {:title=> "View the assessment writeup", :class=>""}%> </li>
+              <li><%= link_to "View writeup", {:action => 'writeup'}, {:title=> "View the assessment writeup"} %> </li>
             <% end %>
-
-            <li><%= link_to "Download handout", {:action => 'handout'}, {:title=> "Download handout materials and starter code" } %> </li>
+            <% if @assessment.has_handout? %>
+              <li><%= link_to "Download handout", {:action => 'handout'}, {:title=> "Download handout materials and starter code" } %> </li>
+            <% end %>
             <% if @assessment.has_groups? %>
               <% if @aud.membership_status != AssessmentUserDatum::UNCONFIRMED then %>
                 <li><%= link_to "Group options", [@course, @assessment, @aud.group], title: "Check your group settings." %></li>
@@ -139,7 +139,6 @@
             <% if @assessment.has_scoreboard? %>
               <li><%= link_to "View scoreboard", [@course, @assessment, :scoreboard], title: "View the assessment scoreboard" %></li>
             <% end %>
-
           <% @list.sort { |a,b| a[1] <=> b[1] }.each { |key, value| %>
             <% if value.size > 0  then  %>
               <li><%= link_to value, {:action => key}, {:title=>(@list_title[key] || "")} %> </li>

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -45,6 +45,10 @@ RSpec.configure do |config|
     Capybara::Selenium::Driver.new(app, browser: :chrome)
   end
 
+  # Temporary fix for chromedriver version issue, until we can update Selenium
+  # https://github.com/titusfortner/webdrivers/issues/247
+  Webdrivers::Chromedriver.required_version = "114.0.5735.90"
+
   Capybara.register_driver :headless_chrome do |app|
     capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
       'goog:chromeOptions': { args: %w[headless] }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Summary
<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 02 Aug 23 05:00 UTC
This pull request includes two patches. 

The first patch hides the "handout" button if no handout is defined. It makes changes to the handout controller, assessment model, and the show.html.erb view file.

The second patch provides a temporary fix for a chromedriver issue. It adds a fix to the rails_helper.rb file to address a specific version issue with chromedriver.

Please review these changes and test them accordingly.
<!-- reviewpad:summarize:end -->

## Description
<!--- Describe your changes in detail -->
Hide "download handout" button if assessment does not overwrite `handout` method, and `handout` is neither a url nor a file.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Removes non-applicable menu items to avoid clutter and confusion. (similar logic for the writeup button was applied in #1615)

Closes #1941

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Create a new assessment, observe that "download handout" button is absent
- Set `handout` to be a random string, observe that "download handout" button is still absent
- Set `handout` to be a url, observe that "download handout" button appears and works
- Set `handout` to be a file (e.g. `<asmt>.yml`), observe that "download handout" button appears and works
- Clear value of `handout`, define `handout` method in `.rb` file as follows:
```ruby
def handout
    {
      "fullpath" => "<full path to a file>",
      "filename" => "<file name>"
    }
end
```
Reload config file. Observe that "download handout" button appears and works.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR

