### PR TITLE
Display Grace Day usage on submission history table, improve management of assessment penalty settings

### DIFF
--- a/app/assets/javascripts/edit_assessment.js
+++ b/app/assets/javascripts/edit_assessment.js
@@ -44,12 +44,16 @@
     });
 
     // Penalties tab
+    let initial_load = true; // determines if the page is loading for the first time, if so, don't clear the fields
+
     $('#unlimited_submissions').on('change', function() {
       const checked = $(this).prop('checked');
       const $max_submissions = $('#assessment_max_submissions');
       $max_submissions.prop('disabled', checked);
       if (checked) {
-        $max_submissions.val(-1);
+        $max_submissions.val('Unlimited submissions');
+      } else if (!initial_load) {
+        $max_submissions.val('');
       }
     });
 
@@ -58,17 +62,22 @@
       const $max_grace_days = $('#assessment_max_grace_days');
       $max_grace_days.prop('disabled', checked);
       if (checked) {
+        $max_grace_days.val('Unlimited grace days');
+      } else if (!initial_load) {
         $max_grace_days.val('');
       }
     });
 
     $('#use_default_late_penalty').on('change', function() {
       const checked = $(this).prop('checked');
-      const $latePenaltyField = $('#assessment_late_penalty_attributes_value').parent();
+      const $latePenaltyValue = $('#assessment_late_penalty_attributes_value');
+      const $latePenaltyField = $latePenaltyValue.parent();
       $latePenaltyField.find('input').prop('disabled', checked);
       $latePenaltyField.find('select').prop('disabled', checked);
       if (checked) {
-        $('#assessment_late_penalty_attributes_value').val('');
+        $latePenaltyValue.val('Course default');
+      } else if (!initial_load) {
+        $latePenaltyValue.val('');
       }
     });
 
@@ -77,20 +86,32 @@
       const $version_threshold = $('#assessment_version_threshold');
       $version_threshold.prop('disabled', checked);
       if (checked) {
+        $version_threshold.val('Course default');
+      } else if (!initial_load) {
         $version_threshold.val('');
       }
     });
 
     $('#use_default_version_penalty').on('change', function() {
       const checked = $(this).prop('checked');
-      const $versionPenaltyField = $('#assessment_version_penalty_attributes_value').parent();
+      const $versionPenaltyValue = $('#assessment_version_penalty_attributes_value');
+      const $versionPenaltyField = $versionPenaltyValue.parent();
       $versionPenaltyField.find('input').prop('disabled', checked);
       $versionPenaltyField.find('select').prop('disabled', checked);
       if (checked) {
-        $('#assessment_version_penalty_attributes_value').val('');
+        $versionPenaltyValue.val('Course default');
+      } else if (!initial_load) {
+        $versionPenaltyValue.val('');
       }
     });
 
+    // Trigger on page load
+    $('#unlimited_submissions').trigger('change');
+    $('#unlimited_grace_days').trigger('change');
+    $('#use_default_late_penalty').trigger('change');
+    $('#use_default_version_threshold').trigger('change');
+    $('#use_default_version_penalty').trigger('change');
+    initial_load = false;
   });
 
 })();

--- a/app/assets/javascripts/edit_assessment.js
+++ b/app/assets/javascripts/edit_assessment.js
@@ -45,27 +45,50 @@
 
     // Penalties tab
     $('#unlimited_submissions').on('change', function() {
-      $('#assessment_max_submissions').prop('disabled', $(this).prop('checked'));
+      const checked = $(this).prop('checked');
+      const $max_submissions = $('#assessment_max_submissions');
+      $max_submissions.prop('disabled', checked);
+      if (checked) {
+        $max_submissions.val(-1);
+      }
     });
 
     $('#unlimited_grace_days').on('change', function() {
-      $('#assessment_max_grace_days').prop('disabled', $(this).prop('checked'));
+      const checked = $(this).prop('checked');
+      const $max_grace_days = $('#assessment_max_grace_days');
+      $max_grace_days.prop('disabled', checked);
+      if (checked) {
+        $max_grace_days.val('');
+      }
     });
 
     $('#use_default_late_penalty').on('change', function() {
+      const checked = $(this).prop('checked');
       const $latePenaltyField = $('#assessment_late_penalty_attributes_value').parent();
-      $latePenaltyField.find('input').prop('disabled', $(this).prop('checked'));
-      $latePenaltyField.find('select').prop('disabled', $(this).prop('checked'));
+      $latePenaltyField.find('input').prop('disabled', checked);
+      $latePenaltyField.find('select').prop('disabled', checked);
+      if (checked) {
+        $('#assessment_late_penalty_attributes_value').val('');
+      }
     });
 
     $('#use_default_version_threshold').on('change', function() {
-      $('#assessment_version_threshold').prop('disabled', $(this).prop('checked'));
+      const checked = $(this).prop('checked');
+      const $version_threshold = $('#assessment_version_threshold');
+      $version_threshold.prop('disabled', checked);
+      if (checked) {
+        $version_threshold.val('');
+      }
     });
 
     $('#use_default_version_penalty').on('change', function() {
+      const checked = $(this).prop('checked');
       const $versionPenaltyField = $('#assessment_version_penalty_attributes_value').parent();
-      $versionPenaltyField.find('input').prop('disabled', $(this).prop('checked'));
-      $versionPenaltyField.find('select').prop('disabled', $(this).prop('checked'));
+      $versionPenaltyField.find('input').prop('disabled', checked);
+      $versionPenaltyField.find('select').prop('disabled', checked);
+      if (checked) {
+        $('#assessment_version_penalty_attributes_value').val('');
+      }
     });
 
   });

--- a/app/assets/javascripts/edit_assessment.js
+++ b/app/assets/javascripts/edit_assessment.js
@@ -43,6 +43,31 @@
       }
     });
 
+    // Penalties tab
+    $('#unlimited_submissions').on('change', function() {
+      $('#assessment_max_submissions').prop('disabled', $(this).prop('checked'));
+    });
+
+    $('#unlimited_grace_days').on('change', function() {
+      $('#assessment_max_grace_days').prop('disabled', $(this).prop('checked'));
+    });
+
+    $('#use_default_late_penalty').on('change', function() {
+      const $latePenaltyField = $('#assessment_late_penalty_attributes_value').parent();
+      $latePenaltyField.find('input').prop('disabled', $(this).prop('checked'));
+      $latePenaltyField.find('select').prop('disabled', $(this).prop('checked'));
+    });
+
+    $('#use_default_version_threshold').on('change', function() {
+      $('#assessment_version_threshold').prop('disabled', $(this).prop('checked'));
+    });
+
+    $('#use_default_version_penalty').on('change', function() {
+      const $versionPenaltyField = $('#assessment_version_penalty_attributes_value').parent();
+      $versionPenaltyField.find('input').prop('disabled', $(this).prop('checked'));
+      $versionPenaltyField.find('select').prop('disabled', $(this).prop('checked'));
+    });
+
   });
 
 })();

--- a/app/assets/stylesheets/style.css.scss
+++ b/app/assets/stylesheets/style.css.scss
@@ -237,7 +237,7 @@ div.main-header img {
 }
 
 /* Custom Form Styling */
-.input-field,
+.input-field:not(.no-padding-bottom),
 form > div {
   padding-bottom: 1rem !important;
 }

--- a/app/controllers/assessments_controller.rb
+++ b/app/controllers/assessments_controller.rb
@@ -780,6 +780,19 @@ class AssessmentsController < ApplicationController
     @has_annotations = @assessment.submissions.any? { |s| !s.annotations.empty? }
 
     @is_positive_grading = @assessment.is_positive_grading
+
+    return unless @assessment.end_at > @assessment.due_at
+
+    warn_message = "Warning: this assessment allows for late submissions (End At > Due At), but"
+    if (@assessment.effective_late_penalty.value || 0) == 0
+      flash.now[:error] ||= warn_message
+      flash.now[:error] += "<br>- Does not penalize late submissions (late penalty = 0)"
+    end
+    if @assessment.max_grace_days == 0
+      flash.now[:error] ||= warn_message
+      flash.now[:error] += "<br>- Does not allow for the use of grace days (max grace days = 0)"
+    end
+    flash.now[:html_safe] = true
   end
 
   action_auth_level :update, :instructor

--- a/app/controllers/assessments_controller.rb
+++ b/app/controllers/assessments_controller.rb
@@ -796,7 +796,7 @@ class AssessmentsController < ApplicationController
     # Used for the penalties tab
     @has_unlimited_submissions = @assessment.max_submissions == -1
     @has_unlimited_grace_days = @assessment.max_grace_days.nil?
-    @uses_default_version_threshold = @assessment.version_threshold.nil?
+    @uses_default_version_threshold = @assessment.version_threshold == -1
     @uses_default_late_penalty = @assessment.late_penalty.nil?
     @uses_default_version_penalty = @assessment.version_penalty.nil?
 
@@ -1026,7 +1026,7 @@ private
     end
 
     if ActiveModel::Type::Boolean.new.cast(params[:use_default_version_threshold]) == true
-      ass[:version_threshold] = ""
+      ass[:version_threshold] = -1
     end
 
     ass.delete(:name)

--- a/app/controllers/assessments_controller.rb
+++ b/app/controllers/assessments_controller.rb
@@ -793,6 +793,13 @@ class AssessmentsController < ApplicationController
       flash.now[:html_safe] = true
     end
 
+    # Used for the penalties tab
+    @has_unlimited_submissions = @assessment.max_submissions == -1
+    @has_unlimited_grace_days = @assessment.max_grace_days.nil?
+    @uses_default_version_threshold = @assessment.version_threshold.nil?
+    @uses_default_late_penalty = @assessment.late_penalty.nil?
+    @uses_default_version_penalty = @assessment.version_penalty.nil?
+
     # make sure the penalties are set up
     # placed after the check above, so that effective_late_penalty displays the correct result
     @assessment.late_penalty ||= Penalty.new(kind: "points")
@@ -998,6 +1005,28 @@ private
     if ass[:version_penalty_attributes] && ass[:version_penalty_attributes][:value].blank?
       ass.delete(:version_penalty_attributes)
       @assessment.version_penalty&.destroy
+    end
+
+    if ActiveModel::Type::Boolean.new.cast(params[:unlimited_submissions]) == true
+      ass[:max_submissions] = -1
+    end
+
+    if ActiveModel::Type::Boolean.new.cast(params[:unlimited_grace_days]) == true
+      ass[:max_grace_days] = ""
+    end
+
+    if ActiveModel::Type::Boolean.new.cast(params[:use_default_late_penalty]) == true
+      ass.delete(:late_penalty_attributes)
+      @assessment.late_penalty&.destroy
+    end
+
+    if ActiveModel::Type::Boolean.new.cast(params[:use_default_version_penalty]) == true
+      ass.delete(:version_penalty_attributes)
+      @assessment.version_penalty&.destroy
+    end
+
+    if ActiveModel::Type::Boolean.new.cast(params[:use_default_version_threshold]) == true
+      ass[:version_threshold] = ""
     end
 
     ass.delete(:name)

--- a/app/controllers/assessments_controller.rb
+++ b/app/controllers/assessments_controller.rb
@@ -786,11 +786,12 @@ class AssessmentsController < ApplicationController
     warn_message = "Late submissions are allowed, but"
     if @assessment.max_grace_days == 0
       flash.now[:error] ||= warn_message
-      flash.now[:error] += "<br>- Max grace days = 0 (students can't use grace days)"
+      flash.now[:error] += "<br>- Max grace days = 0: students can't use grace days"
     end
     if (@assessment.effective_late_penalty.value || 0) == 0
       flash.now[:error] ||= warn_message
-      flash.now[:error] += "<br>- Late penalty = 0 (does not penalize late submissions)"
+      flash.now[:error] += "<br>- Late penalty = 0: late submissions made \
+                            without grace days are not penalized"
     end
     flash.now[:html_safe] = true
   end

--- a/app/controllers/assessments_controller.rb
+++ b/app/controllers/assessments_controller.rb
@@ -796,7 +796,7 @@ class AssessmentsController < ApplicationController
     # Used for the penalties tab
     @has_unlimited_submissions = @assessment.max_submissions == -1
     @has_unlimited_grace_days = @assessment.max_grace_days.nil?
-    @uses_default_version_threshold = @assessment.version_threshold == -1
+    @uses_default_version_threshold = @assessment.version_threshold.nil?
     @uses_default_late_penalty = @assessment.late_penalty.nil?
     @uses_default_version_penalty = @assessment.version_penalty.nil?
 
@@ -1026,7 +1026,7 @@ private
     end
 
     if ActiveModel::Type::Boolean.new.cast(params[:use_default_version_threshold]) == true
-      ass[:version_threshold] = -1
+      ass[:version_threshold] = ""
     end
 
     ass.delete(:name)

--- a/app/controllers/assessments_controller.rb
+++ b/app/controllers/assessments_controller.rb
@@ -783,14 +783,14 @@ class AssessmentsController < ApplicationController
 
     return unless @assessment.end_at > @assessment.due_at
 
-    warn_message = "Warning: this assessment allows for late submissions (End At > Due At), but"
-    if (@assessment.effective_late_penalty.value || 0) == 0
-      flash.now[:error] ||= warn_message
-      flash.now[:error] += "<br>- Does not penalize late submissions (late penalty = 0)"
-    end
+    warn_message = "Late submissions are allowed, but"
     if @assessment.max_grace_days == 0
       flash.now[:error] ||= warn_message
-      flash.now[:error] += "<br>- Does not allow for the use of grace days (max grace days = 0)"
+      flash.now[:error] += "<br>- Max grace days = 0 (students can't use grace days)"
+    end
+    if (@assessment.effective_late_penalty.value || 0) == 0
+      flash.now[:error] ||= warn_message
+      flash.now[:error] += "<br>- Late penalty = 0 (does not penalize late submissions)"
     end
     flash.now[:html_safe] = true
   end

--- a/app/controllers/assessments_controller.rb
+++ b/app/controllers/assessments_controller.rb
@@ -780,17 +780,18 @@ class AssessmentsController < ApplicationController
     # warn instructors if the assessment is configured to allow late submissions
     # but the settings do not make sense
     if @assessment.end_at > @assessment.due_at
-      warn_message = "Late submissions are allowed, but"
+      warn_messages = []
       if @assessment.max_grace_days == 0
-        flash.now[:error] ||= warn_message
-        flash.now[:error] += "<br>- Max grace days = 0: students can't use grace days"
+        warn_messages << "- Max grace days = 0: students can't use grace days"
       end
       if @assessment.effective_late_penalty.value == 0
-        flash.now[:error] ||= warn_message
-        flash.now[:error] += "<br>- Late penalty = 0: late submissions made \
-                              without grace days are not penalized"
+        warn_messages << "- Late penalty = 0: late submissions made \
+                          without grace days are not penalized"
       end
-      flash.now[:html_safe] = true
+      unless warn_messages.empty?
+        flash.now[:error] = "Late submissions are allowed, but<br>#{warn_messages.join('<br>')}"
+        flash.now[:html_safe] = true
+      end
     end
 
     # Used for the penalties tab
@@ -1007,25 +1008,25 @@ private
       @assessment.version_penalty&.destroy
     end
 
-    if ActiveModel::Type::Boolean.new.cast(params[:unlimited_submissions]) == true
+    if params[:unlimited_submissions].to_boolean == true
       ass[:max_submissions] = -1
     end
 
-    if ActiveModel::Type::Boolean.new.cast(params[:unlimited_grace_days]) == true
+    if params[:unlimited_grace_days].to_boolean == true
       ass[:max_grace_days] = ""
     end
 
-    if ActiveModel::Type::Boolean.new.cast(params[:use_default_late_penalty]) == true
+    if params[:use_default_late_penalty].to_boolean == true
       ass.delete(:late_penalty_attributes)
       @assessment.late_penalty&.destroy
     end
 
-    if ActiveModel::Type::Boolean.new.cast(params[:use_default_version_penalty]) == true
+    if params[:use_default_version_penalty].to_boolean == true
       ass.delete(:version_penalty_attributes)
       @assessment.version_penalty&.destroy
     end
 
-    if ActiveModel::Type::Boolean.new.cast(params[:use_default_version_threshold]) == true
+    if params[:use_default_version_threshold].to_boolean == true
       ass[:version_threshold] = ""
     end
 

--- a/app/form_builders/form_builder_with_date_time_input.rb
+++ b/app/form_builders/form_builder_with_date_time_input.rb
@@ -20,7 +20,7 @@ class FormBuilderWithDateTimeInput < ActionView::Helpers::FormBuilder
 
       field = super name, *(args + [options])
 
-      wrap_field name, field, options[:help_text], options[:display_name]
+      wrap_field name, field, options
     end
   end
 
@@ -35,7 +35,7 @@ class FormBuilderWithDateTimeInput < ActionView::Helpers::FormBuilder
         end)
     end
 
-    wrap_field name, fields, options[:help_text]
+    wrap_field name, fields, options
   end
 
   def submit(text, *args)
@@ -132,13 +132,13 @@ private
       "data-date-greater-than": options[:greater_than]
     )
 
-    wrap_field name, field, options[:help_text]
+    wrap_field name, field, options
   end
 
-  def wrap_field(name, field, help_text = nil, display_name = nil)
-    @template.content_tag :div, class: "input-field" do
-      label(name, display_name, class: "control-label") +
-        field + help_text(name, help_text)
+  def wrap_field(name, field, options = {})
+    @template.content_tag :div, class: options[:wrap_class] || "input-field" do
+      label(name, options[:display_name], class: "control-label") +
+        field + help_text(name, options[:help_text])
     end
   end
 

--- a/app/form_builders/form_builder_with_date_time_input.rb
+++ b/app/form_builders/form_builder_with_date_time_input.rb
@@ -28,10 +28,10 @@ class FormBuilderWithDateTimeInput < ActionView::Helpers::FormBuilder
     options = args.extract_options!
 
     fields = fields_for name do |f|
-      (f.vanilla_text_field :value, class: "score-box", placeholder: "10") +
+      (f.vanilla_text_field :value, class: "score-box", placeholder: options[:placeholder] || "", disabled: options[:disabled]) +
         (@template.content_tag :div do
           f.select(:kind, { "points" => "points", "%" => "percent" }, {},
-                   class: "carrot")
+                   class: "carrot", disabled: options[:disabled])
         end)
     end
 

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -141,7 +141,7 @@ class Assessment < ApplicationRecord
   #
   # Use default course late penalty, if not set
   def effective_late_penalty
-    if !late_penalty.value.nil?
+    if !late_penalty&.value.nil?
       late_penalty
     else
       course.late_penalty
@@ -150,7 +150,7 @@ class Assessment < ApplicationRecord
 
   # Penalty to apply per version past the version_threshold
   def effective_version_penalty
-    if !version_penalty.value.nil?
+    if !version_penalty&.value.nil?
       version_penalty
     else
       course.version_penalty

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -141,12 +141,20 @@ class Assessment < ApplicationRecord
   #
   # Use default course late penalty, if not set
   def effective_late_penalty
-    late_penalty || course.late_penalty
+    if !late_penalty.value.nil?
+      late_penalty
+    else
+      course.late_penalty
+    end
   end
 
   # Penalty to apply per version past the version_threshold
   def effective_version_penalty
-    version_penalty || course.version_penalty
+    if !version_penalty.value.nil?
+      version_penalty
+    else
+      course.version_penalty
+    end
   end
 
   # Submission version number past which to start applying version penalty

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -141,20 +141,12 @@ class Assessment < ApplicationRecord
   #
   # Use default course late penalty, if not set
   def effective_late_penalty
-    if !late_penalty&.value.nil?
-      late_penalty
-    else
-      course.late_penalty
-    end
+    late_penalty || course.late_penalty
   end
 
   # Penalty to apply per version past the version_threshold
   def effective_version_penalty
-    if !version_penalty&.value.nil?
-      version_penalty
-    else
-      course.version_penalty
-    end
+    version_penalty || course.version_penalty
   end
 
   # Submission version number past which to start applying version penalty

--- a/app/models/score_adjustment.rb
+++ b/app/models/score_adjustment.rb
@@ -64,13 +64,13 @@ class ScoreAdjustment < ApplicationRecord
   def to_s
     case self[:kind]
     when POINTS
-      type_str = "points"
+      type_str = " points"
     when PERCENT
       type_str = "%"
     else
       raise ArgumentError
     end
 
-    "#{format('%g', value)} #{type_str}"
+    "#{format('%g', value)}#{type_str}"
   end
 end

--- a/app/models/score_adjustment.rb
+++ b/app/models/score_adjustment.rb
@@ -71,6 +71,6 @@ class ScoreAdjustment < ApplicationRecord
       raise ArgumentError
     end
 
-    "#{format('%+g', value)} #{type_str}"
+    "#{format('%g', value)} #{type_str}"
   end
 end

--- a/app/views/assessments/_edit_penalties.html.erb
+++ b/app/views/assessments/_edit_penalties.html.erb
@@ -2,7 +2,6 @@
                  help_text: "The maximum number of times a student can submit the assessment. \
                              <br>If set to -1, unlimited submissions are allowed.".html_safe,
                  placeholder: "10",
-                 disabled: @has_unlimited_submissions,
                  wrap_class: %w[input-field no-padding-bottom] %>
 <%= label_tag(:unlimited_submissions, nil, class: "input-default") do %>
   <%= check_box_tag :unlimited_submissions, "1", @has_unlimited_submissions %>
@@ -12,7 +11,6 @@
 <%= f.text_field :max_grace_days,
                  help_text: "Maximum number of grace days that a student can spend on this assessment. \
                              <br>If left blank, all available grace days can be spent on this assessment.".html_safe,
-                 disabled: @has_unlimited_grace_days,
                  wrap_class: %w[input-field no-padding-bottom] %>
 <%= label_tag(:unlimited_grace_days) do %>
   <%= check_box_tag :unlimited_grace_days, "1", @has_unlimited_grace_days %>
@@ -24,7 +22,6 @@
                              help_text: "The penalty applied to late submissions after a student runs out of grace days.
   It represents the number of points or a percentage of the total score removed per day, and must be a non-negative
   number.<br>If left blank, the course default is used.".html_safe,
-                             disabled: @uses_default_late_penalty,
                              wrap_class: %w[input-field no-padding-bottom] %>
 <%= label_tag(:use_default_late_penalty) do %>
   <%= check_box_tag :use_default_late_penalty, "1", @uses_default_late_penalty %>
@@ -36,7 +33,6 @@
   each additional submission is penalized according to the version penalty.
   <br>If set to -1, no submissions are penalized.
   <br>If left blank, the course default is used.".html_safe,
-                 disabled: @uses_default_version_threshold,
                  wrap_class: %w[input-field no-padding-bottom] %>
 <%= label_tag(:use_default_version_threshold) do %>
   <%= check_box_tag :use_default_version_threshold, "1", @uses_default_version_threshold %>
@@ -49,7 +45,6 @@
   threshold, and must be a non-negative number.
   For example, if this is set to 1 point and the version threshold to 3, the fifth version of a student's submissions would be docked 2 points.
   <br>If left blank, the course default is used.".html_safe,
-                                               disabled: @uses_default_version_penalty,
                                                wrap_class: %w[input-field no-padding-bottom] %>
 <%= label_tag(:use_default_version_penalty) do %>
   <%= check_box_tag :use_default_version_penalty, "1", @uses_default_version_penalty %>

--- a/app/views/assessments/_edit_penalties.html.erb
+++ b/app/views/assessments/_edit_penalties.html.erb
@@ -14,11 +14,17 @@
   It represents the number of points or a percentage of the total score removed per day, and must be a non-negative
   number. If left blank, the course default is used.",
                              placeholder: "E.g. 15%" %>
+<% if @assessment.late_penalty.value.nil? %>
+  <strong class="red-text">The late penalty is currently set to the course default of -<%= @assessment.course.late_penalty %> per day.</strong>
+<% end %>
 
 <%= f.text_field :version_threshold, help_text: "The number of unpenalized submissions allowed. After this threshold,
   each additional submission is penalized according to the version penalty. If set to -1, no submissions are penalized.
   If this is left blank, the course default is used.",
                                      placeholder: "Leave blank to use course default." %>
+<% if @assessment.version_threshold.nil? %>
+  <strong class="red-text">The version threshold is currently set to the course default of <%= @assessment.course.version_threshold %>.</strong>
+<% end %>
 
 <%= f.score_adjustment_input :version_penalty, optional: true,
                                                help_text: "The penalty applied to submissions with version greater than the version
@@ -26,6 +32,9 @@
   threshold, and must be a non-negative number. For example, if this is set to 1 point and the version threshold to 3,
   the fifth version of a student's submissions would be docked 2 points.",
                                                placeholder: "Leave blank to use course default." %>
+<% if @assessment.version_penalty.value.nil? %>
+  <strong class="red-text">The version penalty is currently set to the course default of -<%= @assessment.course.version_penalty %> per submission.</strong>
+<% end %>
 
 <div class="action_buttons">
   <%= f.submit "Save", name: "penalties" %>

--- a/app/views/assessments/_edit_penalties.html.erb
+++ b/app/views/assessments/_edit_penalties.html.erb
@@ -1,5 +1,6 @@
 <%= f.text_field :max_submissions,
-                 help_text: "The maximum number of times a student can submit the assessment.",
+                 help_text: "The maximum number of times a student can submit the assessment. \
+                             <br>If set to -1, unlimited submissions are allowed.".html_safe,
                  placeholder: "10",
                  disabled: @has_unlimited_submissions %>
 <%= label_tag(:unlimited_submissions) do %>
@@ -8,8 +9,8 @@
 <% end %>
 
 <%= f.text_field :max_grace_days,
-                 help_text: "Maximum number of grace days that a student can spend on this assessment.",
-                 placeholder: "2",
+                 help_text: "Maximum number of grace days that a student can spend on this assessment. \
+                             <br>If blank, all available grace days can be spent on this assessment.".html_safe,
                  disabled: @has_unlimited_grace_days %>
 <%= label_tag(:unlimited_grace_days) do %>
   <%= check_box_tag :unlimited_grace_days, "1", @has_unlimited_grace_days %>
@@ -20,7 +21,7 @@
                              optional: true,
                              help_text: "The penalty applied to late submissions after a student runs out of grace days.
   It represents the number of points or a percentage of the total score removed per day, and must be a non-negative
-  number.",
+  number.<br>If blank, the course default is used.".html_safe,
                              disabled: @uses_default_late_penalty %>
 <%= label_tag(:use_default_late_penalty) do %>
   <%= check_box_tag :use_default_late_penalty, "1", @uses_default_late_penalty %>
@@ -29,7 +30,7 @@
 
 <%= f.text_field :version_threshold,
                  help_text: "The number of unpenalized submissions allowed. After this threshold,
-  each additional submission is penalized according to the version penalty. If set to -1, no submissions are penalized.",
+  each additional submission is penalized according to the version penalty.<br>If set to -1, no submissions are penalized.".html_safe,
                  disabled: @uses_default_version_threshold %>
 <%= label_tag(:use_default_version_threshold) do %>
   <%= check_box_tag :use_default_version_threshold, "1", @uses_default_version_threshold %>
@@ -39,8 +40,9 @@
 <%= f.score_adjustment_input :version_penalty, optional: true,
                                                help_text: "The penalty applied to submissions with version greater than the version
   threshold. It represents the number of points or the percentage of the total score removed per version above the
-  threshold, and must be a non-negative number. For example, if this is set to 1 point and the version threshold to 3,
-  the fifth version of a student's submissions would be docked 2 points.",
+  threshold, and must be a non-negative number.
+  <br>For example, if this is set to 1 point and the version threshold to 3, the fifth version of a student's submissions would be docked 2 points.
+  <br>If blank, the course default is used.".html_safe,
                                                disabled: @uses_default_version_penalty %>
 <%= label_tag(:use_default_version_penalty) do %>
   <%= check_box_tag :use_default_version_penalty, "1", @uses_default_version_penalty %>

--- a/app/views/assessments/_edit_penalties.html.erb
+++ b/app/views/assessments/_edit_penalties.html.erb
@@ -10,7 +10,7 @@
 
 <%= f.text_field :max_grace_days,
                  help_text: "Maximum number of grace days that a student can spend on this assessment. \
-                             <br>If blank, all available grace days can be spent on this assessment.".html_safe,
+                             <br>If left blank, all available grace days can be spent on this assessment.".html_safe,
                  disabled: @has_unlimited_grace_days %>
 <%= label_tag(:unlimited_grace_days) do %>
   <%= check_box_tag :unlimited_grace_days, "1", @has_unlimited_grace_days %>
@@ -21,7 +21,7 @@
                              optional: true,
                              help_text: "The penalty applied to late submissions after a student runs out of grace days.
   It represents the number of points or a percentage of the total score removed per day, and must be a non-negative
-  number.<br>If blank, the course default is used.".html_safe,
+  number.<br>If left blank, the course default is used.".html_safe,
                              disabled: @uses_default_late_penalty %>
 <%= label_tag(:use_default_late_penalty) do %>
   <%= check_box_tag :use_default_late_penalty, "1", @uses_default_late_penalty %>
@@ -30,7 +30,9 @@
 
 <%= f.text_field :version_threshold,
                  help_text: "The number of unpenalized submissions allowed. After this threshold,
-  each additional submission is penalized according to the version penalty.<br>If set to -1, no submissions are penalized.".html_safe,
+  each additional submission is penalized according to the version penalty.
+  <br>If set to -1, no submissions are penalized.
+  <br>If left blank, the course default is used.".html_safe,
                  disabled: @uses_default_version_threshold %>
 <%= label_tag(:use_default_version_threshold) do %>
   <%= check_box_tag :use_default_version_threshold, "1", @uses_default_version_threshold %>
@@ -41,8 +43,8 @@
                                                help_text: "The penalty applied to submissions with version greater than the version
   threshold. It represents the number of points or the percentage of the total score removed per version above the
   threshold, and must be a non-negative number.
-  <br>For example, if this is set to 1 point and the version threshold to 3, the fifth version of a student's submissions would be docked 2 points.
-  <br>If blank, the course default is used.".html_safe,
+  For example, if this is set to 1 point and the version threshold to 3, the fifth version of a student's submissions would be docked 2 points.
+  <br>If left blank, the course default is used.".html_safe,
                                                disabled: @uses_default_version_penalty %>
 <%= label_tag(:use_default_version_penalty) do %>
   <%= check_box_tag :use_default_version_penalty, "1", @uses_default_version_penalty %>

--- a/app/views/assessments/_edit_penalties.html.erb
+++ b/app/views/assessments/_edit_penalties.html.erb
@@ -2,8 +2,9 @@
                  help_text: "The maximum number of times a student can submit the assessment. \
                              <br>If set to -1, unlimited submissions are allowed.".html_safe,
                  placeholder: "10",
-                 disabled: @has_unlimited_submissions %>
-<%= label_tag(:unlimited_submissions) do %>
+                 disabled: @has_unlimited_submissions,
+                 wrap_class: %w[input-field no-padding-bottom] %>
+<%= label_tag(:unlimited_submissions, nil, class: "input-default") do %>
   <%= check_box_tag :unlimited_submissions, "1", @has_unlimited_submissions %>
   <%= content_tag("span", "Allow unlimited submissions.") %>
 <% end %>
@@ -11,7 +12,8 @@
 <%= f.text_field :max_grace_days,
                  help_text: "Maximum number of grace days that a student can spend on this assessment. \
                              <br>If left blank, all available grace days can be spent on this assessment.".html_safe,
-                 disabled: @has_unlimited_grace_days %>
+                 disabled: @has_unlimited_grace_days,
+                 wrap_class: %w[input-field no-padding-bottom] %>
 <%= label_tag(:unlimited_grace_days) do %>
   <%= check_box_tag :unlimited_grace_days, "1", @has_unlimited_grace_days %>
   <%= content_tag("span", "Allow unlimited grace days.") %>
@@ -22,7 +24,8 @@
                              help_text: "The penalty applied to late submissions after a student runs out of grace days.
   It represents the number of points or a percentage of the total score removed per day, and must be a non-negative
   number.<br>If left blank, the course default is used.".html_safe,
-                             disabled: @uses_default_late_penalty %>
+                             disabled: @uses_default_late_penalty,
+                             wrap_class: %w[input-field no-padding-bottom] %>
 <%= label_tag(:use_default_late_penalty) do %>
   <%= check_box_tag :use_default_late_penalty, "1", @uses_default_late_penalty %>
   <%= content_tag("span", "Use the course default of deducting #{@assessment.course.late_penalty} per day.") %>
@@ -33,7 +36,8 @@
   each additional submission is penalized according to the version penalty.
   <br>If set to -1, no submissions are penalized.
   <br>If left blank, the course default is used.".html_safe,
-                 disabled: @uses_default_version_threshold %>
+                 disabled: @uses_default_version_threshold,
+                 wrap_class: %w[input-field no-padding-bottom] %>
 <%= label_tag(:use_default_version_threshold) do %>
   <%= check_box_tag :use_default_version_threshold, "1", @uses_default_version_threshold %>
   <%= content_tag("span", "Use the course default of #{@assessment.course.version_threshold}.") %>
@@ -45,7 +49,8 @@
   threshold, and must be a non-negative number.
   For example, if this is set to 1 point and the version threshold to 3, the fifth version of a student's submissions would be docked 2 points.
   <br>If left blank, the course default is used.".html_safe,
-                                               disabled: @uses_default_version_penalty %>
+                                               disabled: @uses_default_version_penalty,
+                                               wrap_class: %w[input-field no-padding-bottom] %>
 <%= label_tag(:use_default_version_penalty) do %>
   <%= check_box_tag :use_default_version_penalty, "1", @uses_default_version_penalty %>
   <%= content_tag("span", "Use the course default of deducting #{@assessment.course.version_penalty} per submission.") %>

--- a/app/views/assessments/_edit_penalties.html.erb
+++ b/app/views/assessments/_edit_penalties.html.erb
@@ -8,36 +8,39 @@
   blank, all of the remaining available course grace days can be spent on this assessment.",
                  placeholder: "Leave blank for no grace day limit" %>
 
+<% late_penalty_help_text = "The penalty applied to late submissions after a student runs out of grace days.
+  It represents the number of points or a percentage of the total score removed per day, and must be a non-negative
+  number. If left blank, the course default is used."
+  if @assessment.late_penalty.value.nil?
+    late_penalty_help_text += "<br><strong class='red-text'>The late penalty is currently set to the course default of deducting #{@assessment.course.late_penalty} per day.</strong>"
+  end %>
 <%= f.score_adjustment_input :late_penalty,
                              optional: true,
-                             help_text: "The penalty applied to late submissions after a student runs out of grace days.
-  It represents the number of points or a percentage of the total score removed per day, and must be a non-negative
-  number. If left blank, the course default is used.",
+                             help_text: late_penalty_help_text.html_safe,
                              placeholder: "E.g. 15%" %>
-<% if @assessment.late_penalty.value.nil? %>
-  <strong class="red-text">The late penalty is currently set to the course default of deducting <%= @assessment.course.late_penalty %> per day.</strong>
-<% end %>
 
-<%= f.text_field :version_threshold, help_text: "The number of unpenalized submissions allowed. After this threshold,
+<% version_threshold_help_text =  "The number of unpenalized submissions allowed. After this threshold,
   each additional submission is penalized according to the version penalty. If set to -1, no submissions are penalized.
-  If this is left blank, the course default is used.",
-                                     placeholder: "Leave blank to use course default." %>
-<% if @assessment.version_threshold.nil? %>
-  <strong class="red-text">
-    The version threshold is currently set to the course default of <%= @assessment.course.version_threshold %>
-    <% if @assessment.course.version_threshold == -1 %>(unlimited)<% end %>.
-  </strong>
-<% end %>
+  If this is left blank, the course default is used."
+   if @assessment.version_threshold.nil?
+     version_threshold_help_text += "<br><strong class='red-text'>The version threshold is currently set to the course default of #{@assessment.course.version_threshold}.</strong>"
+   end
+%>
+<%= f.text_field :version_threshold,
+                 help_text: version_threshold_help_text.html_safe,
+                 placeholder: "Leave blank to use course default." %>
 
-<%= f.score_adjustment_input :version_penalty, optional: true,
-                                               help_text: "The penalty applied to submissions with version greater than the version
+<% version_penalty_help_text = "The penalty applied to submissions with version greater than the version
   threshold. It represents the number of points or the percentage of the total score removed per version above the
   threshold, and must be a non-negative number. For example, if this is set to 1 point and the version threshold to 3,
-  the fifth version of a student's submissions would be docked 2 points.",
+  the fifth version of a student's submissions would be docked 2 points."
+   if @assessment.version_penalty.value.nil?
+     version_penalty_help_text += "<br><strong class='red-text'>The version penalty is currently set to the course default of deducting #{@assessment.course.version_penalty} per submission.</strong>"
+   end
+%>
+<%= f.score_adjustment_input :version_penalty, optional: true,
+                                               help_text: version_penalty_help_text.html_safe,
                                                placeholder: "Leave blank to use course default." %>
-<% if @assessment.version_penalty.value.nil? %>
-  <strong class="red-text">The version penalty is currently set to the course default of deducting <%= @assessment.course.version_penalty %> per submission.</strong>
-<% end %>
 
 <div class="action_buttons">
   <%= f.submit "Save", name: "penalties" %>

--- a/app/views/assessments/_edit_penalties.html.erb
+++ b/app/views/assessments/_edit_penalties.html.erb
@@ -15,7 +15,7 @@
   number. If left blank, the course default is used.",
                              placeholder: "E.g. 15%" %>
 <% if @assessment.late_penalty.value.nil? %>
-  <strong class="red-text">The late penalty is currently set to the course default of -<%= @assessment.course.late_penalty %> per day.</strong>
+  <strong class="red-text">The late penalty is currently set to the course default of deducting <%= @assessment.course.late_penalty %> per day.</strong>
 <% end %>
 
 <%= f.text_field :version_threshold, help_text: "The number of unpenalized submissions allowed. After this threshold,
@@ -23,7 +23,10 @@
   If this is left blank, the course default is used.",
                                      placeholder: "Leave blank to use course default." %>
 <% if @assessment.version_threshold.nil? %>
-  <strong class="red-text">The version threshold is currently set to the course default of <%= @assessment.course.version_threshold %>.</strong>
+  <strong class="red-text">
+    The version threshold is currently set to the course default of <%= @assessment.course.version_threshold %>
+    <% if @assessment.course.version_threshold == -1 %>(unlimited)<% end %>.
+  </strong>
 <% end %>
 
 <%= f.score_adjustment_input :version_penalty, optional: true,
@@ -33,7 +36,7 @@
   the fifth version of a student's submissions would be docked 2 points.",
                                                placeholder: "Leave blank to use course default." %>
 <% if @assessment.version_penalty.value.nil? %>
-  <strong class="red-text">The version penalty is currently set to the course default of -<%= @assessment.course.version_penalty %> per submission.</strong>
+  <strong class="red-text">The version penalty is currently set to the course default of deducting <%= @assessment.course.version_penalty %> per submission.</strong>
 <% end %>
 
 <div class="action_buttons">

--- a/app/views/assessments/_edit_penalties.html.erb
+++ b/app/views/assessments/_edit_penalties.html.erb
@@ -1,46 +1,51 @@
 <%= f.text_field :max_submissions,
-                 help_text: "The maximum number of times a student can submit the assessment.
-  Set this to -1 to allow unlimited submissions.",
-                 placeholder: "E.g. 10" %>
+                 help_text: "The maximum number of times a student can submit the assessment.",
+                 placeholder: "10",
+                 disabled: @has_unlimited_submissions %>
+<%= label_tag(:unlimited_submissions) do %>
+  <%= check_box_tag :unlimited_submissions, "1", @has_unlimited_submissions %>
+  <%= content_tag("span", "Allow unlimited submissions.") %>
+<% end %>
 
 <%= f.text_field :max_grace_days,
-                 help_text: "Maximum number of grace days that a student can spend on this assessment. E.g., 2. If left
-  blank, all of the remaining available course grace days can be spent on this assessment.",
-                 placeholder: "Leave blank for no grace day limit" %>
+                 help_text: "Maximum number of grace days that a student can spend on this assessment.",
+                 placeholder: "2",
+                 disabled: @has_unlimited_grace_days %>
+<%= label_tag(:unlimited_grace_days) do %>
+  <%= check_box_tag :unlimited_grace_days, "1", @has_unlimited_grace_days %>
+  <%= content_tag("span", "Allow unlimited grace days.") %>
+<% end %>
 
-<% late_penalty_help_text = "The penalty applied to late submissions after a student runs out of grace days.
-  It represents the number of points or a percentage of the total score removed per day, and must be a non-negative
-  number. If left blank, the course default is used."
-  if @assessment.late_penalty.value.nil?
-    late_penalty_help_text += "<br><strong class='red-text'>The late penalty is currently set to the course default of deducting #{@assessment.course.late_penalty} per day.</strong>"
-  end %>
 <%= f.score_adjustment_input :late_penalty,
                              optional: true,
-                             help_text: late_penalty_help_text.html_safe,
-                             placeholder: "E.g. 15%" %>
+                             help_text: "The penalty applied to late submissions after a student runs out of grace days.
+  It represents the number of points or a percentage of the total score removed per day, and must be a non-negative
+  number.",
+                             disabled: @uses_default_late_penalty %>
+<%= label_tag(:use_default_late_penalty) do %>
+  <%= check_box_tag :use_default_late_penalty, "1", @uses_default_late_penalty %>
+  <%= content_tag("span", "Use the course default of deducting #{@assessment.course.late_penalty} per day.") %>
+<% end %>
 
-<% version_threshold_help_text =  "The number of unpenalized submissions allowed. After this threshold,
-  each additional submission is penalized according to the version penalty. If set to -1, no submissions are penalized.
-  If this is left blank, the course default is used."
-   if @assessment.version_threshold.nil?
-     version_threshold_help_text += "<br><strong class='red-text'>The version threshold is currently set to the course default of #{@assessment.course.version_threshold}.</strong>"
-   end
-%>
 <%= f.text_field :version_threshold,
-                 help_text: version_threshold_help_text.html_safe,
-                 placeholder: "Leave blank to use course default." %>
+                 help_text: "The number of unpenalized submissions allowed. After this threshold,
+  each additional submission is penalized according to the version penalty. If set to -1, no submissions are penalized.",
+                 disabled: @uses_default_version_threshold %>
+<%= label_tag(:use_default_version_threshold) do %>
+  <%= check_box_tag :use_default_version_threshold, "1", @uses_default_version_threshold %>
+  <%= content_tag("span", "Use the course default of #{@assessment.course.version_threshold}.") %>
+<% end %>
 
-<% version_penalty_help_text = "The penalty applied to submissions with version greater than the version
+<%= f.score_adjustment_input :version_penalty, optional: true,
+                                               help_text: "The penalty applied to submissions with version greater than the version
   threshold. It represents the number of points or the percentage of the total score removed per version above the
   threshold, and must be a non-negative number. For example, if this is set to 1 point and the version threshold to 3,
-  the fifth version of a student's submissions would be docked 2 points."
-   if @assessment.version_penalty.value.nil?
-     version_penalty_help_text += "<br><strong class='red-text'>The version penalty is currently set to the course default of deducting #{@assessment.course.version_penalty} per submission.</strong>"
-   end
-%>
-<%= f.score_adjustment_input :version_penalty, optional: true,
-                                               help_text: version_penalty_help_text.html_safe,
-                                               placeholder: "Leave blank to use course default." %>
+  the fifth version of a student's submissions would be docked 2 points.",
+                                               disabled: @uses_default_version_penalty %>
+<%= label_tag(:use_default_version_penalty) do %>
+  <%= check_box_tag :use_default_version_penalty, "1", @uses_default_version_penalty %>
+  <%= content_tag("span", "Use the course default of deducting #{@assessment.course.version_penalty} per submission.") %>
+<% end %>
 
 <div class="action_buttons">
   <%= f.submit "Save", name: "penalties" %>

--- a/app/views/assessments/_submission_history_row.html.erb
+++ b/app/views/assessments/_submission_history_row.html.erb
@@ -54,9 +54,12 @@
   <% end %>
 
   <% if @course.grace_days >= 0 then %>
-    <td title="Submitted <%= submission.days_late %> days late">
-      <span class="nobr">
-      <%= submission.days_late.to_s + " day".pluralize(submission.days_late) %>
+    <td>
+      <span class="nobr" title="Submitted <%= submission.days_late %> day(s) late">
+        <%= submission.days_late.to_s + " day".pluralize(submission.days_late) %>
+      </span>
+      <span class="nobr" title="Used <%= submission.grace_days_used %> grace day(s)">
+        (<%= submission.grace_days_used.to_s + " day".pluralize(submission.grace_days_used) %>)
       </span>
     </td>
   <% end %>

--- a/app/views/assessments/_submission_history_table.html.erb
+++ b/app/views/assessments/_submission_history_table.html.erb
@@ -15,7 +15,7 @@
         <% end %>
 
         <% if @course.grace_days >= 0 %>
-          <th>Late Days Used</th>
+          <th>Days Late<br>(Grace Days Used)</th>
         <% end %>
 
         <% if @assessment.version_penalty? %>

--- a/app/views/assessments/edit.html.erb
+++ b/app/views/assessments/edit.html.erb
@@ -26,21 +26,6 @@
 <div class="row">
   <div class="col s12">
     <%= form_for [@course, @assessment], url: edit_course_assessment_path(@course, @assessment) + "/#{params[:active_tab]}", builder: FormBuilderWithDateTimeInput do |f| %>
-      <% if @course.errors.any? %>
-          <ul>
-            <% @course.errors.full_messages.each do |msg| %>
-              <li><%= msg %></li>
-            <% end %>
-          </ul>
-      <% end %>
-
-      <% if @assessment.errors.any? %>
-          <ul>
-            <% @assessment.errors.full_messages.each do |msg| %>
-              <li><%= msg %></li>
-            <% end %>
-          </ul>
-      <% end %>
       <div id="tab_basic">
         <%= render "edit_basic", f: f %>
       </div>

--- a/app/views/courses/_courseFields.html.erb
+++ b/app/views/courses/_courseFields.html.erb
@@ -19,16 +19,15 @@
 <%= f.score_adjustment_input :late_penalty, optional: true, help_text: "The penalty applied to late submissions after
   a student runs out of grace days. It represents an amount of points or a percentage of the total score removed per
   day, and must be a non-negative number. This field can be overriden on a per-assessment basis.",
-                                            placeholder: "E.g. 15%" %>
+                                            placeholder: "10" %>
 
 <%= f.text_field :version_threshold, help_text: "If a submission's version is greater than this threshold, it is
-  penalized according to the version penalty. If set to -1, no submissions are penalized. This is required, but can be
-  overridden on a per-assessment basis.", placeholder: "E.g. 10" %>
+  penalized according to the version penalty. If set to -1, no submissions are penalized. This field can be overriden on a per-assessment basis.", placeholder: "10" %>
 
 <%= f.score_adjustment_input :version_penalty, optional: true, help_text: "The penalty applied to submissions with
   versions greater than the version threshold, i.e. number of points or percentage of the total score removed per
   version above the threshold. For example, if this is set to 1 point and the version threshold to 3, the fifth
-  version of a student's submissions would be docked 2 points.", placeholder: "E.g. 15%" %>
+  version of a student's submissions would be docked 2 points. This field can be overriden on a per-assessment basis.", placeholder: "10" %>
 
 <%= f.date_select :start_date, help_text: "When the course becomes active.",
                                less_than: "course_end_date" %>

--- a/config/initializers/core_ext.rb
+++ b/config/initializers/core_ext.rb
@@ -1,0 +1,11 @@
+class String
+  def to_boolean
+    ActiveRecord::Type::Boolean.new.cast(self)
+  end
+end
+
+class NilClass
+  def to_boolean
+    false
+  end
+end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Summary
<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 01 Nov 23 03:23 UTC
This pull request includes several changes across multiple files. Here's a summary of the changes:

- In the file `_edit_penalties.html.erb`, changes were made to text fields, labels, and checkboxes related to assessment penalties. The changes aim to improve user experience and provide more flexibility in setting penalties for assessments.
- In the file `assessments_controller.rb`, modifications were made to the `edit` and `update` actions to handle penalty-related parameters and provide warning messages for instructors. These changes enhance the functionality and flexibility of the assessment controller.
- The file `courses/_courseFields.html.erb` includes modifications to the placeholder values of certain input fields.
- Changes in the `FormBuilderWithDateTimeInput` class consolidate and improve the arguments and options passed to various methods.
- The file diff related to the Penalties tab in the assessment editor introduces event listeners for checkboxes, logic to enable or disable input fields, and triggering change events on page load.
- Changes in the `ScoreAdjustment` model's `to_s` method enhance consistency and formatting.
- The `app/views/assessments/_submission_history_table.html.erb` file modifies a label in the submission history table.
- CSS selectors in another file now exclude elements with a specific class and target additional elements, adding a bottom padding.
- The `edit.html.erb` file in the `app/views/assessments` directory removes error message handling code.
- A new file `config/initializers/core_ext.rb` is being added, defining class extensions for string-to-boolean conversions.
- Changes in the `app/views/assessments/_submission_history_row.html.erb` file enhance the display of submission details.

These changes improve functionality, user experience, and consistency in different parts of the codebase.
<!-- reviewpad:summarize:end -->

## Description
<!--- Describe your changes in detail -->
- Display grace days used next to number of late days
- Add warnings when late days are allowed but settings do not make sense (e.g. grace days can't be used and/or penalty late days are "free")
- Add checkboxes on penalty tab to easily use course defaults / allow unlimited submissions / allow unlimited grace days

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Closes #1989

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Make a late submission on an assessment that allows the use of grace days. Observe the correct number of grace days used displayed.

![Screenshot 2023-10-03 at 16 23 02](https://github.com/autolab/Autolab/assets/9074856/0ff1c52d-bdab-401c-bdad-4c3fd10b1353)

Allow late submissions on assessment (end at > due at). Set late penalty to 0 and/or max grace days to 0, see warning(s). Also check that they display correctly when course defaults are used for these values.

![Screenshot 2023-10-06 at 01 15 52](https://github.com/autolab/Autolab/assets/9074856/fc1ee167-7a8e-48b4-b4ef-050e88d7b7bf)

- Set values for max submissions, max grace days, late penalty, version threshold, version penalty -> ensure it saves successfully
- Check all the checkboxes and save
  - max submissions -> -1
  - max grace days -> (blank)
  - late penalty -> (blank)
  - version threshold -> -1
  - version penalty -> (blank)
- Verify that the above settings take effect
  - make a student account submit once, a few days late
  - they should see unlimited submissions left
  - they should see all their grace days being used (e.g. 3)
  - can test late penalty by toggling between 0 (assessment-specific), and 1 (course default)
  - can test version threshold / penalty in a similar manner

![Screenshot 2023-10-12 at 22 37 07](https://github.com/autolab/Autolab/assets/9074856/fece1920-4ac5-4d73-bdfa-b26be2775d92)
![Screenshot 2023-10-12 at 22 37 13](https://github.com/autolab/Autolab/assets/9074856/1262cce5-4a23-4eef-b116-ffbf29e701ad)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://github.com/autolab/docs)
- [ ] I have updated the documentation accordingly, included in this PR
