### PR TITLE
Prevent spoofing the author of an annotation

### DIFF
--- a/app/assets/javascripts/annotations.js
+++ b/app/assets/javascripts/annotations.js
@@ -510,7 +510,6 @@ function elt(t, a) {
 function createAnnotation() {
   var annObj = {
     filename: fileNameStr,
-    submitted_by: cudEmailStr,
   };
 
   if (currentHeaderPos || currentHeaderPos === 0) {

--- a/app/controllers/annotations_controller.rb
+++ b/app/controllers/annotations_controller.rb
@@ -75,6 +75,8 @@ private
     params[:annotation].delete(:id)
     params[:annotation].delete(:created_at)
     params[:annotation].delete(:updated_at)
+    # Prevent spoofing the submitter
+    params[:annotation][:submitted_by] = @current_user.email
     params.require(:annotation).permit(:filename, :position, :line, :submitted_by,
                                        :comment, :shared_comment, :global_comment, :value,
                                        :problem_id, :submission_id, :coordinate)


### PR DESCRIPTION
## Summary
<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 22 Sep 23 17:42 UTC
This pull request prevents spoofing the author of an annotation by setting the submitter as the current user's email.
<!-- reviewpad:summarize:end -->

## Description
This very small change overwrites the `submitted_by` parameter on `annotation_params` to the current user's email address to prevent client-side spoofing of the author.

## Motivation and Context
Previously, course assistants could modify the POST request sent by their browser to make annotations look like they were written by somebody else. This update ensures that the annotation's author is the currently authenticated user, ignoring who the client says the author is.

## How Has This Been Tested?
I saved an annotation like normal with the browser dev tools open. I recreated the request and modified it to change the `submitted_by` parameter to be something else. I verified the backend doesn't use my custom author, so the annotation's author is saved as the real user's email address.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR