### PR TITLE
Check that handout/writeup exists before checking path

### DIFF
--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -283,7 +283,7 @@ class Assessment < ApplicationRecord
 
   def writeup_is_file?
     # Ensure that writeup lies within the assessment folder
-    Archive.in_dir?(writeup_path, folder_path) && is_file?(writeup)
+    writeup.present? && Archive.in_dir?(writeup_path, folder_path) && is_file?(writeup)
   end
 
   def handout_is_url?
@@ -292,7 +292,7 @@ class Assessment < ApplicationRecord
 
   def handout_is_file?
     # Ensure that handout lies within the assessment folder
-    Archive.in_dir?(handout_path, folder_path) && is_file?(handout)
+    handout.present? && Archive.in_dir?(handout_path, folder_path) && is_file?(handout)
   end
 
   # raw_score
@@ -543,7 +543,7 @@ private
   end
 
   def is_file?(name)
-    name.present? && File.file?(path(name))
+    File.file?(path(name))
   end
 
   def verify_dates_order


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Summary
<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 03 Nov 23 19:59 UTC
This pull request moves the `present?` check to the front in the `writeup_is_file?` and `handout_is_file?` methods in the `assessment.rb` file.
<!-- reviewpad:summarize:end -->

## Description
<!--- Describe your changes in detail -->
Move `.present?` check before `Archive.in_dir?` check to avoid calling `path` on `nil` (if writeup or handout is nil)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
![Screenshot 2023-11-03 at 15 58 01](https://github.com/autolab/Autolab/assets/9074856/754119f0-67df-4197-82b0-6735c6f59f26)


## How Has This Been Tested?
Tests pass

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have run rubocop and erblint for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://docs.autolabproject.com/)
- [ ] I have updated the documentation accordingly, included in this PR
