### PR TITLE
Autolab v2.12.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,28 +115,20 @@ Please feel free to use Autolab at your school/organization. If you run into any
 
 
 ## Changelog
+### [v2.12.0](https://github.com/autolab/Autolab/releases/tag/v2.12.0) (2024/01/20) Attachment categories and visual cues
+- Ruby upgraded to 3.2.2
+- Rails upgraded to 6.1.7.6
+- Instructors can now specify a category and release at date for attachments
+- Assessment start / end dates are now displayed on the course homepage
+
 ### [v2.11.0](https://github.com/autolab/Autolab/releases/tag/v2.11.0) (2023/05/21) LTI Settings UI, extensions metrics, and simultaneous extension creation
 - Introduced UI to manage LTI integration settings
 - Added extension metrics for instructors to monitor students by number of extensions granted
 - Instructors can now create extensions for multiple students at once
-- Numerous UI updates
-- Numerous bug fixes and improvements
 
 ### [v2.10.0](https://github.com/autolab/Autolab/releases/tag/v2.10.0) (2023/01/13) LTI Integration, Generalized Feedback, and Streaming Output
 - Autolab now supports roster syncing with courses on Canvas and other LTI (Learning Tools Interoperability) services. For full instructions on setup, see the documentation.
 - Streaming partial output and new feedback interface
 - Generalized annotations
-- Numerous UI updates
-- Numerous bug fixes and improvements
-
-### [v2.9.0](https://github.com/autolab/Autolab/releases/tag/v2.9.0) (2022/08/08) Metrics Excluded Categories and New Speedgrader Interface
-- Instructors can now exclude selected categories of assessments from metrics watchlist calculations
-- Introduced new speedgrader interface which utilizes the Golden Layout library, amongst other new features
-- Numerous bug fixes and improvements
-
-### [v2.8.0](https://github.com/autolab/Autolab/releases/tag/v2.8.0) (2021/12/20) GitHub Integration and Roster Upload Improvement
-- Students can now submit code via GitHub
-- Improved Roster Upload with better error reporting
-- Numerous bug fixes and improvements
 
 **For older releases, please check out the [releases page](https://github.com/autolab/Autolab/releases).**

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Please feel free to use Autolab at your school/organization. If you run into any
 - Ruby upgraded to 3.2.2
 - Rails upgraded to 6.1.7.6
 - Instructors can now specify a category and "release at" date for attachments
-- Assessment start / end dates are now displayed on the course homepage
+- Assessment start / end dates are now shown on course homepages
 
 ### [v2.11.0](https://github.com/autolab/Autolab/releases/tag/v2.11.0) (2023/05/21) LTI Settings UI, extensions metrics, and simultaneous extension creation
 - Introduced UI to manage LTI integration settings

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Please feel free to use Autolab at your school/organization. If you run into any
 ### [v2.12.0](https://github.com/autolab/Autolab/releases/tag/v2.12.0) (2024/01/20) Attachment categories and visual cues
 - Ruby upgraded to 3.2.2
 - Rails upgraded to 6.1.7.6
-- Instructors can now specify a category and release at date for attachments
+- Instructors can now specify a category and "release at" date for attachments
 - Assessment start / end dates are now displayed on the course homepage
 
 ### [v2.11.0](https://github.com/autolab/Autolab/releases/tag/v2.11.0) (2023/05/21) LTI Settings UI, extensions metrics, and simultaneous extension creation

--- a/config/application.rb
+++ b/config/application.rb
@@ -112,7 +112,7 @@ module Autolab3
     config.middleware.use Rack::Attack
 
     # site version
-    config.site_version = "2.11.1"
+    config.site_version = "2.12.0"
 
     # Set application host for mailer
     config.action_mailer.default_url_options = { host: ENV['MAILER_HOST'] || "YOUR_APP_HOST" }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Summary
<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 21 Jan 24 03:59 UTC
This pull request includes three patches. 

Patch 1/3 bumps the version and updates the README file. It includes changes such as upgrading Ruby to 3.2.2, upgrading Rails to 6.1.7.6, allowing instructors to specify a category and release date for attachments, and displaying assessment start and end dates on the course homepage.

Patch 2/3 updates the wording in the README file.

Patch 3/3 tweaks the wording in the README file to match the release notes.
<!-- reviewpad:summarize:end -->

## Description
<!--- Describe your changes in detail -->
- Bump site version to v2.12.0
- Update README

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Bump version for Autolab release.

To merge after v2.12.0 released.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Verify that site footer now displays `v2.12.0`.

Check README of branch at https://github.com/autolab/Autolab/tree/v2.12.0

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have run rubocop and erblint for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://docs.autolabproject.com/)
- [ ] I have updated the documentation accordingly, included in this PR
