### PR TITLE
Interface elements to support Github personal access tokens

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -5,8 +5,9 @@ class UsersController < ApplicationController
   skip_before_action :update_persistent_announcements
   before_action :set_gh_oauth_client, only: [:github_oauth, :github_oauth_callback]
   before_action :set_user,
-                only: [:github_oauth, :github_revoke, :lti_launch_initialize,
-                       :lti_launch_link_course]
+                only: [:github_oauth, :github_revoke,
+                       :show_github_token_form, :submit_github_token_form,
+                        :lti_launch_initialize, :lti_launch_link_course]
 
   # GET /users
   action_auth_level :index, :student
@@ -248,6 +249,27 @@ class UsersController < ApplicationController
     course = Course.find(params[:course_id])
     flash[:success] = "#{course.name} successfully linked."
     redirect_to(course)
+  end
+
+  action_auth_level :github_token, :student
+  def show_github_token_form
+    @github_integration = GithubIntegration.find_by(user_id: @user.id)
+    render('github_token')
+  end
+
+  action_auth_level :github_token_form, :student
+  def submit_github_token_form
+    github_integration = GithubIntegration.find_by(user_id: @user.id)
+    access_token = params[:access_token]
+
+    if github_integration.nil?
+      github_integration = GithubIntegration.create!(access_token:, user: @user)
+    else
+      github_integration.update!(access_token:)
+    end
+
+    flash[:success] = "Updated Github Token"
+    redirect_to(user_path)
   end
 
   action_auth_level :github_oauth, :student

--- a/app/views/users/github_token.erb
+++ b/app/views/users/github_token.erb
@@ -1,0 +1,13 @@
+<% @title = "Github Access Token" %>
+
+<h2>Github Update Access Token</h2>
+<% if GithubIntegration.connected %>
+  <%= form_with url: github_token_user_path do |form| %>
+    <div class="input-field">
+      <%= form.text_field :access_token, required: true %>
+      <%= form.label :access_token, "Access Token" %>
+      <span class="helper-text">Helpful description here</span>
+    </div>
+    <%= form.submit "Update Token", { class: "btn primary" } %>
+  <% end %>
+<% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -62,6 +62,7 @@
     </span>
   <% end %>
   <% if GithubIntegration.connected %>
+    <h4>Github Settings</h4>
     <% if @user.github_integration && @user.github_integration.is_connected %>
       <%= link_to github_revoke_user_path(@user), data: { method: "post" } do %>
         <span class="btn primary">
@@ -74,6 +75,12 @@
           Connect to Github
         </span>
       <% end %>
+    <% end %>
+
+    <%= link_to github_token_user_path(@user) do %>
+      <span class="btn primary">
+        Use Personal access Token
+      </span>
     <% end %>
   <% end %>
   <h4>API Settings</h4>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -79,6 +79,8 @@ Rails.application.routes.draw do
     get "lti_launch_initialize", on: :member
     post "lti_launch_link_course", on: :member
     post "github_revoke", on: :member
+    get "github_token", on: :member, to: 'users#show_github_token_form'
+    post 'github_token', on: :member, to: 'users#submit_github_token_form'
     get "github_oauth_callback", on: :collection
     match "update_password_for_user", on: :member, via: [:get, :put]
     post "change_password_for_user", on: :member


### PR DESCRIPTION
Added interface button in Account page next to the "Connect to Github" button - "Use Personal Access Token".  Clicking takes to a single field form to manually (copy-paste) token. This uses the same tables as the existing github_integration and applies the same encryption through ActiveRecord.  

Note: you can set the token *without* progressing through the Oauth flow so this avoids having to approve the permissions per Issue #2059 .

There are no tests so understand if you dont Accept the PR, but it should be proof of concept enough to allow others to easily implement the feature fully.

## Summary
reviewpad:summary

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
No, see above.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] I have run rubocop and erblint for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://docs.autolabproject.com/)
- [ ] I have updated the documentation accordingly, included in this PR

## Other issues / help required
<!--- Do you have any other relevant issues / questions? --->
<!--- For example, if you require assistance for a certain part of your PR --->
<!--- or are facing specific issues while creating the pull request that you would like to highlight --->

If unsure, feel free to submit first and we'll help you along.
