### PR TITLE
Don't clear assessment penalty fields on initial load

### DIFF
--- a/app/assets/javascripts/edit_assessment.js
+++ b/app/assets/javascripts/edit_assessment.js
@@ -55,13 +55,15 @@
     });
 
     // Penalties tab
+    let initial_load = true; // determines if the page is loading for the first time, if so, don't clear the fields
+
     function unlimited_submissions_callback() {
       const checked = $(this).prop('checked');
       const $max_submissions = $('#assessment_max_submissions');
       $max_submissions.prop('disabled', checked);
       if (checked) {
         $max_submissions.val('Unlimited submissions');
-      } else {
+      } else if (!initial_load) {
         $max_submissions.val('');
       }
     }
@@ -73,7 +75,7 @@
       $max_grace_days.prop('disabled', checked);
       if (checked) {
         $max_grace_days.val('Unlimited grace days');
-      } else {
+      } else if (!initial_load)  {
         $max_grace_days.val('');
       }
     }
@@ -87,7 +89,7 @@
       $latePenaltyField.find('select').prop('disabled', checked);
       if (checked) {
         $latePenaltyValue.val('Course default');
-      } else {
+      } else if (!initial_load)  {
         $latePenaltyValue.val('');
       }
     }
@@ -99,7 +101,7 @@
       $version_threshold.prop('disabled', checked);
       if (checked) {
         $version_threshold.val('Course default');
-      } else {
+      } else if (!initial_load)  {
         $version_threshold.val('');
       }
     }
@@ -113,7 +115,7 @@
       $versionPenaltyField.find('select').prop('disabled', checked);
       if (checked) {
         $versionPenaltyValue.val('Course default');
-      } else {
+      } else if (!initial_load)  {
         $versionPenaltyValue.val('');
       }
     }
@@ -125,6 +127,7 @@
     use_default_late_penalty_callback.call($('#use_default_late_penalty'));
     use_default_version_threshold_callback.call($('#use_default_version_threshold'));
     use_default_version_penalty_callback.call($('#use_default_version_penalty'));
+    initial_load = false;
   });
 
 })();

--- a/app/assets/javascripts/edit_assessment.js
+++ b/app/assets/javascripts/edit_assessment.js
@@ -75,7 +75,7 @@
       $max_grace_days.prop('disabled', checked);
       if (checked) {
         $max_grace_days.val('Unlimited grace days');
-      } else if (!initial_load)  {
+      } else if (!initial_load) {
         $max_grace_days.val('');
       }
     }
@@ -89,7 +89,7 @@
       $latePenaltyField.find('select').prop('disabled', checked);
       if (checked) {
         $latePenaltyValue.val('Course default');
-      } else if (!initial_load)  {
+      } else if (!initial_load) {
         $latePenaltyValue.val('');
       }
     }
@@ -101,7 +101,7 @@
       $version_threshold.prop('disabled', checked);
       if (checked) {
         $version_threshold.val('Course default');
-      } else if (!initial_load)  {
+      } else if (!initial_load) {
         $version_threshold.val('');
       }
     }
@@ -115,7 +115,7 @@
       $versionPenaltyField.find('select').prop('disabled', checked);
       if (checked) {
         $versionPenaltyValue.val('Course default');
-      } else if (!initial_load)  {
+      } else if (!initial_load) {
         $versionPenaltyValue.val('');
       }
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Summary
<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 13 Nov 23 01:46 UTC
This pull request includes two patches. 

The first patch fixes a bug where fields were being cleared on the initial load. The code now only clears the fields if it is not the initial load. 

The second patch removes extraneous spaces in the code. This improves code readability and eliminates unnecessary characters.
<!-- reviewpad:summarize:end -->

## Description
<!--- Describe your changes in detail -->
Use an initial_load flag to avoid clearing penalty fields on page load.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes a bug in #2004 where penalty fields are cleared on page load.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Fill in values for all 5 fields, ensure they display correctly after saving.

Successfully toggle each of the fields to clear them.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have run rubocop and erblint for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://docs.autolabproject.com/)
- [ ] I have updated the documentation accordingly, included in this PR
