### PR TITLE
Lint views/problems

### DIFF
--- a/app/assets/stylesheets/problems.css.scss
+++ b/app/assets/stylesheets/problems.css.scss
@@ -1,6 +1,5 @@
 form.new_problem,
 form.edit_problem {
-  max-width: 600px;
 
   div.action_buttons {
     margin: 25px 0 15px 0;

--- a/app/views/problems/_fields.html.erb
+++ b/app/views/problems/_fields.html.erb
@@ -1,15 +1,16 @@
-<h2>Edit Problem</h2>
-<br>
 <%= f.error_messages %>
 
-<%= f.text_field :name, help_text: "Each problem has a name that is unique to the assessment.", placeholder: "E.g. problem1", required: true %>
+<%= f.text_field :name, help_text: "Each problem has a name that is unique to the assessment.",
+                        placeholder: "problem1", required: true %>
 
 <%= f.text_field :description, help_text: "Short description of the problem.", placeholder: "(Optional)" %>
 
 <% if @problem %>
-<%= f.number_field :max_score, help_text: "The maximum score for this problem.", value: @problem.max_score, placeholder: "E.g. 0", step: "any", required: true %>
+<%= f.number_field :max_score, help_text: "The maximum score for this problem.",
+                               value: @problem.max_score, placeholder: "0", step: "any", required: true %>
 <% else %>
-<%= f.number_field :max_score, help_text: "The maximum score for this problem.", value: 0, placeholder: "E.g. 0", step: "any", required: true %>
+<%= f.number_field :max_score, help_text: "The maximum score for this problem.",
+                               value: 0, placeholder: "0", step: "any", required: true %>
 <% end %>
 
 <%= f.check_box :optional, help_text: "By default, all problems are
@@ -20,10 +21,12 @@ problem. Use this option carefully. In most cases, you should leave it
 unchecked." %>
 
 <div class="action_buttons">
-	<%= f.submit "Save Problem" , {:class=>"btn primary"} %>
-	<% if @problem %>
-	<button class="delete_btn"> 
-	  <%= link_to "Delete this Problem", [@course, @assessment, @problem], method: :delete, class: 'btn btn-danger', data: { confirm: "Deleting will delete all associated problem data (such as scores and annotations) and cannot be undone. Are you sure you want to delete this problem?" } %>
-	</button>
-	<% end %>
+  <%= f.submit "Save Problem", { class: "btn primary" } %>
+  <% if @problem %>
+  <button class="delete_btn">
+    <%= link_to "Delete this Problem", [@course, @assessment, @problem],
+                method: :delete, class: 'btn btn-danger',
+                data: { confirm: "Deleting will delete all associated problem data (such as scores and annotations) and cannot be undone. Are you sure you want to delete this problem?" } %>
+  </button>
+  <% end %>
 </div>

--- a/app/views/problems/edit.html.erb
+++ b/app/views/problems/edit.html.erb
@@ -5,6 +5,10 @@
   <%= stylesheet_link_tag "problems" %>
 <% end %>
 
-<%= form_for @problem, url: course_assessment_problem_path(@course, @assessment, @problem), method: :patch, builder: FormBuilderWithDateTimeInput do |f|%>
-  <%= render partial: "fields", locals: {f: f} %>
+<h2>
+  Edit Problem
+</h2>
+<%= form_for @problem, url: course_assessment_problem_path(@course, @assessment, @problem),
+                       method: :patch, builder: FormBuilderWithDateTimeInput do |f| %>
+  <%= render partial: "fields", locals: { f: f } %>
 <% end %>

--- a/app/views/problems/new.html.erb
+++ b/app/views/problems/new.html.erb
@@ -5,6 +5,10 @@
   <%= stylesheet_link_tag "problems" %>
 <% end %>
 
-<%= form_for :problem, url: course_assessment_problems_path(@course, @assessment), method: :post, html: {class: 'edit_problem'}, builder: FormBuilderWithDateTimeInput do |f|%>
-  <%= render partial: "fields", locals: {f: f} %>
+<h2>
+  Create New Problem
+</h2>
+<%= form_for :problem, url: course_assessment_problems_path(@course, @assessment), method: :post,
+                       html: { class: 'edit_problem' }, builder: FormBuilderWithDateTimeInput do |f| %>
+  <%= render partial: "fields", locals: { f: f } %>
 <% end %>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Summary
<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 14 Aug 23 18:22 UTC
This pull request includes changes to the views and stylesheets related to problems. The changes fix some linting issues and improve the formatting and readability of the code.
<!-- reviewpad:summarize:end -->

## Description
<!--- Describe your changes in detail -->
- Run `erblint` on `views/problems` using `bundle exec erblint app/views/problems/*.html.erb -a`      
- Edit `_fields.html.erb` to have better placeholder values, and move "Edit Problem" header out of file so that "New Problem" page doesn't have "Edit Problem" header and has correct header of "Create New Problem"
- Fix styling so that form takes up full width of page

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Part of summer linting

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Verified that creating a new problem works, page renders
- Verified that editing a problem works and page renders

### New Problem page

Before:

<img width="1512" alt="Screenshot 2023-08-14 at 11 18 16 AM" src="https://github.com/autolab/Autolab/assets/25730111/a304b1cc-e6cf-4b8e-adc7-4687b4a96bef">

After:

<img width="1512" alt="Screenshot 2023-08-14 at 11 17 46 AM" src="https://github.com/autolab/Autolab/assets/25730111/6da016fc-2c4d-48f0-92b3-42b080e5fef6">


### Edit Problem page

Before:

<img width="1512" alt="Screenshot 2023-08-14 at 11 18 16 AM" src="https://github.com/autolab/Autolab/assets/25730111/cc16ef6c-1a0c-4e21-8adf-5d1849b5c4f3">

After:

<img width="1512" alt="Screenshot 2023-08-14 at 11 17 55 AM" src="https://github.com/autolab/Autolab/assets/25730111/d39447f0-5218-464f-8068-885add079b4d">

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting

