### PR TITLE
Correct Autolab spelling

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -84,7 +84,7 @@
           <% end %>
           <noscript>
               <div id="flash_error" class="error">
-                  AutoLab requires Javascript to be enabled for all features to correctly function. Please enable Javascript.
+                  Autolab requires Javascript to be enabled for all features to correctly function. Please enable Javascript.
               </div>
           </noscript>
         </div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Summary
reviewpad:summary

## Description
Corrected miscapitalized spelling of Autolab.

## Motivation and Context
Autolab should be spelled the same across the platform for professionalism and consistency.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Cosmetic change, no tests needed.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have run rubocop and erblint for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://docs.autolabproject.com/)
- [ ] I have updated the documentation accordingly, included in this PR

## Other issues / help required
<!--- Do you have any other relevant issues / questions? --->
<!--- For example, if you require assistance for a certain part of your PR --->
<!--- or are facing specific issues while creating the pull request that you would like to highlight --->

If unsure, feel free to submit first and we'll help you along.
