### PR TITLE
Lint views/gradebook

### DIFF
--- a/app/views/gradebooks/statistics.html.erb
+++ b/app/views/gradebooks/statistics.html.erb
@@ -8,12 +8,12 @@
   <div class="category">
     <table class="grades">
       <colgroup>
-        <col class="asmt_names"></col>
-        <col class="gdu"></col>
-        <col class="gdu"></col>
-        <col class="gdu"></col>
-        <col class="gdu"></col>
-        <col class="gdu"></col>
+        <col class="asmt_names">
+        <col class="gdu">
+        <col class="gdu">
+        <col class="gdu">
+        <col class="gdu">
+        <col class="gdu">
       </colgroup>
       <thead>
         <tr class="header">
@@ -29,10 +29,10 @@
       <% @course_stats.each do |name, stats| %>
         <tr>
           <td>
-            <% # TODO: RESTORE LINKS %>
+# TODO: RESTORE LINKS %>
             <%= name %>
-            <% # TODO: BAD! FIX! %>
-            <% # name.end_with?(' Average') ? name : (link_to name, { :controller => name }, :class => :asmt_link) %>
+# TODO: BAD! FIX! %>
+# name.end_with?(' Average') ? name : (link_to name, { :controller => name }, :class => :asmt_link) %>
           </td>
           <td><%= stats[:mean] %></td>
           <td><%= stats[:median] %></td>

--- a/app/views/gradebooks/statistics.html.erb
+++ b/app/views/gradebooks/statistics.html.erb
@@ -29,10 +29,10 @@
       <% @course_stats.each do |name, stats| %>
         <tr>
           <td>
-# TODO: RESTORE LINKS
+<%# TODO: RESTORE LINKS %>
             <%= name %>
-# TODO: BAD! FIX!
-# name.end_with?(' Average') ? name : (link_to name, { :controller => name }, :class => :asmt_link)
+<%# TODO: BAD! FIX!%>
+<%# name.end_with?(' Average') ? name : (link_to name, { :controller => name }, :class => :asmt_link)%>
           </td>
           <td><%= stats[:mean] %></td>
           <td><%= stats[:median] %></td>

--- a/app/views/gradebooks/statistics.html.erb
+++ b/app/views/gradebooks/statistics.html.erb
@@ -29,10 +29,10 @@
       <% @course_stats.each do |name, stats| %>
         <tr>
           <td>
-# TODO: RESTORE LINKS %>
+# TODO: RESTORE LINKS
             <%= name %>
-# TODO: BAD! FIX! %>
-# name.end_with?(' Average') ? name : (link_to name, { :controller => name }, :class => :asmt_link) %>
+# TODO: BAD! FIX!
+# name.end_with?(' Average') ? name : (link_to name, { :controller => name }, :class => :asmt_link)
           </td>
           <td><%= stats[:mean] %></td>
           <td><%= stats[:median] %></td>

--- a/app/views/gradebooks/student.html.erb
+++ b/app/views/gradebooks/student.html.erb
@@ -14,7 +14,7 @@
   <h4>Grades for <%= @_cud.email %></h4>
 
   <% if not @course.gb_message.blank? %>
-    <div class="gb_message"><%=raw(@course.gb_message)%></div>
+    <div class="gb_message"><%= raw(@course.gb_message) %></div>
   <% end %>
 
   <div class="grades_container">
@@ -26,12 +26,12 @@
         <div class="category">
           <table class="grades">
             <colgroup>
-              <col class="asmt_names"></col>
+              <col class="asmt_names">
               <% if @course.grace_days > 0 %>
-                <col class="gdu"></col>
+                <col class="gdu">
               <% end %>
-              <col class="pld"></col>
-              <col class="fs"></col>
+              <col class="pld">
+              <col class="fs">
             </colgroup>
 
             <tr class="header">
@@ -39,17 +39,29 @@
               <% if @course.grace_days > 0 %>
                 <th>
                   GDU
-                  <i class="material-icons tooltipped" tabindex="0" data-html="true" data-tooltip="<b>Grace Days Used</b><br />Number of late days used for which <em>no</em> penalty was incurred">help</i>
+                  <i
+                    class="material-icons tooltipped"
+                    tabindex="0"
+                    data-html="true"
+                    data-tooltip="<b>Grace Days Used</b><br />Number of late days used for which <em>no</em> penalty was incurred">
+                      help
+                  </i>
                 </th>
               <% end %>
               <th>
                 PLD
-                <i class="material-icons tooltipped" tabindex="0" data-html="true" data-tooltip="<b>Penalty Late Days</b><br />Number of late days used for which a penalty was incurred">help</i>
+                <i
+                  class="material-icons tooltipped"
+                  tabindex="0"
+                  data-html="true"
+                  data-tooltip="<b>Penalty Late Days</b><br />Number of late days used for which a penalty was incurred">
+                  help
+                </i>
               </th>
               <th>Final Score</th>
             </tr>
             <% @course.assessments_with_category(cat, @cud.student?).each do |asmt| %>
-              <% aud = asmt.aud_for @_cud  %>
+              <% aud = asmt.aud_for @_cud %>
               <tr>
                 <td>
                   <span>
@@ -89,7 +101,11 @@
                        when :submitted %>
                       <% if Time.now <= aud.assessment.grading_deadline || !aud.latest_submission.all_scores_released? %>
                         <a href="<%= history_url(@_cud, asmt) %>">
-                          <i class="material-icons tooltipped" data-tooltip="Final score will be visible once grading is complete.">access_time</i>
+                          <i
+                            class="material-icons tooltipped"
+                            data-tooltip="Final score will be visible once grading is complete.">
+                            access_time
+                          </i>
                         </a>
                       <% else %>
                         <%= render_final_score aud %>
@@ -97,7 +113,11 @@
 
                     <% when :not_submitted %>
                       <% if Time.now <= aud.assessment.grading_deadline %>
-                        <i class="material-icons tooltipped" data-tooltip="No submission was made.">priority_high</i>
+                        <i
+                          class="material-icons tooltipped"
+                          data-tooltip="No submission was made.">
+                          priority_high
+                        </i>
                       <% else %>
                         <span class="not-submitted tooltipped" data-tooltip="No submission was made.">
                           <%= render_final_score aud %>
@@ -106,7 +126,11 @@
 
                     <% when :not_yet_submitted %>
                       <% if Time.now <= aud.assessment.grading_deadline %>
-                        <i class="material-icons tooltipped" data-tooltip="No submission has been made yet.">priority_high</i>
+                        <i
+                          class="material-icons tooltipped"
+                          data-tooltip="No submission has been made yet.">
+                          priority_high
+                        </i>
                       <% else %>
                         <span class="not-yet-submitted tooltipped" data-tooltip="No submission has been made yet.">
                           <%= render_final_score aud %>

--- a/app/views/gradebooks/view.html.erb
+++ b/app/views/gradebooks/view.html.erb
@@ -18,10 +18,10 @@
 
 <% content_for :javascripts do %>
   <%= external_javascript_include_tag "jquery-ui" %>
-  <%= javascript_include_tag "jquery.event.drag-2.2.js"%>
-  <%= javascript_include_tag "SlickGrid/2.02/slick.core.js"  %>
-  <%= javascript_include_tag "SlickGrid/2.02/slick.grid.js"  %>
-  <%= javascript_include_tag "SlickGrid/2.02/slick.dataview.js"  %>
+  <%= javascript_include_tag "jquery.event.drag-2.2.js" %>
+  <%= javascript_include_tag "SlickGrid/2.02/slick.core.js" %>
+  <%= javascript_include_tag "SlickGrid/2.02/slick.grid.js" %>
+  <%= javascript_include_tag "SlickGrid/2.02/slick.dataview.js" %>
   <%= javascript_include_tag "SlickGrid/2.02/controls/slick.columnpicker.js" %>
 
   <script type="text/javascript">
@@ -34,32 +34,31 @@
 <% end %>
 
 <% if not @course.gb_message.blank? %>
-  <div class="gb_message"><%=raw(@course.gb_message)%></div>
+  <div class="gb_message"><%= raw(@course.gb_message) %></div>
 <% end %>
 
 <div class="gradebook-row">
   <div class="filter_container search-student-bar">
     <i class="material-icons prefix">search</i>
     <div style="width: 30%;">
-      <input id="filter" placeholder="Search..." type="text">
+      <input id="filter" placeholder="Search..." type="text" autocomplete="off">
     </div>
     <% if @options[:show_actions] %>
       <div id="last_updated">
-        <a class="tip link" title="Export as CSV" href="<%= url_for :action => :csv %>">
+        <a class="tip link" title="Export as CSV" href="<%= url_for action: :csv %>">
           Export
         </a> /
-        <a class="tip link" title="Course Statistics" href="<%= url_for :action => :statistics %>">
+        <a class="tip link" title="Course Statistics" href="<%= url_for action: :statistics %>">
           Statistics
         </a> /
-        <a class="tip regenerate" title="Regenerate (~10 seconds)" href="<%= url_for :action => :invalidate %>" data-method="post">
+        <a class="tip regenerate" title="Regenerate (~10 seconds)" href="<%= url_for action: :invalidate %>" data-method="post">
           <i class="icon-refresh"></i>
-          <%= time_ago_in_words(DateTime.parse @matrix.last_updated) %> old
+          <%= time_ago_in_words(DateTime.parse(@matrix.last_updated)) %> old
         </a>
       </div>
     <% end %>
   </div>
 </div>
-
 
 <div id="gradebook">
   <!-- will be filled in by gradebook.js -->


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Summary
<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 10 Sep 23 16:57 UTC
This pull request includes several changes in the code:
- In the `statistics.html.erb` file, there are changes in the table structure, specifically in the `<col>` elements.
- In the `student.html.erb` file, there are changes in the table structure as well, including the `<col>` elements and some spacing adjustments.
- In the `view.html.erb` file, there are changes in the javascript includes and some spacing adjustments. Additionally, there is an `autocomplete` attribute added to an input field.
<!-- reviewpad:summarize:end -->

## Description
<!--- Describe your changes in detail -->
- Lint `views/gradebook` using `bundle exec erblint app/views/gradebook/*.html.erb -a`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

As part of summer linting

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Ensure that Instructor gradebook renders properly
- Ensure that Student gradebook renders properly
- Ensure that Statistics render properly for an assessment


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
