### PR TITLE
Use unordered Course.assessments to get categories

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -254,7 +254,7 @@ class Course < ApplicationRecord
   end
 
   def assessment_categories
-    assessments.distinct.pluck(:category_name).sort
+    assessments.unscope(:order).distinct.pluck(:category_name).sort
   end
 
   def assessments_with_category(cat_name, is_student = false)


### PR DESCRIPTION
Course.assessment_categories needs to make sure that the associated .assessments do not have an .order scope attached

<!--- Provide a general summary of your changes in the Title above -->

## Summary
<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 18 Aug 23 16:28 UTC
This pull request updates the `Course` model to use unordered `Course.assessments` when retrieving categories for assessment categories. Specifically, the `assessment_categories` method now uses `assessments.unscope(:order)` instead of `assessments` to ensure that the associated assessments do not have an `order` scope attached.
<!-- reviewpad:summarize:end -->

## Description
<!--- Describe your changes in detail -->
Courses have an assessment_categories method that returns the list of categories for all the assessments in the course as a list of strings. It uses an ActiveRecord query with `distinct` to get this list.

This change makes sure that there is no `ORDER BY` in the resulting query.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
If the database used by autolab is a mysql instance with [ONLY_FULL_GROUP_BY](https://dev.mysql.com/doc/refman/8.0/en/sql-mode.html#sqlmode_only_full_group_by) enabled, the gradebook cannot be rendered unless this change is included (or the sql_mode is changed)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR

## Other issues / help required
<!--- Do you have any other relevant issues / questions? --->
<!--- For example, if you require assistance for a certain part of your PR --->
<!--- or are facing specific issues while creating the pull request that you would like to highlight --->
