### PR TITLE
 Click into submissions from gradebook score

### DIFF
--- a/app/assets/javascripts/gradebook.js
+++ b/app/assets/javascripts/gradebook.js
@@ -69,8 +69,7 @@ var slickgrid_options = {
         break;
       }
     }
-
-    return (value !== null) ? link_to(data[history_key], value) : "&ndash;";
+    return (value !== null) ? ((data[history_key] !== undefined) ? link_to(data[history_key], value) : value) : "&ndash;";
   }
 };
 

--- a/app/assets/javascripts/gradebook.js
+++ b/app/assets/javascripts/gradebook.js
@@ -20,6 +20,7 @@ var slickgrid_options = {
     submission_status_key = columnDef.field + "_submission_status"
     grade_type_key = columnDef.field + "_grade_type"
     end_at_key = columnDef.field + "_end_at"
+    history_key = columnDef.field + "_history_url";
 
     switch (data[grade_type_key]) {
     case "excused":
@@ -69,7 +70,7 @@ var slickgrid_options = {
       }
     }
 
-    return (value !== null) ? value : "&ndash;";
+    return (value !== null) ? link_to(data[history_key], value) : "&ndash;";
   }
 };
 

--- a/app/helpers/gradebook_helper.rb
+++ b/app/helpers/gradebook_helper.rb
@@ -90,6 +90,7 @@ module GradebookHelper
         next unless matrix.has_assessment? a.id
 
         cell = matrix.cell(a.id, cud.id)
+        row["#{a.name}_history_url"] = history_url(cud, a)
         row[a.name] = round cell["final_score"]
         row["#{a.name}_submission_status"] = cell["submission_status"]
         row["#{a.name}_grade_type"] = cell["grade_type"]


### PR DESCRIPTION
Users can now click a gradebook score and immediately get redirected to the specific submission.

Currently on the gradebook, you have to click on the student email and then the score that shows up for a grade in order to get to the submissions for that assignment. This improves usability as you can directly click on a score in the grade book to go to the student's submission.


## How Has This Been Tested?
- Click on a gradebook score
- Check that you have been redirected to the right submission

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have run rubocop and erblint for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://docs.autolabproject.com/)
- [ ] I have updated the documentation accordingly, included in this PR

