### PR TITLE
Hide irrelevant cud fields for students

### DIFF
--- a/app/views/course_user_data/_fields.html.erb
+++ b/app/views/course_user_data/_fields.html.erb
@@ -1,23 +1,24 @@
-<%= f.fields_for :user, cud.user do |u| %>
-    <%# It doesn't make sense for these fields to be editable when editing an existing CUD %>
-    <%= u.email_field :email, disabled: edit, placeholder: "johndoe@example.com" %>
+<% if @cud.instructor? %>
+  <%= f.fields_for :user, cud.user do |u| %>
+      <%# It doesn't make sense for these fields to be editable when editing an existing CUD %>
+      <%= u.email_field :email, disabled: edit, placeholder: "johndoe@example.com" %>
 
-    <%= u.text_field :first_name, disabled: edit, placeholder: "John" %>
-    <%= u.text_field :last_name, disabled: edit, placeholder: "Doe" %>
+      <%= u.text_field :first_name, disabled: edit, placeholder: "John" %>
+      <%= u.text_field :last_name, disabled: edit, placeholder: "Doe" %>
+  <% end %>
 
 <% end %>
 
 <%= f.text_field :nickname, help_text: "Anonymous nickname to display on the public scoreboards (max length: 32)",
                             placeholder: "droh", maxlength: 32 %>
 
-<%= f.text_field :course_number, help_text: "The course number", placeholder: "15213", disabled: !@cud.instructor? %>
-
-<%= f.text_field :lecture, help_text: "The lecture number", placeholder: "1", disabled: !@cud.instructor? %>
-
-<%= f.text_field :section, placeholder: "A", disabled: !@cud.instructor?,
-                           help_text: "The section letter. A course assistant can see the gradebook and bulk-release grades for their assigned lecture and section." %>
-
 <% if @cud.instructor? %>
+  <%= f.text_field :course_number, help_text: "The course number", placeholder: "15213", disabled: !@cud.instructor? %>
+
+  <%= f.text_field :lecture, help_text: "The lecture number", placeholder: "1", disabled: !@cud.instructor? %>
+
+  <%= f.text_field :section, placeholder: "A", disabled: !@cud.instructor?,
+                             help_text: "The section letter. A course assistant can see the gradebook and bulk-release grades for their assigned lecture and section." %>
 
   <h4>Course average tweak:</h4>
   <div class="row">

--- a/app/views/course_user_data/show.html.erb
+++ b/app/views/course_user_data/show.html.erb
@@ -12,6 +12,4 @@
   <li><b>Course Average Tweak</b> of <%= raw tweak(@requestedUser.tweak) %></li>
   <% end %>
 </ul>
-<% if @cud.instructor? %>
-  <%= link_to raw('<span class="btn primary">Edit Information</span>'), edit_course_course_user_datum_path(@course, @requestedUser) %>
-<% end %>
+<%= link_to raw('<span class="btn primary">Edit Information</span>'), edit_course_course_user_datum_path(@course, @requestedUser) %>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Summary
reviewpad:summary

## Description
<!--- Describe your changes in detail -->
- Display edit CUD button on course profile for students
- Hide all fields except nickname on edit CUD page for students

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Closes #1981

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
As instructor, successfully create / edit CUD

As student, click on "edit information" button on profile and note that only nickname field is visible. Successfully update nickname

<img width="362" alt="Screenshot 2023-09-29 at 15 02 16" src="https://github.com/autolab/Autolab/assets/9074856/4f8ae77b-91a6-46d7-92fb-ae49b2239c06">

<img width="520" alt="Screenshot 2023-09-29 at 15 01 43" src="https://github.com/autolab/Autolab/assets/9074856/7130d775-73f4-435e-9e9a-c27029476730">


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR
