### PR TITLE
Load enable_starttls_auto as a boolean

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -175,7 +175,7 @@ protected
 
     when :admin_created
       @cud = cud
-      flash[:notice] = "Administrator user added to course"
+      flash.now[:notice] = "Administrator user added to course"
 
     when :admin_creation_error
       flash[:error] = "Error adding administrator #{current_user.email} to course"

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -126,7 +126,7 @@ class CoursesController < ApplicationController
         rescue StandardError => e
           # roll back course creation
           @newCourse.destroy
-          flash[:error] = "Can't create instructor for the course: #{e}"
+          flash.now[:error] = "Can't create instructor for the course: #{e}"
           render(action: "new") && return
         end
 
@@ -143,7 +143,7 @@ class CoursesController < ApplicationController
           # roll back course creation and instruction creation
           new_cud.destroy
           @newCourse.destroy
-          flash[:error] = "Can't load course config for #{@newCourse.name}."
+          flash.now[:error] = "Can't load course config for #{@newCourse.name}."
           render(action: "new") && return
         else
           flash[:success] = "New Course #{@newCourse.name} successfully created!"
@@ -152,12 +152,12 @@ class CoursesController < ApplicationController
       else
         # roll back course creation
         @newCourse.destroy
-        flash[:error] = "Can't create instructor for the course."
+        flash.now[:error] = "Can't create instructor for the course."
         render(action: "new") && return
       end
 
     else
-      flash[:error] = "Course creation failed. Check all fields"
+      flash.now[:error] = "Course creation failed. Check all fields"
       render(action: "new") && return
     end
   end

--- a/config/environments/production.rb.template
+++ b/config/environments/production.rb.template
@@ -88,7 +88,7 @@ Autolab3::Application.configure do
   config.action_mailer.smtp_settings = {
     address:              ENV.fetch('SMTP_SETTINGS_ADDRESS','smtp.example.com'),
     port:                 ENV.fetch('SMTP_SETTINGS_PORT',25),
-    enable_starttls_auto: ENV.fetch('SMTP_SETTINGS_ENABLE_STARTTLS_AUTO',true),
+    enable_starttls_auto: ENV.fetch('SMTP_SETTINGS_ENABLE_STARTTLS_AUTO','true') == 'true',
     authentication:       ENV.fetch('SMTP_SETTINGS_AUTHENTICATION','login'),
     user_name:            ENV.fetch('SMTP_SETTINGS_USER_NAME','example'),
     password:             ENV.fetch('SMTP_SETTINGS_PASSWORD','example'),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Summary
<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 13 Jan 24 03:34 UTC
This pull request consists of three patches:
1. Correctly load `enable_starttls_auto` in the `production.rb.template` file.
2. Change `flash` to `flash.now` when rendering directly in the `courses_controller.rb` file.
3. Change `flash` to `flash.now` when `admin_created` in the `application_controller.rb` file.
<!-- reviewpad:summarize:end -->

## Description
<!--- Describe your changes in detail -->
- Correctly set `enable_starttls_auto` to a boolean
- Change some `flash` to `flash.now` to prevent flashes from persisting longer than they're supposed to

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

`enable_starttls_auto` is read as a string from Docker's `.env` file, when the setting expects a boolean. This leads to an error when attempting to send mail.

In particular, creating a course with a new instructor (not already in the user list) calls `instructor_create`, which then calls `send_reset_password_instructions`.

Closes #2048

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Using the docker install, create a new course with an instructor email that doesn't exist yet.
Before, this would have led to an error. Now, the course is successfully created.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have run rubocop and erblint for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://docs.autolabproject.com/)
- [ ] I have updated the documentation accordingly, included in this PR
