### PR TITLE
Adds warning when assessment.rb file upload isn't a .rb file

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -436,6 +436,7 @@ PLATFORMS
   arm64-darwin-22
   x86_64-darwin-19
   x86_64-darwin-20
+  x86_64-darwin-21
   x86_64-linux
 
 DEPENDENCIES

--- a/app/assets/javascripts/edit_assessment.js
+++ b/app/assets/javascripts/edit_assessment.js
@@ -35,12 +35,10 @@
     $('#assessment_config_file').on('change', function () {
       var fileSelector = $("#assessment_config_file").get(0);
       var file = fileSelector.files[0];
-      const targetFile = $('#assessment_config_file').data('target-name');
 
-      if (file?.name !== targetFile) {
-        $('#config-file-type-incorrect').text(`Warning: ${file.name} doesn't match expected ${targetFile} file name`)
+      if (!file?.name?.endsWith('.rb')) {
+        $('#config-file-type-incorrect').text(`Warning: ${file.name} doesn't match expected .rb file type`)
       } else {
-        console.log('uhhh')
         $('#config-file-type-incorrect').text("")
       }
     })

--- a/app/assets/javascripts/edit_assessment.js
+++ b/app/assets/javascripts/edit_assessment.js
@@ -32,6 +32,19 @@
       changes = false;
     });
 
+    $('#assessment_config_file').on('change', function () {
+      var fileSelector = $("#assessment_config_file").get(0);
+      var file = fileSelector.files[0];
+      const targetFile = $('#assessment_config_file').data('target-name');
+
+      if (file?.name !== targetFile) {
+        $('#config-file-type-incorrect').text(`Warning: ${file.name} doesn't match expected ${targetFile} file name`)
+      } else {
+        console.log('uhhh')
+        $('#config-file-type-incorrect').text("")
+      }
+    })
+
     $('input[name="assessment[is_positive_grading]"]').on('change', function() {
       if(has_annotations){
         if ($(this).prop('checked') !=  is_positive_grading) {

--- a/app/views/assessments/_edit_basic.html.erb
+++ b/app/views/assessments/_edit_basic.html.erb
@@ -31,8 +31,7 @@
 
 <%= f.file_field :config_file, button_text: "Upload #{@assessment.name}.rb",
                                help_text: "Config file will be automatically reloaded after saving. Changes to other settings will
-                 be lost if an error is encountered.",
-                               data: { target_name: "#{@assessment.name}.rb" } %>
+                 be lost if an error is encountered." %>
 <b id="config-file-type-incorrect" style="color: red; margin: 0"></b>
 
 <h4>Modules Used</h4>

--- a/app/views/assessments/_edit_basic.html.erb
+++ b/app/views/assessments/_edit_basic.html.erb
@@ -31,7 +31,9 @@
 
 <%= f.file_field :config_file, button_text: "Upload #{@assessment.name}.rb",
                                help_text: "Config file will be automatically reloaded after saving. Changes to other settings will
-                 be lost if an error is encountered." %>
+                 be lost if an error is encountered.",
+                               data: { target_name: "#{@assessment.name}.rb" } %>
+<b id="config-file-type-incorrect" style="color: red; margin: 0"></b>
 
 <h4>Modules Used</h4>
 <ul class="collection attachments">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Summary
<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 04 Nov 23 02:48 UTC
This pull request includes two patches. 

The first patch, "preliminary working version," adds functionality to the code with changes to Gemfile.lock and edit_assessment.js files. It introduces a new platform, x86_64-darwin-21, to the Gemfile.lock file. In the edit_assessment.js file, it adds an event listener for the #assessment_config_file element, where it checks if the selected file matches the expected target file name. If not, it displays a warning message.

The second patch, "only validates .rb files," modifies the edit_assessment.js and _edit_basic.html.erb files. In the edit_assessment.js file, it updates the if condition in the event listener for #assessment_config_file element to check if the selected file does not end with ".rb". If it doesn't match, it displays a warning message. In the _edit_basic.html.erb file, it removes the data attribute that stored the target file name.

Overall, these patches make improvements and bug fixes to enhance the functionality and validation of the code for the assessment editing feature.
<!-- reviewpad:summarize:end -->

## Description
Resolves #1973 
![image](https://github.com/autolab/Autolab/assets/50491000/c37033dc-2d7b-4498-a804-7e8926919310)
If a file for assessment.rb is an invalid file type (i.e., not a `.rb` file), shows user a warning.

## Motivation and Context
Warn instructors from submitting an invalid / error prone file.

## How Has This Been Tested?
Go into an assessment --> Click "Edit Assessment" --> Click Upload <assessment name>.rb button
- [ ] Validate that an invalid file extension shows a warning
- [ ] Validate that a .rb file doesn't show a warning
- [ ] When submitted, valid .rb config file doesn't raise an error & updates assignment correctly once "reload config file" is clicked

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ x I have run rubocop and erblint for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://docs.autolabproject.com/)
- [ ] I have updated the documentation accordingly, included in this PR

## Other issues / help required
<!--- Do you have any other relevant issues / questions? --->
<!--- For example, if you require assistance for a certain part of your PR --->
<!--- or are facing specific issues while creating the pull request that you would like to highlight --->

If unsure, feel free to submit first and we'll help you along.
