### PR TITLE
Switch mossnet clean to use rails root instead of tilde expansion

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -571,7 +571,9 @@ class CoursesController < ApplicationController
     system("chmod -R a+r #{tmp_dir}")
     ActiveRecord::Base.clear_active_connections!
     # Remove non text files when making a moss run
-    `~/Autolab/script/cleanMoss #{tmp_dir}`
+    Dir.chdir(Rails.root.join("script")) do
+      system("./cleanMoss #{tmp_dir}")
+    end
     # Now run the Moss command
     @mossCmdString = @mossCmd.join(" ")
     @mossOutput = `#{@mossCmdString} 2>&1`


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Summary
<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 24 Oct 23 22:41 UTC
This pull request updates the usage of the cleanMoss script in the app/controllers/courses_controller.rb file. Instead of using the "~/Autolab/script/cleanMoss" path, it now uses Rails.root.join("script") to ensure compatibility across different systems.
<!-- reviewpad:summarize:end -->

## Description
<!--- Describe your changes in detail -->
- Use `Rails.root.join("script")` instead of `~/Autolab/script/` to get to directory of `cleanMoss` script, which removes non-text files (necessary to run in order for moss to run successfully)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

MOSS has been found not to work on docker-based Autolab instances, due to instances where a non-text file is found in submissions, failing the entire moss run:
![Screenshot 2023-10-24 at 6 28 08 PM](https://github.com/autolab/Autolab/assets/25730111/75e91cef-e9f1-4301-bdac-4300b9f2666f)

This is because the tilde expansion used to move into the `script` directory will not work on docker-based installs, which don't have Autolab at the top-level (unlike local installs).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- On nightly, run moss on Malloc Lab in [NewLTILinkedCourse](https://nightly.autolabproject.com/courses/NewLTILinkedCourse/moss):

![Screenshot 2023-10-24 at 6 37 58 PM](https://github.com/autolab/Autolab/assets/25730111/83befd00-c80b-4094-8e9b-027b62ac2f45)

- run moss, see that it fails:
- switch to this branch (on nightly), rebuild / up the autolab instance, and do the same thing as before, see that it now works:
![Screenshot 2023-10-24 at 6 14 39 PM](https://github.com/autolab/Autolab/assets/25730111/cd386487-a923-422a-b3d3-86425e56bef3)
- test locally that MOSS still works

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have run rubocop and erblint for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
