### PR TITLE
Remove element overlapping scrollbar hitbox

### DIFF
--- a/app/assets/stylesheets/annotations.scss
+++ b/app/assets/stylesheets/annotations.scss
@@ -893,6 +893,14 @@
   font-weight: bold;
 }
 
+/* Disable Bootstrap styling to allow for scrolling within annotations and
+ * grades sidebars in file viewer
+ * (allows clicking on the scrollbar)
+ */
+.drag-target.right-aligned {
+  display: none;
+}
+
 /* Tooltip */
 span > .material-icons {
   vertical-align: middle;

--- a/app/assets/stylesheets/style.css.scss
+++ b/app/assets/stylesheets/style.css.scss
@@ -585,6 +585,14 @@ ul.gray-box.small > li + li {
   color: red;
 }
 
+/* Disable Bootstrap styling to allow for scrolling within annotations and
+ * grades sidebars in file viewer
+ * (allows clicking on the scrollbar)
+ */
+div.drag-target.right-aligned {
+  display: none;
+}
+
 /**
 * Displayed on the home page
 **/

--- a/app/assets/stylesheets/style.css.scss
+++ b/app/assets/stylesheets/style.css.scss
@@ -585,14 +585,6 @@ ul.gray-box.small > li + li {
   color: red;
 }
 
-/* Disable Bootstrap styling to allow for scrolling within annotations and
- * grades sidebars in file viewer
- * (allows clicking on the scrollbar)
- */
-div.drag-target.right-aligned {
-  display: none;
-}
-
 /**
 * Displayed on the home page
 **/


### PR DESCRIPTION
## Summary
<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 05 Dec 23 01:08 UTC
This pull request includes two patches. 

The first patch removes an element overlapping the scrollbar hitbox in the CSS file. This change allows for scrolling within annotations and grades sidebars in the file viewer by disabling Bootstrap styling.

The second patch moves the corresponding style to the annotations.scss file. It also disables Bootstrap styling for scrolling within annotations and grades sidebars in the file viewer.

Overall, these changes improve the user experience by allowing clicking on the scrollbar without any overlapping elements.
<!-- reviewpad:summarize:end -->

## Description
Changes display of element that was blocking the scrollbar as mentioned in issue #1946

## Motivation and Context
Issue #1946 

## How Has This Been Tested?
Have a submission in assessment with problems
Open the file viewer (View Source button)
Reduce the height of the window until a scrollbar appears in the Annotations or Grades subwindow
Try to scroll the Annotations or Grades by clicking on the scrollbar

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have run rubocop and erblint for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://docs.autolabproject.com/)
- [ ] I have updated the documentation accordingly, included in this PR

If unsure, feel free to submit first and we'll help you along.
