### PR TITLE
Remove gradebooks directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,6 @@ config/environments/production.rb
 coverage/
 /courses/
 /courses
-/gradebooks/
 config/database.yml
 config/school.yml
 config/lti_config.yml

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -125,7 +125,6 @@ class Course < ApplicationRecord
 
     FileUtils.mkdir_p Rails.root.join("assessmentConfig")
     FileUtils.mkdir_p Rails.root.join("courseConfig")
-    FileUtils.mkdir_p Rails.root.join("gradebooks")
   end
 
   def order_of_dates


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Summary
<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 13 Jan 24 14:11 UTC
This pull request removes the "gradebooks" directory and updates the .gitignore file and the "course.rb" model accordingly.
<!-- reviewpad:summarize:end -->

## Description
<!--- Describe your changes in detail -->
- Don't create `gradebooks` directory when creating a new course
- Remove `gradebooks` directory from `gitignore`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Gradebooks directory is unused and can be removed accordingly.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Test that gradebooks still load and can be refreshed.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have run rubocop and erblint for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://docs.autolabproject.com/)
- [ ] I have updated the documentation accordingly, included in this PR