### PR TITLE
Remove custom pluralize method in application_controller.rb

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -345,11 +345,6 @@ protected
   end
   ### END HELPERS
 
-  def pluralize(count, singular, plural = nil)
-    "#{count || 0} " +
-      (count == 1 || count =~ /^1(\.0+)?$/ ? singular : (plural || singular.pluralize))
-  end
-
   # make_dlist - Creates a string of emails that can be added as b/cc field.
   # @param section The section to email.  nil if we should email the entire
   # class.

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -310,11 +310,6 @@ protected
                     end
   end
 
-  def pluralize(count, singular, plural = nil)
-    "#{count || 0} " +
-      (count == 1 || count =~ /^1(\.0+)?$/ ? singular : (plural || singular.pluralize))
-  end
-
   # make_dlist - Creates a string of emails that can be added as b/cc field.
   # @param section The section to email.  nil if we should email the entire
   # class.

--- a/app/controllers/assessment/autograde.rb
+++ b/app/controllers/assessment/autograde.rb
@@ -104,7 +104,7 @@ module AssessmentAutograde
 
     failure_jobs = failed_list.length
     if failure_jobs > 0
-      flash[:error] = "Warning: Could not regrade #{pluralize(failure_jobs, "submission")}:<br>"
+      flash[:error] = "Warning: Could not regrade #{ActionController::Base.helpers.pluralize(failure_jobs, "submission")}:<br>"
       failed_list.each do |failure|
         if failure[:error].error_code == :nil_submission
           flash[:error] += "Unrecognized submission ID<br>"
@@ -116,7 +116,7 @@ module AssessmentAutograde
 
     success_jobs = submission_ids.size - failure_jobs
     if success_jobs > 0
-      link = "<a href=\"#{url_for(controller: 'jobs')}\">#{pluralize(success_jobs, "submission")}</a>"
+      link = "<a href=\"#{url_for(controller: 'jobs')}\">#{ActionController::Base.helpers.pluralize(success_jobs, "submission")}</a>"
       flash[:success] = ("Regrading #{link}")
     end
 
@@ -151,7 +151,7 @@ module AssessmentAutograde
 
     failure_jobs = failed_list.length
     if failure_jobs > 0
-      flash[:error] = "Warning: Could not regrade #{pluralize(failure_jobs, "submission")}:<br>"
+      flash[:error] = "Warning: Could not regrade #{ActionController::Base.helpers.pluralize(failure_jobs, "submission")}:<br>"
       failed_list.each do |failure|
         if failure[:error].error_code == :nil_submission
           flash[:error] += "Unrecognized submission ID<br>"
@@ -163,7 +163,7 @@ module AssessmentAutograde
 
     success_jobs = last_submissions.size - failure_jobs
     if success_jobs > 0
-      link = "<a href=\"#{url_for(controller: 'jobs')}\">#{pluralize(success_jobs, "student")}</a>"
+      link = "<a href=\"#{url_for(controller: 'jobs')}\">#{ActionController::Base.helpers.pluralize(success_jobs, "student")}</a>"
       flash[:success] = ("Regrading the most recent submissions from #{link}")
     end
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

- Remove custom pluralize method as there already exists a [method provided by rails](https://apidock.com/rails/ActionView/Helpers/TextHelper/pluralize) which is being used by views code. 
- The pluralize code doesn't even work with controllers (where it was being used, such as in `autograde.rb`),as it only handles strings but was being fed integers which caused error such as this when trying to run `regradeAll`

![Screenshot 2024-02-10 at 2 42 03 PM](https://github.com/autolab/Autolab/assets/25730111/79d39d10-5012-44f1-8bef-42ed75cf79b7)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- the pluralize code was throwing an error unrelated to regradeAll which was not caught

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Run `regradeAll`, see that it runs successfully and pluralizes students
![Screenshot 2024-02-10 at 2 47 52 PM](https://github.com/autolab/Autolab/assets/25730111/4aa7cb17-3cf3-4df9-a5c9-b3144fb1f4f9)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Other issues / help required
<!--- Do you have any other relevant issues / questions? --->
<!--- For example, if you require assistance for a certain part of your PR --->
<!--- or are facing specific issues while creating the pull request that you would like to highlight --->

If unsure, feel free to submit first and we'll help you along.
