### PR TITLE
Lint views/groups

### DIFF
--- a/app/views/groups/_form.html.erb
+++ b/app/views/groups/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_for @group, url: [@course, @assessment, @group], builder: FormBuilderWithDateTimeInput do |f| %>
+<%= form_for @group, url: course_assessment_group_url(@course, @assessment, @group), builder: FormBuilderWithDateTimeInput do |f| %>
   <%= f.text_field :name, help_text: "Change the name of this group." %>
 
   <%= f.submit "Change Name" %>

--- a/app/views/groups/_list_item.html.erb
+++ b/app/views/groups/_list_item.html.erb
@@ -1,11 +1,12 @@
 <li>
   <h3><%= group.name %></h3>
-  <p><b><%= group.assessment_user_data.all.map{|aud| aud.course_user_datum.full_name }.join(", ") %></b></p>
+  <p><b><%= group.assessment_user_data.all.map{ |aud| aud.course_user_datum.full_name }.join(", ") %></b></p>
   <p>
-    <%= link_to "Ask to Join Group", [:join, @course, @assessment, group], method: :post %>
+    <%= link_to "Ask to Join Group", join_course_assessment_group_path(@course, @assessment, group), method: :post %>
     <% if @cud.instructor then %>
-      | <%= link_to "View", [@course, @assessment, group] %>
-      | <%= link_to "Destroy", [@course, @assessment, group], method: :delete, data: { confirm: "Are you sure you want to disband this group?" } %>
+      | <%= link_to "View", course_assessment_group_path(@course, @assessment, group) %>
+      | <%= link_to "Destroy", course_assessment_group_path(@course, @assessment, group),
+                    method: :delete, data: { confirm: "Are you sure you want to disband this group?" } %>
     <% end %>
   </p>
 </li>

--- a/app/views/groups/_new_form.html.erb
+++ b/app/views/groups/_new_form.html.erb
@@ -1,13 +1,13 @@
 <%= form_tag action: :create do %>
   <div class="form-group">
     <label class="control-label" for="group_name">Group Name</label>
-    <%= text_field_tag :group_name, nil, class: "form-control" %>
+    <%= text_field_tag :group_name, nil, class: "form-control", autocomplete: "off" %>
     <p class="help-block">Set the name of this group.</p>
   </div>
 
   <div class="form-group">
     <label class="control-label" for="member_email">Partner Email</label>
-    <%= text_field_tag :member_email, nil, class: "form-control" %>
+    <%= text_field_tag :member_email, nil, class: "form-control", autocomplete: "email" %>
     <p class="help-block">The email of your desired partner. They will need to confirm their membership.</p>
   </div>
 

--- a/app/views/groups/_new_form.html.erb
+++ b/app/views/groups/_new_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_tag [@course, @assessment, @group] do %>
+<%= form_tag action: :create do %>
   <div class="form-group">
     <label class="control-label" for="group_name">Group Name</label>
     <%= text_field_tag :group_name, nil, class: "form-control" %>
@@ -11,5 +11,5 @@
     <p class="help-block">The email of your desired partner. They will need to confirm their membership.</p>
   </div>
 
-  <%= submit_tag "Create Group", class:"btn btn-primary" %>
+  <%= submit_tag "Create Group", class: "btn btn-primary" %>
 <% end %>

--- a/app/views/groups/index.html.erb
+++ b/app/views/groups/index.html.erb
@@ -1,7 +1,9 @@
-<% if @groups.size > 0 then %>
-  <h2>Groups</h2>
+<% @title = "Groups" %>
 
-  <table class=prettyBorder >
+<h2>Groups</h2>
+<% if @groups.size > 0 then %>
+
+  <table class=prettyBorder>
     <tr>
       <th>Group Name</th>
 
@@ -14,7 +16,7 @@
 
     <% @groups.each do |group| %>
       <tr>
-        <td><%= link_to group.name, [@course, @assessment, group] %></td>
+        <td><%= link_to group.name, course_assessment_group_path(@course, @assessment, group) %></td>
 
         <% group.assessment_user_data.each do |aud| %>
           <% cud = aud.course_user_datum %>
@@ -31,17 +33,25 @@
         <% end %>
 
         <td>
-          <%= link_to "Edit", [@course, @assessment, group] %> | 
-          <%= link_to "Destroy", [@course, @assessment, group], method: :delete, data: { confirm: "Are you sure you want to disband this group?" } %>
+          <%= link_to "Edit", course_assessment_group_path(@course, @assessment, group) %> |
+          <%= link_to "Destroy", course_assessment_group_path(@course, @assessment, group),
+                      method: :delete, data: { confirm: "Are you sure you want to disband this group?" } %>
         </td>
       </tr>
     <% end %>
   </table>
 <% else %>
-  <h2>No Groups have been set yet.</h2>
+  <p>
+    No Groups have been set yet.
+  </p>
 <% end %>
 
-<h3><%= link_to 'Create New Group', [:new, @course, @assessment, :group] %></h3>
+<br>
+<%= link_to new_course_assessment_group_path(@course, @assessment) do %>
+  <span class="btn primary">
+    Create New Group
+  </span>
+<% end %>
 
 <% if @grouplessCUDs.size > 0 then %>
   <h2>Users Without Groups</h2>
@@ -57,6 +67,6 @@
   <h2>Load Groups from Another Assessment</h2>
   <%= form_tag [:import, @course, @assessment, :groups] do %>
     <%= select_tag :ass, options_from_collection_for_select(@groupAssessments, :id, :name) %>
-    <%= submit_tag 'Go!', class: "btn btn-primary" %>
+    <%= submit_tag 'Import Groups', class: "btn btn-primary" %>
   <% end %>
 <% end %>

--- a/app/views/groups/new.html.erb
+++ b/app/views/groups/new.html.erb
@@ -1,4 +1,6 @@
-<h2>Create a Group</h2>
+<% @title = "New Group" %>
+
+<h2>Create New Group</h2>
 
 <%= render "new_form" %>
 
@@ -9,7 +11,7 @@
     <% @grouplessCUDs.each do |cud| %>
       <% if cud.id != @cud.id && cud.student? then %>
         <li><b><%= cud.email %></b>
-          (<%= link_to "Invite to Group", [@course, @assessment, @group, member_id: cud.id], method: :post %>)
+          (<%= link_to "Invite to Group", [@course, @assessment, @group, { member_id: cud.id }], method: :post %>)
         </li>
       <% end %>
     <% end %>
@@ -21,7 +23,7 @@
 
   <ul class="gray-box">
     <% @unfullGroups.each do |group| %>
-      <%= render "list_item", {group: group} %>
+      <%= render "list_item", { group: group } %>
     <% end %>
   </ul>
 <% end %>

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -52,7 +52,7 @@
     <%= form_tag add_course_assessment_group_path(@course, @assessment, @group) do %>
       <div class="form-group">
         <label class="control-label" for="member_email">Partner Email</label>
-        <%= text_field_tag :member_email, nil, class: "form-control" %>
+        <%= text_field_tag :member_email, nil, class: "form-control", autocomplete: "email" %>
         <p class="help-block">The email of your desired partner. They will need to confirm their membership.</p>
       </div>
 

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -1,10 +1,11 @@
+<% @title = @group.name %>
 <h2>Group: <%= @group.name %></h2>
 
 <% if @aud.group_id == @group.id or @cud.instructor then %>
   <% if (@aud.membership_status & AssessmentUserDatum::MEMBER_CONFIRMED) == 0 then %>
     <p>You have not confirmed your group membership yet.</p>
-    <%= link_to "Confirm Membership", [:join, @course, @assessment, @group], method: :post %> | 
-    <%= link_to "Deny Membership", [:leave, @course, @assessment, @group], method: :post %>
+    <%= link_to "Confirm Membership", join_course_assessment_group_path(@course, @assessment, @group), method: :post %> |
+    <%= link_to "Deny Membership", leave_course_assessment_group_path(@course, @assessment, @group), method: :post %>
   <% elsif (@aud.membership_status & AssessmentUserDatum::GROUP_CONFIRMED) == 0 then %>
     <p>Your group has not confirmed your membership yet.</p>
   <% end %>
@@ -22,14 +23,22 @@
       <% if !aud.group_confirmed(AssessmentUserDatum::MEMBER_CONFIRMED) then %>
         <p>This Member has not Confirmed their Membership yet.</p>
         <% if @group.is_member(@aud) or @cud.instructor then %>
-          <p><%= link_to "Cancel Request", [:leave, @course, @assessment, @group, member_id: cud.id], method: :post %></p>
+          <p>
+            <%= link_to "Cancel Request",
+                        leave_course_assessment_group_path(@course, @assessment, @group, member_id: cud.id),
+                        method: :post %>
+          </p>
         <% end %>
       <% elsif !aud.group_confirmed(AssessmentUserDatum::GROUP_CONFIRMED) then %>
         <p>This Member has not been Confirmed by the Group yet.</p>
         <% if @group.is_member(@aud) or @cud.instructor then %>
           <p>
-            <%= link_to "Confirm Membership", [:add, @course, @assessment, @group, member_id: cud.id], method: :post %> |
-            <%= link_to "Deny Membership", [:leave, @course, @assessment, @group, member_id: cud.id], method: :post %>
+            <%= link_to "Confirm Membership",
+                        add_course_assessment_group_path(@course, @assessment, @group, member_id: cud.id),
+                        method: :post %> |
+            <%= link_to "Deny Membership",
+                        leave_course_assessment_group_path(@course, @assessment, @group, member_id: cud.id),
+                        method: :post %>
           </p>
         <% end %>
       <% end %>
@@ -40,14 +49,14 @@
 <% if @group.is_member(@aud) or @cud.instructor then %>
   <% if @group.assessment_user_data.size < @assessment.group_size then %>
     <h2>Invite Another Student to Join This Group</h2>
-    <%= form_tag [:add, @course, @assessment, @group] do %>
+    <%= form_tag add_course_assessment_group_path(@course, @assessment, @group) do %>
       <div class="form-group">
         <label class="control-label" for="member_email">Partner Email</label>
         <%= text_field_tag :member_email, nil, class: "form-control" %>
         <p class="help-block">The email of your desired partner. They will need to confirm their membership.</p>
       </div>
 
-      <%= submit_tag "Invite to Group", class:"btn btn-primary" %>
+      <%= submit_tag "Invite to Group", class: "btn btn-primary" %>
     <% end %>
   <% end %>
 <% end %>
@@ -58,7 +67,8 @@
     <% @grouplessCUDs.each do |cud| %>
       <% if cud.id != @cud.id && cud.student? then %>
         <li><b><%= cud.email %></b>
-          (<%= link_to "Invite to Group", [:add, @course, @assessment, @group, member_id: cud.id], method: :post %>)
+          (<%= link_to "Invite to Group", add_course_assessment_group_path(@course, @assessment, @group, member_id: cud.id),
+                       method: :post %>)
         </li>
       <% end %>
     <% end %>
@@ -67,7 +77,8 @@
 
 <div style="margin-top: 1em">
   <% if @group.is_member(@aud) then %>
-    <%= link_to "Leave Group", [:leave, @course, @assessment, @group], {method: :post, data: {confirm: "Are you sure you want to leave your group?"}} %> | 
+    <%= link_to "Leave Group", leave_course_assessment_group_path(@course, @assessment, @group),
+                { method: :post, data: { confirm: "Are you sure you want to leave your group?" } } %> |
   <% end %>
   <%= groups_back_link %>
 </div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Summary
<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 20 Aug 23 21:14 UTC
This pull request includes changes to multiple files:

1. The "index.html.erb" file in the "groups" view has been modified. The changes involve adding a title, rearranging the heading, modifying table class, updating link paths, adding a paragraph for when there are no groups set, adding a link to create a new group, and updating the button label for importing groups from another assessment.

2. There are changes in a file related to modifying the URL in the form_for method. Previously, the URL was specified as [@course, @assessment, @group], but now it has been changed to use the helper method course_assessment_group_url(@course, @assessment, @group). This change ensures that the form submits to the correct URL. Additionally, a help_text attribute has been added to the text field, providing guidance on changing the name of the group. Finally, a submit button with the label "Change Name" has been added.

3. The "_new_form.html.erb" file in the "app/views/groups" directory has changes. The form tag for creating a new group was modified to use the `action: :create` instead of specifying the `[@course, @assessment, @group]`. Some text_field_tags were also modified to include additional attributes.

4. The "_list_item.html.erb" file in the "app/views/groups" directory has changes. These changes include modifications to the code for correctly formatting the output, changes in the `link_to` method, and addition of the `method` and `data` attributes.

5. The "show.html.erb" file in the "app/views/groups" directory has changes. These changes involve adding a line to set the `@title` variable, updating `link_to` method calls, and updating the `form_tag` method call.

Please let me know if you need further assistance with this pull request.
<!-- reviewpad:summarize:end -->

## Description
<!--- Describe your changes in detail -->
- Lint `views/groups` using `bundle exec erblint app/users/groups/*.html.erb -a`
- Change any bracket-based `link_to` to use `_path()` methods
- Add breadcrumbs to pages (Groups overview for Instructor, Create New Group, Group overview)
- Make "Create New Group" Link in Groups overview to be a button, rename "GO!" button to import groups from other assessment to be "Import Groups"


Before:

<img width="1512" alt="Screenshot 2023-08-20 at 5 03 39 PM" src="https://github.com/autolab/Autolab/assets/25730111/984ae95d-f12a-41b6-9938-5ec8955092f0">
<img width="1286" alt="Screenshot 2023-08-20 at 5 03 28 PM" src="https://github.com/autolab/Autolab/assets/25730111/40d3cbd9-9cdc-4a5d-ab4b-8239417c5e0a">


After:

<img width="1512" alt="Screenshot 2023-08-20 at 5 07 46 PM" src="https://github.com/autolab/Autolab/assets/25730111/6df4bbb2-ee01-4678-b5fe-b70bb4839812">
<img width="1512" alt="Screenshot 2023-08-20 at 5 07 52 PM" src="https://github.com/autolab/Autolab/assets/25730111/4c983301-9f2b-48a6-8f19-08c1c050aaf2">



## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- As part of Summer linting

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Ensure that all links still function correctly
- Example testing strategy: As an instructor, enable an assessment to have group size > 1 (Go to "Advanced" tab in "Edit Assessment")
  - Then go to "Group settings" in Assessment page, and then create a new group (choose a student)
  - Login as the student, and join the group. Then, leave the group. Then, click "Ask to Join Group"
  - Login again as the Instructor, and confirm the student's membership
  - Try editing the name of the group, and then destroy the group
  - Create some more groups in the same way
  - Go to another assessment, and enable groups, and then check that importing groups from another assessment works

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
