### PR TITLE
Update old migrations for Ruby 3

### DIFF
--- a/db/migrate/007_add_instructor_to_users.rb
+++ b/db/migrate/007_add_instructor_to_users.rb
@@ -1,6 +1,6 @@
 class AddInstructorToUsers < ActiveRecord::Migration[4.2]
   def self.up
-    add_column :users, :instructor, :boolean, {:default=>false}
+    add_column :users, :instructor, :boolean, **{:default=>false}
   end
 
   def self.down

--- a/db/migrate/20100723040512_add_gradebook_caching.rb
+++ b/db/migrate/20100723040512_add_gradebook_caching.rb
@@ -4,7 +4,7 @@ class AddGradebookCaching < ActiveRecord::Migration[4.2]
       t.string :key
       t.string :value
     end
-    add_index :gradebook_cache, :key, {:unique=>true}
+    add_index :gradebook_cache, :key, **{:unique=>true}
 
     create_table :gradebook_cache_averages, :id=>false do |t|
       t.string :field

--- a/db/migrate/20100807150918_remove_key_from_gradebook_cache.rb
+++ b/db/migrate/20100807150918_remove_key_from_gradebook_cache.rb
@@ -4,6 +4,6 @@ class RemoveKeyFromGradebookCache < ActiveRecord::Migration[4.2]
   end
 
   def self.down
-    add_index :gradebook_cache, :key, {:unique=>true}
+    add_index :gradebook_cache, :key, **{:unique=>true}
   end
 end

--- a/db/migrate/20100826234109_make_andrew_id_unique_key.rb
+++ b/db/migrate/20100826234109_make_andrew_id_unique_key.rb
@@ -1,6 +1,6 @@
 class MakeAndrewIdUniqueKey < ActiveRecord::Migration[4.2]
   def self.up
-    add_index :users, [:andrewID,:course_id], {:unique=>true,:name=>"users_andrewID_index"}
+    add_index :users, [:andrewID,:course_id], **{:unique=>true,:name=>"users_andrewID_index"}
   end
 
   def self.down

--- a/db/migrate/20101220043448_add_disabled_to_courses.rb
+++ b/db/migrate/20101220043448_add_disabled_to_courses.rb
@@ -1,6 +1,6 @@
 class AddDisabledToCourses < ActiveRecord::Migration[4.2]
   def self.up
-    add_column :courses, :disabled, :boolean, {:default=>false}
+    add_column :courses, :disabled, :boolean, **{:default=>false}
   end
 
   def self.down

--- a/db/migrate/20120204025713_add_tweak_type_to_submissions.rb
+++ b/db/migrate/20120204025713_add_tweak_type_to_submissions.rb
@@ -1,6 +1,6 @@
 class AddTweakTypeToSubmissions < ActiveRecord::Migration[4.2]
   def self.up
-  add_column :submissions, :absolute_tweak, :boolean, { :default => true, :null => false }
+  add_column :submissions, :absolute_tweak, :boolean, **{ :default => true, :null => false }
 
   Submission.where("tweak <= 1 and tweak >= -1").each do |s|
     s.absolute_tweak = false

--- a/db/migrate/20120204061221_add_tweak_type_to_users.rb
+++ b/db/migrate/20120204061221_add_tweak_type_to_users.rb
@@ -1,6 +1,6 @@
 class AddTweakTypeToUsers < ActiveRecord::Migration[4.2]
   def self.up
-  add_column :users, :absolute_tweak, :boolean, { :default => true, :null => false }
+  add_column :users, :absolute_tweak, :boolean, **{ :default => true, :null => false }
 
   User.where("tweak <= 1 and tweak >= -1").each do |u|
     u.absolute_tweak = false

--- a/db/migrate/20130121040729_remove_unused_gradebook_caching.rb
+++ b/db/migrate/20130121040729_remove_unused_gradebook_caching.rb
@@ -12,7 +12,7 @@ class RemoveUnusedGradebookCaching < ActiveRecord::Migration[4.2]
       t.integer "course_id"
     end
 
-    add_index :gradebook_cache, :key, {:unique=>true}
+    add_index :gradebook_cache, :key, **{:unique=>true}
 
     create_table "gradebook_cache_averages", :id => false do |t|
       t.string  "field"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Summary
reviewpad:summary

## Description
<!--- Describe your changes in detail -->
Updates syntax of old migrations to work with Ruby 3

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
With splat kwargs (e.g. those used by `add_column`), passing a hash no longer works. Instead, we should splat the hash or separate the arguments.

ref: https://makandracards.com/makandra/496481-changes-to-positional-and-keyword-args-in-ruby-3-0

Closes #2043

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Checkout this branch for your docker compose install
- Enter the `autolab` container (`docker exec -it autolab bash`)
- Successfully drop the database and run migrations again (`RAILS_ENV=production DISABLE_DATABASE_ENVIRONMENT_CHECK=1 rake db:drop db:create db:migrate`)

**BEFORE**
<img width="1383" alt="Screenshot 2024-01-05 at 15 22 25" src="https://github.com/autolab/Autolab/assets/9074856/35300964-0e3a-41fe-bfa4-5f1a94c006af">

**AFTER**
<img width="1383" alt="Screenshot 2024-01-05 at 15 33 31" src="https://github.com/autolab/Autolab/assets/9074856/6cdb1773-c0ba-485b-b6b1-b864192f54f9">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have run rubocop and erblint for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://docs.autolabproject.com/)
- [ ] I have updated the documentation accordingly, included in this PR