### PR TITLE
Autolab v2.11.1

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -112,7 +112,7 @@ module Autolab3
     config.middleware.use Rack::Attack
 
     # site version
-    config.site_version = "2.11.0"
+    config.site_version = "2.11.1"
 
     # Set application host for mailer
     config.action_mailer.default_url_options = { host: ENV['MAILER_HOST'] || "YOUR_APP_HOST" }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -54,9 +54,13 @@ RSpec.configure do |config|
       'goog:chromeOptions': { args: %w[headless] }
     )
 
+    service_args = %w[--disable-build-check]
+    service = Selenium::WebDriver::Service.chrome(args: service_args)
+
     Capybara::Selenium::Driver.new app,
                                    browser: :chrome,
-                                   capabilities: capabilities
+                                   capabilities: capabilities,
+                                   service: service
   end
   # change to chrome to see execution on browser
   Capybara.javascript_driver = :headless_chrome


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Summary
<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 05 Sep 23 19:12 UTC
This pull request includes two patches. 

The first patch (PATCH 1/2) bumps the version to v2.11.1 in the `config/application.rb` file. It changes the value of `config.site_version` from "2.11.0" to "2.11.1".

The second patch (PATCH 2/2) disables the build check in the `spec/rails_helper.rb` file. It adds the `--disable-build-check` argument to the service configuration for the Selenium Chrome driver.

Overall, these patches update the version and disable the build check in the codebase. Nice work!
<!-- reviewpad:summarize:end -->

## Description
<!--- Describe your changes in detail -->
* Bump site version to v2.11.1
* Add workaround for tests

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Bump Autolab to v2.11.1, in view of changes and important bug fixes over summer.

Also adds a workaround for the ChromeDriver issue: https://twitter.com/jeremysmithco/status/1695089140373553266

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Run Autolab, observe that version number displayed is now `v2.11.1`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR