### PR TITLE
Add erblint to overcommit and github actions

### DIFF
--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -1,5 +1,7 @@
 glob: "app/**/*.{html,text,js}{+*,}.erb"
 EnableDefaultLinters: true
+exclude:
+  - '**/javascripts/*'
 linters:
   HardCodedString:
     enabled: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -23,7 +23,7 @@ reviewpad:summary
 
 ## Checklist:
 <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
-- [ ] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
+- [ ] I have run rubocop and erblint for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
 - [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://docs.autolabproject.com/)
 - [ ] I have updated the documentation accordingly, included in this PR
 

--- a/.github/workflows/rubyonrails.yml
+++ b/.github/workflows/rubyonrails.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Rubocop
         run: bundle exec rubocop
 
+      - name: Erblint
+        run: bundle exec erblint --lint-all
+
   test:
     runs-on: ubuntu-latest
 

--- a/.overcommit.yml
+++ b/.overcommit.yml
@@ -21,6 +21,9 @@ PreCommit:
  RuboCop:
    enabled: true
    on_warn: fail # Treat all warnings as failures
+ ErbLint:
+   enabled: true
+   on_warn: fail
 
 #  TrailingWhitespace:
 #    enabled: true

--- a/Gemfile
+++ b/Gemfile
@@ -45,8 +45,8 @@ gem 'slack-notifier'
 gem 'exception_notification', ">= 4.1.0"
 
 # Used by lib/tasks/autolab.rake to populate DB with dummy seed data
-gem 'rake', '>=10.3.2'
 gem 'populator', '>=1.0.0'
+gem 'rake', '>=10.3.2'
 
 # To communicate with MySQL database
 gem 'mysql2', '~>0.4.10'
@@ -83,20 +83,20 @@ gem 'rubyzip'
 gem 'httparty'
 
 # Enables RSpec testing framework with Capybara and FactoryBot.
-gem 'rspec-rails', '>=3.5.0'
-gem 'rack-test'
 gem 'capybara', group: [:development, :test]
+gem 'rack-test'
+gem 'rspec-rails', '>=3.5.0'
 # To enable webdriver testing capabilities along with capybara
 gem 'selenium-webdriver', '>=4.7.1', group: :test
 # required to run webdriver for selenium on chrome
 gem 'webdrivers', group: :test
 # required for capybara debugging
-gem 'launchy', group: :test
-gem 'factory_bot_rails', group: [:development, :test]
-gem 'database_cleaner', group: [:development, :test]
-gem 'webmock', group: [:development, :test]
 gem 'codeclimate-test-reporter', group: :test, require: nil
+gem 'database_cleaner', group: [:development, :test]
+gem 'factory_bot_rails', group: [:development, :test]
+gem 'launchy', group: :test
 gem 'newrelic_rpm'
+gem 'webmock', group: [:development, :test]
 
 # Automatic Time Zone Management
 gem 'browser-timezone-rails'
@@ -112,9 +112,9 @@ gem 'js_cookie_rails'
 # gem 'capistrano-rails', group: :development
 
 # Dates and times
+gem 'bootstrap3-datetimepicker-rails', '>= 4.17.47'
 gem 'momentjs-rails', '>= 2.9.0'
 gem 'moment_timezone-rails'
-gem 'bootstrap3-datetimepicker-rails', '>= 4.17.47'
 
 # Force SSL on certain routes
 gem 'rack-ssl-enforcer'
@@ -125,6 +125,7 @@ group :development do
   gem 'binding_of_caller' # enhances better_errors
 
   # static code analyzer
+  gem 'erb_lint', require: false
   gem 'rubocop', require: false
   gem 'rubocop-rails', require: false
 
@@ -170,4 +171,3 @@ gem 'lockbox'
 # to decode / verify jwts for LTI Integration
 gem "jwt"
 
-gem 'erb_lint', require: true

--- a/Gemfile
+++ b/Gemfile
@@ -170,4 +170,4 @@ gem 'lockbox'
 # to decode / verify jwts for LTI Integration
 gem "jwt"
 
-gem 'erb_lint', require: false
+gem 'erb_lint', require: true

--- a/app/views/assessments/bulkGrade.html.erb
+++ b/app/views/assessments/bulkGrade.html.erb
@@ -10,15 +10,15 @@
 <% end %>
 
   <% if @valid_entries %>
-    <%= render "bulkGrade_entries", :entries => @entries, :problems => @assessment.problems if @entries %>
-    <%= form_for :confirm, :url => "bulkGrade_complete", :html => { :class => "confirm" } do |f| %>
-      <%= f.hidden_field :bulkGrade_csv, :value => @csv %>
-      <%= f.hidden_field :bulkGrade_data_type, :value => @data_type %>
+    <%= render "bulkGrade_entries", entries: @entries, problems: @assessment.problems if @entries %>
+    <%= form_for :confirm, url: "bulkGrade_complete", html: { class: "confirm" } do |f| %>
+      <%= f.hidden_field :bulkGrade_csv, value: @csv %>
+      <%= f.hidden_field :bulkGrade_data_type, value: @data_type %>
 
-      <%= f.submit 'Yes' , {:class=>"btn submit"} %><%= link_to "No", { :action => :bulkGrade }, :class => "btn submit" %>
+      <%= f.submit 'Yes', { class: "btn submit" } %><%= link_to "No", { action: :bulkGrade }, class: "btn submit" %>
     <% end %>
   <% else %>
-    <%= render "bulkGrade_error_entries", :entries => @entries, :problems => @assessment.problems if @entries %>
+    <%= render "bulkGrade_error_entries", entries: @entries, problems: @assessment.problems if @entries %>
     <%= render 'bulkGrade_initial' %>
   <% end %>
 </div>

--- a/app/views/course_user_data/new.html.erb
+++ b/app/views/course_user_data/new.html.erb
@@ -1,6 +1,6 @@
 <% content_for :javascripts do %>
   <%= javascript_include_tag "course_user_data_edit" %>
-  <script type="application/javascript">
+  <script type="text/javascript">
     $("#course_user_datum_user_attributes_email").on('change', user_lookup);
     $("#course_user_datum_user_attributes_email").on('input', user_lookup);
     /**

--- a/app/views/courses/email.html.erb
+++ b/app/views/courses/email.html.erb
@@ -19,13 +19,13 @@
   <table class=verticalTable>
     <tr>
       <th><b> From: </b></th>
-      <td><%= text_field_tag :from %></td>
+      <td><%= text_field_tag :from, autocomplete: "email" %></td>
       <td class=smallText>This will be the from and reply-to address,
       so it should be legitimate</td>
     </tr>
     <tr>
       <th><b> Subject:</b></th>
-      <td><%= text_field_tag :subject %></td>
+      <td><%= text_field_tag :subject, autocomplete: "off" %></td>
     </tr>
     <tr>
       <th><b>Section:</b></th>

--- a/app/views/courses/new.html.erb
+++ b/app/views/courses/new.html.erb
@@ -13,7 +13,7 @@
 
   <div class="input-field">
     <label class="control-label" for="instructor_email">Instructor Email</label>
-    <%= email_field_tag :instructor_email, nil, class: "validate", placeholder: "", required: true %>
+    <%= email_field_tag :instructor_email, nil, class: "validate", placeholder: "", required: true, autocomplete: "off" %>
   <p class="help-block">Email of an Instructor, they will set up the course from here!</p>
   </div>
 

--- a/app/views/courses/report_bug.html.erb
+++ b/app/views/courses/report_bug.html.erb
@@ -24,7 +24,7 @@ Note: if you encountered the following problems, please contact your course inst
 <table>
   <tr>
     <th>Title: </th>
-    <td><%= text_field_tag :title %></td>
+    <td><%= text_field_tag :title, autocomplete: "off" %></td>
   </tr>
   <tr>
     <th colspan=2>Summary: </th>

--- a/app/views/schedulers/new.html.erb
+++ b/app/views/schedulers/new.html.erb
@@ -6,11 +6,11 @@
 <%= form_for :scheduler, url: course_schedulers_path(@course), builder: FormBuilderWithDateTimeInput do |f| %>
   <%= f.error_messages %>
   <%= f.text_field :action, help_text: "Path to scheduler file relative to Autolab root",
-                   placeholder: "(scheduler action)" %>
+                            placeholder: "(scheduler action)" %>
   <%= f.datetime_select :next, help_text: "Time of next run" %>
   <%= f.datetime_select :until, help_text: "Don't run after this time" %>
   <%= f.number_field :interval, min: 1, help_text: "Minimum interval between each run (in seconds)",
-                     value: 600 %>
+                                value: 600 %>
   <%= f.check_box :disabled %>
   <div class="action_buttons">
     <%= link_to 'Back', course_schedulers_path(@course), { class: "btn" } %>

--- a/app/views/submissions/_version_dropdown.html.erb
+++ b/app/views/submissions/_version_dropdown.html.erb
@@ -3,8 +3,7 @@
   <select
     class="browser-default"
     onchange="location.assign(this.value)"
-    title="* version also contains the currently selected file"
-  >
+    title="* version also contains the currently selected file">
     <% for submission in @userVersions do %>
       <% selected = @submission.version == submission.version %>
       <% path = view_course_assessment_submission_path(@course, @assessment, submission, { header_position: submission.header_position }) %>

--- a/app/views/submissions/edit.html.erb
+++ b/app/views/submissions/edit.html.erb
@@ -2,8 +2,8 @@
 #<%= @submission.version %> for <%= link_to @assessment.display_name, course_assessment_path(@submission.course_user_datum.course, @assessment) %></h2>
 
 <%= form_for @submission, url: [@submission.course_user_datum.course, @assessment, @submission],
-             builder: FormBuilderWithDateTimeInput,
-             method: :patch do |f| %>
+                          builder: FormBuilderWithDateTimeInput,
+                          method: :patch do |f| %>
 <%= f.error_messages %>
 <table class="verticalTable">
   <tr>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Summary
<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 06 Oct 23 18:17 UTC
This pull request modifies multiple files with the following changes:

1. The `.overcommit.yml` file has been modified to enable the `ErbLint` pre-commit hook and treat warnings as failures.
2. The `edit.html.erb` file has changes related to indentation and closing tags.
3. The `app/views/submissions/_version_dropdown.html.erb` file has changes to the `<select>` element's attributes, including adding a JavaScript function to the `onchange` attribute and modifying the `title` attribute.
4. The `.github/pull_request_template.md` file has changes to checklist items, documentation link, and requirement for documentation update.
5. The `email.html.erb` file in the `app/views/courses` directory has changes to the `text_field_tag` attributes related to autocomplete.
6. The `new.html.erb` file has changes to the script tag's `type` attribute.
7. The `.erb-lint.yml` file has changes related to exclude rules and disabling a linter.
8. The `rubyonrails.yml` workflow file has a new step added.
9. The `new.html.erb` file has changes related to indentation and alignment.
10. The `report_bug.html.erb` file in the `app/views/courses` directory has changes to the `text_field_tag` attributes related to autocomplete.
11. The `bulkGrade.html.erb` file has changes to the syntax for rendering partials, `form_for` method, hidden fields, class attribute of submit buttons, and `link_to` method.
12. The Gemfile has various changes, including reordering gems, adding new gems, and grouping gems.

Let me know if you need more details or further assistance with this diff.
<!-- reviewpad:summarize:end -->

## Description
<!--- Describe your changes in detail -->
- Enable `erblint` in overcommit so that it is now a pre-commit hook, and have it run in github actions as well to show linting errors automatically
- lint some files which didn't seem to get linted during initial linting push
- update pull request documentation to include erblint check

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- All initial `erblint` PRs have been merged, so we can now enable pre-commit hooks for `erblint` to enforce `erb` style automatically from now on

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- check out this branch, remove a newline from a erb file, try to commit and see that commit fails due to failed erblint

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have run rubocop for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting


