### PR TITLE
lint views/layouts

### DIFF
--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -22,12 +22,13 @@
   <ul id="dropdown1" class="dropdown-content">
     <% unless current_user.nil? %>
       <li role="presentation">
-        <%= link_to "Account", user_path(current_user), :title => "View your account info" %>
+        <%= link_to "Account", user_path(current_user), title: "View your account info" %>
       </li>
     <% end %>
     <% if @cud %>
       <li role="presentation">
-        <%= link_to "Course Profile", [@course, @cud], :title => "View your user profile for the current course" %>
+        <%= link_to "Course Profile", course_course_user_data_path(@course, @cud),
+                    title: "View your user profile for the current course" %>
       </li>
     <% end %>
     <% if Rails.env.development? %>
@@ -37,7 +38,7 @@
     <% end %>
     <li role="presentation" class="divider"></li>
     <li role="presentation">
-      <%= link_to "Log out", destroy_user_session_path, :method => :delete  %>
+      <%= link_to "Log out", destroy_user_session_path, method: :delete %>
     </li>
   </ul>
 
@@ -48,15 +49,22 @@
 
       <li role="presentation"><%= link_to "Manage Users", users_path, title: "Manage every Autolab user" %></li>
 
-      <li role="presentation"><%= link_to "Github Integration", github_integration_admin_path, title: "Manage Github Integration" %></li>
+      <li role="presentation"><%= link_to "Github Integration",
+                                          github_integration_admin_path, title: "Manage Github Integration" %></li>
 
-      <li role="presentation"><%= link_to "Manage API Applications", oauth_applications_path, title: "Manage registered API clients" %></li>
+      <li role="presentation"><%= link_to "Manage API Applications",
+                                          oauth_applications_path, title: "Manage registered API clients" %></li>
 
-      <li role="presentation"><%= link_to "Bulk Email Instructors", email_instructors_admin_path, title: "Send a bulk email to every Autolab instructor" %></li>
+      <li role="presentation"><%= link_to "Bulk Email Instructors",
+                                          email_instructors_admin_path,
+                                          title: "Send a bulk email to every Autolab instructor" %></li>
 
-      <li role="presentation"><%= link_to "LTI Integration", lti_config_index_path, title: "View and update LTI Integration Configuration" %></li>
+      <li role="presentation"><%= link_to "LTI Integration",
+                                          lti_config_index_path,
+                                          title: "View and update LTI Integration Configuration" %></li>
 
-      <li role="presentation"><%= link_to "Clear Cache", clear_cache_admin_url, title: "Clear Cache" , data: {method: "post"} %></li>
+      <li role="presentation"><%= link_to "Clear Cache", clear_cache_admin_url,
+                                          title: "Clear Cache", data: { method: "post" } %></li>
     </ul>
   <% end %>
 
@@ -67,48 +75,86 @@
 
       <li role="presentation"><%= link_to "Manage Users", users_path, title: "Manage every Autolab user" %></li>
 
-      <li role="presentation"><%= link_to "Github Integration", github_integration_admin_path, title: "Manage Github Integration" %></li>
+      <li role="presentation"><%= link_to "Github Integration",
+                                          github_integration_admin_path, title: "Manage Github Integration" %></li>
 
-      <li role="presentation"><%= link_to "Manage API Applications", oauth_applications_path, title: "Manage registered API clients" %></li>
+      <li role="presentation"><%= link_to "Manage API Applications",
+                                          oauth_applications_path, title: "Manage registered API clients" %></li>
 
-      <li role="presentation"><%= link_to "Bulk Email Instructors", email_instructors_admin_path, title: "Send a bulk email to every Autolab instructor" %></li>
+      <li role="presentation"><%= link_to "Bulk Email Instructors",
+                                          email_instructors_admin_path,
+                                          title: "Send a bulk email to every Autolab instructor" %></li>
 
-      <li role="presentation"><%= link_to "LTI Integration", lti_config_index_path, title: "View and update LTI Integration Configuration" %></li>
+      <li role="presentation"><%= link_to "LTI Integration",
+                                          lti_config_index_path,
+                                          title: "View and update LTI Integration Configuration" %></li>
 
-      <li role="presentation"><%= link_to "Clear Cache", clear_cache_admin_url, title: "Clear Cache", data: {method: "post"} %></li>
+      <li role="presentation"><%= link_to "Clear Cache",
+                                          clear_cache_admin_url,
+                                          title: "Clear Cache", data: { method: "post" } %></li>
 
     </ul>
   <% end %>
 
   <nav>
     <div class="nav-wrapper">
-      <a href="/courses" class="brand-logo logo"><%= image_tag "AUTOLAB@2x.png", :width=> 180, :alt=>"Carnegie Mellon University" %></a>
-      <a href="#" data-target="mobile-demo" class="sidenav-trigger right"><i class="material-icons">menu</i></a>
+      <a href="/courses" class="brand-logo logo">
+        <%= image_tag "AUTOLAB@2x.png", width: 180, alt: "Carnegie Mellon University" %>
+      </a>
+      <a href="#" data-target="mobile-demo" class="sidenav-trigger right">
+        <i class="material-icons">menu</i>
+      </a>
 
       <ul class="right hide-on-med-and-down">
         <% if session[:sudo] && @cud then %>
-          <li><%= link_to "(#{@cud.display_name}) Return to instructor view", [:unsudo, @course, @cud], data: {method: "post"} %></li>
+          <li>
+            <%= link_to "(#{@cud.display_name}) Return to instructor view",
+                        unsudo_course_course_user_datum_path(@course, @cud),
+                        data: { method: "post" } %>
+          </li>
         <% end %>
 
         <% if @cud %>
           <% if !@cud.instructor? && @cud.course_assistant? && !@cud.section.blank? %>
-            <li><%= link_to "<i class='material-icons left'>grading</i> Section #{@cud.section} Gradebook".html_safe, [:view, @course, @cud, :gradebook, section: @cud.section], title: "View your gradebook" %></li>
+            <li>
+              <%= link_to "<i class='material-icons left'>grading</i> Section #{@cud.section} Gradebook".html_safe,
+                          view_course_course_user_datum_gradebook_path(@course, @cud, { section: @cud.section }),
+                          title: "View your gradebook" %>
+            </li>
           <% elsif @cud.instructor? || @cud.student? %>
-            <li><%= link_to "<i class='material-icons left'>grading</i> Gradebook".html_safe, [@course, @cud, :gradebook], title: "View your gradebook" %></li>
+            <li>
+              <%= link_to "<i class='material-icons left'>grading</i> Gradebook".html_safe,
+                          [@course, @cud, :gradebook], title: "View your gradebook" %>
+            </li>
           <% end %>
 
-          <li><%= link_to "<i class='material-icons left'>clear_all</i> Jobs".html_safe, [@course, :jobs], title: "View a history of autograding jobs" %></li>
+          <li>
+            <%= link_to "<i class='material-icons left'>clear_all</i> Jobs".html_safe, course_jobs_path(@course),
+                        title: "View a history of autograding jobs" %>
+          </li>
 
           <% if @cud.instructor? %>
-            <li><%= link_to "<i class='material-icons left'>settings</i>Manage Course".html_safe, [:manage, @course], title: "Perform course-wise administrative actions" %></li>
+            <li>
+              <%= link_to "<i class='material-icons left'>settings</i>Manage Course".html_safe,
+                          manage_course_path(@course),
+                          title: "Perform course-wise administrative actions" %>
+            </li>
           <% end %>
         <% end %>
 
         <% if current_user&.administrator? %>
-          <li><a class="dropdown-trigger" href="#!" data-target="dropdown2" data-beloworigin="true" data-hover="false"><i class='material-icons left'>lock</i>Manage Autolab<i class="material-icons right">arrow_drop_down</i></a></li>
+          <li>
+            <a class="dropdown-trigger" href="#!" data-target="dropdown2" data-beloworigin="true" data-hover="false">
+              <i class='material-icons left'>lock</i>Manage Autolab<i class="material-icons right">arrow_drop_down</i>
+            </a>
+          </li>
         <% end %>
         <% if user_signed_in? %>
-          <li><a class="dropdown-trigger" href="#!" data-target="dropdown1" data-beloworigin="true" data-hover="false"><%= current_user.display_name %><i class="material-icons right">arrow_drop_down</i></a></li>
+          <li>
+            <a class="dropdown-trigger" href="#!" data-target="dropdown1" data-beloworigin="true" data-hover="false">
+              <%= current_user.display_name %><i class="material-icons right">arrow_drop_down</i>
+            </a>
+          </li>
         <% end %>
       </ul>
 
@@ -122,16 +168,20 @@
           </div>
         <% unless current_user.nil? %>
           <li role="presentation">
-            <%= link_to "<i class='material-icons left'>account_circle</i> Account".html_safe, user_path(current_user), :title => "View your account info" %>
+            <%= link_to "<i class='material-icons left'>account_circle</i> Account".html_safe,
+                        user_path(current_user), title: "View your account info" %>
           </li>
         <% end %>
         <% if @cud %>
           <li role="presentation">
-            <%= link_to "<i class='material-icons left'>assignment_ind</i> Course Profile".html_safe, [@course, @cud], :title => "View your user profile for the current course" %>
+            <%= link_to "<i class='material-icons left'>assignment_ind</i> Course Profile".html_safe,
+                        course_course_user_data_path(@course, @cud),
+                        title: "View your user profile for the current course" %>
           </li>
         <% end %>
         <li role="presentation">
-          <%= link_to "<i class='material-icons left'>exit_to_app</i> Log out".html_safe, destroy_user_session_path, :method => :delete  %>
+          <%= link_to "<i class='material-icons left'>exit_to_app</i> Log out".html_safe,
+                      destroy_user_session_path, method: :delete %>
         </li>
         <li role="presentation" class="divider"></li>
         <% end %>
@@ -143,25 +193,47 @@
       </div>
         <!-- Usual Navbar Items -->
         <% if session[:sudo] && @cud then %>
-          <li><%= link_to "(#{@cud.display_name}) Return to instructor view", [:unsudo, @course, @cud], data: {method: "post"} %></li>
+          <li>
+            <%= link_to "(#{@cud.display_name}) Return to instructor view",
+                        unsudo_course_course_user_datum_path(@course, @cud), data: { method: "post" } %>
+          </li>
         <% end %>
 
         <% if @cud %>
           <% if !@cud.instructor? && @cud.course_assistant? && !@cud.section.blank? %>
-            <li><%= link_to "<i class='material-icons left'>grading</i> Section #{@cud.section} Gradebook".html_safe, [:view, @course, @cud, :gradebook, section: @cud.section], title: "View your gradebook" %></li>
+            <li>
+              <%= link_to "<i class='material-icons left'>grading</i> Section #{@cud.section} Gradebook".html_safe,
+                          view_course_course_user_datum_gradebook_path(@course, @cud, { section: @cud.section }),
+                          title: "View your gradebook" %>
+            </li>
           <% elsif @cud.instructor? || @cud.student? %>
-            <li><%= link_to "<i class='material-icons left'>grading</i> Gradebook".html_safe, [@course, @cud, :gradebook], title: "View your gradebook" %></li>
+            <li>
+              <%= link_to "<i class='material-icons left'>grading</i> Gradebook".html_safe,
+                          [@course, @cud, :gradebook], title: "View your gradebook" %>
+            </li>
           <% end %>
 
-          <li><%= link_to "<i class='material-icons left'>clear_all</i> Jobs".html_safe, [@course, :jobs], title: "View a history of autograding jobs" %></li>
+          <li>
+            <%= link_to "<i class='material-icons left'>clear_all</i> Jobs".html_safe,
+                        course_jobs_path(@course, :jobs), title: "View a history of autograding jobs" %>
+          </li>
 
           <% if @cud.instructor? %>
-            <li><%= link_to "<i class='material-icons left'>settings</i> Manage Course".html_safe, [:manage, @course], title: "Perform course-wise administrative actions" %></li>
+            <li>
+              <%= link_to "<i class='material-icons left'>settings</i> Manage Course".html_safe,
+                          manage_course_path(@course), title: "Perform course-wise administrative actions" %>
+            </li>
           <% end %>
         <% end %>
 
         <% if current_user&.administrator? %>
-          <li><a class="dropdown-trigger" href="#!" data-target="dropdown3" data-beloworigin="true" data-hover="false"><i class='material-icons left'>lock</i>Manage Autolab<i class="material-icons right">arrow_drop_down</i></a></li>
+          <li>
+            <a class="dropdown-trigger" href="#!" data-target="dropdown3" data-beloworigin="true" data-hover="false">
+              <i class='material-icons left'>lock</i>Manage Autolab<i class="material-icons right">
+                arrow_drop_down
+              </i>
+            </a>
+          </li>
         <% end %>
       </ul>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -33,7 +33,15 @@
     <%= content_for :head %>
     <link href='//fonts.googleapis.com/css?family=Source+Sans+Pro:300,400' rel='stylesheet' type='text/css'>
     <%= content_for :stylesheets %>
-    <title><%= if @title then @title elsif @course then @course.display_name else "Autolab Home" end %></title>
+    <title>
+      <%= if @title
+            @title
+          elsif @course
+            @course.display_name
+          else
+            "Autolab Home"
+          end %>
+    </title>
 
   </head>
 
@@ -53,7 +61,9 @@
       <div id="pageBody" class="container">
 
         <% if @cud && @cud.dropped? %>
-          <h3 class="error">You seem to have dropped this course. Please email your instructor if this is incorrect.</h3>
+          <h3 class="error">
+            You seem to have dropped this course. Please email your instructor if this is incorrect.
+          </h3>
         <% end %>
 
         <!-- Flashes -->
@@ -65,13 +75,13 @@
           <% flash.each do |name, msg| %>
             <% if name == "roster_error" %>
               <div class="error" id="flash_error">
-                <%= render :partial=>'courses/uploadError',
-                            locals: {roster_errors: msg} %>
+                <%= render partial: 'courses/uploadError',
+                           locals: { roster_errors: msg } %>
               </div>
             <% else %>
               <% msg = msg.html_safe if html_safe %>
               <%= content_tag :div, msg, id: "flash_#{name}",
-                  class: "#{name}" %>
+                                         class: name.to_s %>
             <% end %>
           <% end %>
           <noscript>
@@ -98,7 +108,6 @@
       <!-- End Page Body -->
       <!-- Footer -->
     </div>
-
 
     <script async defer id="github-bjs" src="https://buttons.github.io/buttons.js"></script>
     <%= content_for :javascripts %>

--- a/app/views/layouts/doorkeeper/admin.html.erb
+++ b/app/views/layouts/doorkeeper/admin.html.erb
@@ -15,7 +15,7 @@
       <%= link_to t('doorkeeper.layouts.admin.nav.oauth2_provider'), oauth_applications_path, class: 'navbar-brand' %>
     </div>
     <ul class="nav navbar-nav">
-      <%= content_tag :li, class: "#{'active' if request.path == oauth_applications_path}" do %>
+      <%= content_tag :li, class: ('active' if request.path == oauth_applications_path).to_s do %>
         <%= link_to t('doorkeeper.layouts.admin.nav.applications'), oauth_applications_path %>
       <% end %>
       <%= content_tag :li do %>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Summary
<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 10 Sep 23 17:49 UTC
This pull request includes the following changes:

- In the file `admin.html.erb`, the class attribute of a `content_tag` block has been updated to ensure it always has a value.

- In the file `app/views/layouts/application.html.erb`, several changes have been made including adding an external stylesheet, modifying the dynamic content of the `<title>` tag, updating the error message for dropped courses, changing the rendering of flash messages, removing a blank line, adding a script tag for a GitHub button, and modifying the content for JavaScripts.

Overall, these changes involve adding conditional logic, improving error messages, and enhancing the rendering of flash messages.
<!-- reviewpad:summarize:end -->

## Description
<!--- Describe your changes in detail -->
- lint `views/layouts` using `bundle exec erblint app/views/*(folder)/*(file).html.erb -a`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- Part of summer linting

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- make sure doorkeeper renders properly (navigate via "Manage Autolab"->"Manage API applications")
- ensure navbar renders properly for all user types (instructor, course assistant, student)
  - Instructor navbar should look like this:
![Screenshot 2023-09-10 at 1 35 05 PM](https://github.com/autolab/Autolab/assets/25730111/d7501edf-de7d-4648-b018-3148bc44a314)
    - ensure all button links work
    - try to sudo (go to Manage Course), and then see that unsudo button shows up on navbar to get out of sudo view
    - ensure gradebook is instructor gradebook
  - Course assistant navbar should look like this (minus the Manage Autolab button):
    - ![Screenshot 2023-09-10 at 1 35 14 PM](https://github.com/autolab/Autolab/assets/25730111/ae6af98e-8572-43a9-8bbc-9e3adb63971f)
      - Make sure course assistant has a section assigned, then see that button to view section gradebook shows up, and that link correctly goes to gradebook for that section
   - student navbar:
![Screenshot 2023-09-10 at 1 35 22 PM](https://github.com/autolab/Autolab/assets/25730111/df521aea-56fc-488e-b3de-79d8b717fcd1)
     - ensure that button to view gradebook works and goes to student gradebook
   - Make sure admin navbar options work

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
