### PR TITLE
Remove redundant conditional to migrate config file, Allow empty config file to be loaded

### DIFF
--- a/app/controllers/assessment/handout.rb
+++ b/app/controllers/assessment/handout.rb
@@ -14,7 +14,21 @@ module AssessmentHandout
 
   def handout
     # If the logic here changes, do update assessment#has_handout?
-    extend_config_module(@assessment, nil, @cud)
+    begin
+      extend_config_module(@assessment, nil, @cud)
+    rescue StandardError => e
+      if @cud.has_auth_level? :instructor
+        flash[:error] = "Error loading the config file: "
+        flash[:error] += e.message
+        flash[:error] += "<br/> Try reloading the course config file," \
+          " or re-upload the course config file in order to recover your assessment."
+        flash[:html_safe] = true
+      else
+        flash[:error] = "Error loading #{@assessment.display_name}. Please contact your instructor."
+      end
+      return
+    end
+
 
     if @assessment.overwrites_method?(:handout)
       hash = @assessment.config_module.handout

--- a/app/controllers/assessments_controller.rb
+++ b/app/controllers/assessments_controller.rb
@@ -514,7 +514,7 @@ class AssessmentsController < ApplicationController
     set_handin
     begin
       extend_config_module(@assessment, @submission, @cud)
-    rescue AutogradeError => e
+    rescue StandardError => e
       if @cud.has_auth_level? :instructor
         flash[:error] = "Error loading the config file: "
         flash[:error] += e.message


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Summary
<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 22 Jan 24 18:37 UTC
This pull request includes two patches. The first patch removes a redundant conditional and fixes an issue with an empty config source file in the `assessments_controller.rb` file. The second patch adds error handling to the `handout#handout` method in the `assessment/handout.rb` file.
<!-- reviewpad:summarize:end -->

## Description
<!--- Describe your changes in detail -->

- Remove a conditional which was originally meant to migrate over old config modules over to the new naming system, due to differences in allowed assessment names / sanitization methods. However, in practice this check is not necessary.
- Add code to check if the regex match for a `module something` returned nil in the case that the provided configuration file did not have a module. If so, build a default config file and load that instead, while maintaining the source config file and backing up previous config file, as per previous behavior
 - Change Rescue to catch `StandardError` instead of just `AutogradeError` so that errors such as a malformed config file get caught as well
 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

- #1987 introduced changes to config modules which introduced breaking behavior on autolab production. Previously, empty configuration files were acceptable and able to be used in assessments, but with the new changes, such a file causes an error upon loading the assessment.

Closes #2051
Closes #2052

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- (not necessary to recreate) Rebuilt autolab docker using commit 3676b13 (commit before #1987)
- Created Autopopulated course / assessments using autopopulator, to have courses created pre-1987
- switched to 1987 commit and checked that migration of assessments still worked

Necessary testing:
- imported an assessment with a config file different from default, with a module
  - verified that this file was loaded into `assessmentConfig` folder properly
- imported an assessment without a config file, verified it loaded
- imported an assessment with a config file but with nothing inside, verified that default config was loaded into `assessmentConfig`
- for an existing assessment, first changed source config file to include something other than default, verified that change was loaded properly
  - changed source config file to not have a module inside it, verified that default config file was loaded into `assessmentConfig`
 - directly modified config file in `assessmentConfig` to not have a module, saw that error is now caught
 
![Screenshot 2024-01-21 at 9 05 04 PM](https://github.com/autolab/Autolab/assets/25730111/588d2542-9125-492d-ae56-8a2d492d6279)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have run rubocop and erblint for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting

