### PR TITLE
Allow instructors to also be CAs

### DIFF
--- a/app/assets/javascripts/course_user_data_edit.js
+++ b/app/assets/javascripts/course_user_data_edit.js
@@ -16,30 +16,27 @@ function formvalidation(form){
   }
 }
 
-// User can be at most one of the following: instructor, course assistant, or dropped (student)
 const $instructor_checkbox = $('#course_user_datum_instructor');
 const $course_assistant_checkbox = $('#course_user_datum_course_assistant');
 const $dropped_checkbox = $('#course_user_datum_dropped');
-const mutually_exclusive_fields = [
-  $instructor_checkbox, $course_assistant_checkbox, $dropped_checkbox
-];
+const $fields = [$instructor_checkbox, $course_assistant_checkbox, $dropped_checkbox];
 
-function mutual_exclusion() {
-  const fields = mutually_exclusive_fields; // For brevity
-  // Enable all fields
-  fields.forEach((field) => field.prop('disabled', false));
+function disable_fields(cur_field, excluded_fields) {
+  const checked = cur_field.is(':checked');
+  if (checked) {
+    excluded_fields.forEach((field) => {
+      field.prop('disabled', true);
+      field.prop('checked', false);
+    });
+  }
+}
 
-  // If any field is checked, disable the rest
-  fields.forEach((field, idx) => {
-    if (field.is(':checked')) {
-      fields.forEach((field2, idx2) => {
-        if (idx !== idx2) {
-          field2.prop('disabled', true);
-          field2.prop('checked', false);
-        }
-      });
-    }
-  });
+// User can't be dropped if they are an instructor or course assistant
+function instructor_or_ca_not_dropped() {
+  $fields.forEach((field) => field.prop('disabled', false));
+  disable_fields($instructor_checkbox, [$dropped_checkbox]);
+  disable_fields($course_assistant_checkbox, [$dropped_checkbox]);
+  disable_fields($dropped_checkbox, [$instructor_checkbox, $course_assistant_checkbox]);
 }
 
 $(document).ready(function(){
@@ -48,6 +45,6 @@ $(document).ready(function(){
     e.preventDefault();
   });
 
-  mutual_exclusion();
-  mutually_exclusive_fields.forEach((field) => field.on("click", mutual_exclusion));
+  instructor_or_ca_not_dropped();
+  $fields.forEach((field) => field.on("click", instructor_or_ca_not_dropped));
 });

--- a/app/models/course_user_datum.rb
+++ b/app/models/course_user_datum.rb
@@ -31,7 +31,7 @@ class CourseUserDatum < ApplicationRecord
   accepts_nested_attributes_for :tweak, allow_destroy: true
   accepts_nested_attributes_for :user, allow_destroy: false
   validate :valid_nickname?
-  validate :instructor_or_ca_or_dropped
+  validate :instructor_or_ca_not_dropped
   after_create :create_AUDs_modulo_callbacks
 
   def self.conditions_by_like(value, *columns)
@@ -75,13 +75,11 @@ class CourseUserDatum < ApplicationRecord
     errors.add("nickname", "can only contain ASCII characters")
   end
 
-  # User can be at most one of the following: instructor, course assistant, or dropped (student)
-  def instructor_or_ca_or_dropped
-    status_count = [instructor?, course_assistant?, dropped?].count(true)
+  # User can't be dropped if they are an instructor or course assistant
+  def instructor_or_ca_not_dropped
+    return unless dropped? && (instructor? || course_assistant?)
 
-    return if status_count <= 1
-
-    errors.add(:base, "User can be at most one of instructor, course assistant, or dropped")
+    errors.add(:base, "User can't be dropped if they are an instructor or course assistant")
   end
 
   ##


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Re-allow instructors to be CAs.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
#2065 prevented instructors from also being CAs. However, this caused problems in parts of the code that set users to be both. Furthermore, it might be desirable to allow instructors to also be CAs since only CAs have sections.

This PR re-allows instructors to be CAs, but improves upon #1420 by disabling the instructor & ca fields when the dropped checkbox is clicked.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Edit a user, and check that dropped checkbox disables instructor / ca checkboxes and vice versa.

**dropped selected**
![Screenshot 2024-02-11 at 15 01 17](https://github.com/autolab/Autolab/assets/9074856/ee1e5593-a969-49d3-9f08-caa483af7ab1)

**instructor / ca selected**
![Screenshot 2024-02-11 at 15 01 28](https://github.com/autolab/Autolab/assets/9074856/fa2841e9-4b01-42cc-9ae0-cf9c4a07790a)

**none selected**
![Screenshot 2024-02-11 at 15 01 36](https://github.com/autolab/Autolab/assets/9074856/e1b90dad-3d48-4f39-9695-64b6da5d3190)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have run rubocop and erblint for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://docs.autolabproject.com/)
- [ ] I have updated the documentation accordingly, included in this PR