### PR TITLE
Suppress confirmation dialog on edit assessment page when no changes made

### DIFF
--- a/app/assets/javascripts/edit_assessment.js
+++ b/app/assets/javascripts/edit_assessment.js
@@ -73,7 +73,7 @@
       $max_grace_days.prop('disabled', checked);
       if (checked) {
         $max_grace_days.val('Unlimited grace days');
-      } else  {
+      } else {
         $max_grace_days.val('');
       }
     }

--- a/app/assets/javascripts/edit_assessment.js
+++ b/app/assets/javascripts/edit_assessment.js
@@ -55,31 +55,31 @@
     });
 
     // Penalties tab
-    let initial_load = true; // determines if the page is loading for the first time, if so, don't clear the fields
-
-    $('#unlimited_submissions').on('change', function() {
+    function unlimited_submissions_callback() {
       const checked = $(this).prop('checked');
       const $max_submissions = $('#assessment_max_submissions');
       $max_submissions.prop('disabled', checked);
       if (checked) {
         $max_submissions.val('Unlimited submissions');
-      } else if (!initial_load) {
+      } else {
         $max_submissions.val('');
       }
-    });
+    }
+    $('#unlimited_submissions').on('change', unlimited_submissions_callback);
 
-    $('#unlimited_grace_days').on('change', function() {
+    function unlimited_grace_days_callback() {
       const checked = $(this).prop('checked');
       const $max_grace_days = $('#assessment_max_grace_days');
       $max_grace_days.prop('disabled', checked);
       if (checked) {
         $max_grace_days.val('Unlimited grace days');
-      } else if (!initial_load) {
+      } else  {
         $max_grace_days.val('');
       }
-    });
+    }
+    $('#unlimited_grace_days').on('change', unlimited_grace_days_callback);
 
-    $('#use_default_late_penalty').on('change', function() {
+    function use_default_late_penalty_callback() {
       const checked = $(this).prop('checked');
       const $latePenaltyValue = $('#assessment_late_penalty_attributes_value');
       const $latePenaltyField = $latePenaltyValue.parent();
@@ -87,23 +87,25 @@
       $latePenaltyField.find('select').prop('disabled', checked);
       if (checked) {
         $latePenaltyValue.val('Course default');
-      } else if (!initial_load) {
+      } else {
         $latePenaltyValue.val('');
       }
-    });
+    }
+    $('#use_default_late_penalty').on('change', use_default_late_penalty_callback);
 
-    $('#use_default_version_threshold').on('change', function() {
+    function use_default_version_threshold_callback() {
       const checked = $(this).prop('checked');
       const $version_threshold = $('#assessment_version_threshold');
       $version_threshold.prop('disabled', checked);
       if (checked) {
         $version_threshold.val('Course default');
-      } else if (!initial_load) {
+      } else {
         $version_threshold.val('');
       }
-    });
+    }
+    $('#use_default_version_threshold').on('change', use_default_version_threshold_callback);
 
-    $('#use_default_version_penalty').on('change', function() {
+    function use_default_version_penalty_callback() {
       const checked = $(this).prop('checked');
       const $versionPenaltyValue = $('#assessment_version_penalty_attributes_value');
       const $versionPenaltyField = $versionPenaltyValue.parent();
@@ -111,18 +113,18 @@
       $versionPenaltyField.find('select').prop('disabled', checked);
       if (checked) {
         $versionPenaltyValue.val('Course default');
-      } else if (!initial_load) {
+      } else {
         $versionPenaltyValue.val('');
       }
-    });
+    }
+    $('#use_default_version_penalty').on('change', use_default_version_penalty_callback);
 
     // Trigger on page load
-    $('#unlimited_submissions').trigger('change');
-    $('#unlimited_grace_days').trigger('change');
-    $('#use_default_late_penalty').trigger('change');
-    $('#use_default_version_threshold').trigger('change');
-    $('#use_default_version_penalty').trigger('change');
-    initial_load = false;
+    unlimited_submissions_callback.call($('#unlimited_submissions'));
+    unlimited_grace_days_callback.call($('#unlimited_grace_days'));
+    use_default_late_penalty_callback.call($('#use_default_late_penalty'));
+    use_default_version_threshold_callback.call($('#use_default_version_threshold'));
+    use_default_version_penalty_callback.call($('#use_default_version_penalty'));
   });
 
 })();

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -643,7 +643,7 @@ private
   def valid_handin_directory
     return true if handin_directory.blank? || Archive.in_dir?(handin_directory_path, folder_path)
 
-    errors.add :handin_directory, " must be a directory in the assessment folder"
+    errors.add :handin_directory, "must be a directory in the assessment folder"
     false
   end
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Summary
<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 07 Nov 23 02:58 UTC
This pull request includes three patches. 

The first patch (PATCH 1/3) extracts logic and calls functions directly in the `edit_assessment.js` file. It also introduces a new callback function for handling the `change` event on certain checkboxes. The patch modifies the code related to penalties in the assessment, including submission limits, grace days, late penalties, and version thresholds. Additionally, the patch adjusts the initial load behavior and trigger event handlers.

The second patch (PATCH 2/3) focuses on removing an extraneous space in the `assessment.rb` file. It modifies the `valid_handin_directory` method to correctly validate the handin directory path by removing the unnecessary space in the error message.

The third patch (PATCH 3/3) also removes an extraneous space in the `edit_assessment.js` file. It modifies the callback function for handling the `change` event on the "unlimited grace days" checkbox, ensuring that the appropriate value is set for the grace days input field.

Overall, these patches improve code readability and remove unnecessary spaces in the codebase.
<!-- reviewpad:summarize:end -->

## Description
Extract callback logic for edit penalties to separate functions, manually call them instead of triggering change.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
#1990 initializes the penalties fields on load by triggering the change event. However, this also triggers the confirmation dialog logic, so a dialog is shown when exiting the page, even when no changes were made.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Navigate to edit assessment > penalties.

- Ensure that fields fill correctly
- Ensure that toggling checkboxes works
- Ensure that dialog displays when making changes, and doesn't otherwise

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have run rubocop and erblint for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://docs.autolabproject.com/)
- [ ] I have updated the documentation accordingly, included in this PR

## Other issues / help required
<!--- Do you have any other relevant issues / questions? --->
<!--- For example, if you require assistance for a certain part of your PR --->
<!--- or are facing specific issues while creating the pull request that you would like to highlight --->

If unsure, feel free to submit first and we'll help you along.
