### PR TITLE
Export files inside nested directories

### DIFF
--- a/app/controllers/assessments_controller.rb
+++ b/app/controllers/assessments_controller.rb
@@ -465,7 +465,6 @@ class AssessmentsController < ApplicationController
       @assessment.dump_embedded_quiz
       # Pack assessment directory into a tarball.
       tarStream = StringIO.new("")
-      tar = Gem::Package::TarWriter.new(tarStream)
       Gem::Package::TarWriter.new(tarStream) do |tar|
         tar.mkdir asmt_dir, File.stat(File.join(dir_path, asmt_dir)).mode
         filter = [File.join(dir_path, asmt_dir, @assessment.handin_directory)]

--- a/app/controllers/assessments_controller.rb
+++ b/app/controllers/assessments_controller.rb
@@ -468,7 +468,8 @@ class AssessmentsController < ApplicationController
       tar = Gem::Package::TarWriter.new(tarStream)
       Gem::Package::TarWriter.new(tarStream) do |tar|
         tar.mkdir asmt_dir, File.stat(File.join(dir_path, asmt_dir)).mode
-        @assessment.load_dir_to_tar(dir_path, asmt_dir, tar, ["handin"])
+        filter = [File.join(dir_path, asmt_dir, @assessment.handin_directory)]
+        @assessment.load_dir_to_tar(dir_path, asmt_dir, tar, filter)
       end
       tarStream.rewind
       tarStream.close

--- a/app/controllers/assessments_controller.rb
+++ b/app/controllers/assessments_controller.rb
@@ -467,7 +467,7 @@ class AssessmentsController < ApplicationController
       tarStream = StringIO.new("")
       Gem::Package::TarWriter.new(tarStream) do |tar|
         tar.mkdir asmt_dir, File.stat(File.join(dir_path, asmt_dir)).mode
-        filter = [File.join(dir_path, asmt_dir, @assessment.handin_directory)]
+        filter = [@assessment.handin_directory_path]
         @assessment.load_dir_to_tar(dir_path, asmt_dir, tar, filter)
       end
       tarStream.rewind

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -427,19 +427,25 @@ class Assessment < ApplicationRecord
     date.strftime("%b %e at %l:%M%P")
   end
 
-  def load_dir_to_tar(dir_path, asmt_dir, tar, filters=[])
+  def load_dir_to_tar(dir_path, asmt_dir, tar, filters = [], export_dir = "")
     Dir[File.join(dir_path, asmt_dir, "**")].each do |file|
       mode = File.stat(file).mode
       relative_path = file.sub(%r{^#{Regexp.escape dir_path}/?}, "")
+      export_path = if export_dir == ""
+                      relative_path
+                    else
+                      File.join(export_dir, relative_path)
+                    end
 
       if File.directory?(file)
-        if filters.all? {|filter| !Archive.in_dir?(Pathname.new(filter), Pathname.new(file), strict: false)}
-          tar.mkdir relative_path, mode
-          load_dir_to_tar(dir_path, relative_path, tar)
+        if filters.all? { |filter|
+          !Archive.in_dir?(Pathname.new(filter), Pathname.new(file), strict: false)
+        }
+          tar.mkdir export_path, mode
+          load_dir_to_tar(dir_path, relative_path, tar, filters, export_dir)
         end
-      elsif !relative_path.starts_with? File.join(:name.to_s,
-                                                  :handin_directory.to_s)
-        tar.add_file relative_path, mode do |tarFile|
+      else
+        tar.add_file export_path, mode do |tarFile|
           File.open(file, "rb") { |f| tarFile.write f.read }
         end
       end

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -427,14 +427,14 @@ class Assessment < ApplicationRecord
     date.strftime("%b %e at %l:%M%P")
   end
 
-  def load_dir_to_tar(dir_path, asmt_dir, tar, filter=[])
+  def load_dir_to_tar(dir_path, asmt_dir, tar, filters=[])
     Dir[File.join(dir_path, asmt_dir, "**")].each do |file|
       mode = File.stat(file).mode
       relative_path = file.sub(%r{^#{Regexp.escape dir_path}/?}, "")
 
       if File.directory?(file)
-        tar.mkdir relative_path, mode
-        unless filter.include?(File.basename(file))
+        if filters.all? {|filter| !Archive.in_dir?(Pathname.new(filter), Pathname.new(file), strict: false)}
+          tar.mkdir relative_path, mode
           load_dir_to_tar(dir_path, relative_path, tar)
         end
       elsif !relative_path.starts_with? File.join(:name.to_s,

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -340,19 +340,8 @@ class Course < ApplicationRecord
           assessments.each do |assessment|
             asmt_dir = assessment.name
             assessment.dump_yaml
-            Dir[File.join(base_path, asmt_dir, "**")].each do |file|
-              mode = File.stat(file).mode
-              relative_path = File.join(course_dir, file.sub(%r{^#{Regexp.escape base_path}/?}, ""))
-
-              if File.directory?(file)
-                tar.mkdir relative_path, mode
-              elsif !relative_path.starts_with? File.join(asmt_dir,
-                                                          assessment.handin_directory)
-                tar.add_file relative_path, mode do |tar_file|
-                  File.open(file, "rb") { |f| tar_file.write f.read }
-                end
-              end
-            end
+            filter = [File.join(base_path, asmt_dir, assessment.handin_directory)]
+            assessment.load_dir_to_tar(base_path, asmt_dir, tar, filter, course_dir)
           end
         end
       end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -340,7 +340,7 @@ class Course < ApplicationRecord
           assessments.each do |assessment|
             asmt_dir = assessment.name
             assessment.dump_yaml
-            filter = [File.join(base_path, asmt_dir, assessment.handin_directory)]
+            filter = [assessment.handin_directory_path]
             assessment.load_dir_to_tar(base_path, asmt_dir, tar, filter, course_dir)
           end
         end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -212,8 +212,8 @@ ActiveRecord::Schema.define(version: 2024_01_27_172855) do
     t.string "context_id"
     t.integer "course_id"
     t.datetime "last_synced"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.string "membership_url"
     t.string "platform"
     t.boolean "auto_sync", default: false
@@ -312,7 +312,7 @@ ActiveRecord::Schema.define(version: 2024_01_27_172855) do
     t.integer "course_id"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.datetime "until"
+    t.datetime "until", default: -> { "CURRENT_TIMESTAMP" }
     t.boolean "disabled", default: false
   end
 
@@ -417,4 +417,5 @@ ActiveRecord::Schema.define(version: 2024_01_27_172855) do
     t.index ["course_user_datum_id"], name: "index_watchlist_instances_on_course_user_datum_id"
     t.index ["risk_condition_id"], name: "index_watchlist_instances_on_risk_condition_id"
   end
+
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -15,8 +15,8 @@ ActiveRecord::Schema.define(version: 2024_01_27_172855) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
-    t.bigint "record_id", null: false
-    t.bigint "blob_id", null: false
+    t.integer "record_id", null: false
+    t.integer "blob_id", null: false
     t.datetime "created_at", null: false
     t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
     t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
@@ -27,7 +27,7 @@ ActiveRecord::Schema.define(version: 2024_01_27_172855) do
     t.string "filename", null: false
     t.string "content_type"
     t.text "metadata"
-    t.bigint "byte_size", null: false
+    t.integer "byte_size", null: false
     t.string "checksum", null: false
     t.datetime "created_at", null: false
     t.string "service_name", null: false
@@ -35,7 +35,7 @@ ActiveRecord::Schema.define(version: 2024_01_27_172855) do
   end
 
   create_table "active_storage_variant_records", force: :cascade do |t|
-    t.bigint "blob_id", null: false
+    t.integer "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end
@@ -76,7 +76,7 @@ ActiveRecord::Schema.define(version: 2024_01_27_172855) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer "grade_type", default: 0, null: false
-    t.string "repository"
+    t.string "repository", limit: 255
     t.integer "group_id"
     t.integer "membership_status", limit: 1, default: 0
     t.integer "version_number"
@@ -117,8 +117,8 @@ ActiveRecord::Schema.define(version: 2024_01_27_172855) do
     t.integer "group_size", default: 1
     t.text "embedded_quiz_form_data"
     t.boolean "embedded_quiz"
-    t.boolean "allow_student_assign_group", default: true
     t.boolean "github_submission_enabled", default: true
+    t.boolean "allow_student_assign_group", default: true
     t.boolean "is_positive_grading", default: false
   end
 
@@ -131,7 +131,7 @@ ActiveRecord::Schema.define(version: 2024_01_27_172855) do
     t.integer "course_id"
     t.integer "assessment_id"
     t.string "category_name", default: "General"
-    t.datetime "release_at", default: -> { "CURRENT_TIMESTAMP" }
+    t.datetime "release_at"
     t.index ["assessment_id"], name: "index_attachments_on_assessment_id"
   end
 
@@ -212,8 +212,8 @@ ActiveRecord::Schema.define(version: 2024_01_27_172855) do
     t.string "context_id"
     t.integer "course_id"
     t.datetime "last_synced"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.string "membership_url"
     t.string "platform"
     t.boolean "auto_sync", default: false
@@ -312,7 +312,7 @@ ActiveRecord::Schema.define(version: 2024_01_27_172855) do
     t.integer "course_id"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.datetime "until", default: -> { "CURRENT_TIMESTAMP" }
+    t.datetime "until"
     t.boolean "disabled", default: false
   end
 
@@ -324,14 +324,14 @@ ActiveRecord::Schema.define(version: 2024_01_27_172855) do
 
   create_table "scoreboards", force: :cascade do |t|
     t.integer "assessment_id"
-    t.text "banner"
-    t.text "colspec"
+    t.text "banner", limit: 65535
+    t.text "colspec", limit: 65535
   end
 
   create_table "scores", force: :cascade do |t|
     t.integer "submission_id"
     t.float "score"
-    t.text "feedback", size: :medium
+    t.text "feedback", limit: 16777215
     t.integer "problem_id"
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -357,7 +357,7 @@ ActiveRecord::Schema.define(version: 2024_01_27_172855) do
     t.string "submitter_ip", limit: 40
     t.integer "tweak_id"
     t.boolean "ignored", default: false, null: false
-    t.string "dave"
+    t.string "dave", limit: 255
     t.text "embedded_quiz_form_answer"
     t.integer "submitted_by_app_id"
     t.string "group_key", default: ""
@@ -418,4 +418,10 @@ ActiveRecord::Schema.define(version: 2024_01_27_172855) do
     t.index ["risk_condition_id"], name: "index_watchlist_instances_on_risk_condition_id"
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "github_integrations", "users"
+  add_foreign_key "oauth_access_grants", "oauth_applications", column: "application_id"
+  add_foreign_key "oauth_access_tokens", "oauth_applications", column: "application_id"
+  add_foreign_key "oauth_device_flow_requests", "oauth_applications", column: "application_id"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -15,8 +15,8 @@ ActiveRecord::Schema.define(version: 2024_01_27_172855) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
-    t.integer "record_id", null: false
-    t.integer "blob_id", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
     t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
     t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
@@ -27,7 +27,7 @@ ActiveRecord::Schema.define(version: 2024_01_27_172855) do
     t.string "filename", null: false
     t.string "content_type"
     t.text "metadata"
-    t.integer "byte_size", null: false
+    t.bigint "byte_size", null: false
     t.string "checksum", null: false
     t.datetime "created_at", null: false
     t.string "service_name", null: false
@@ -35,7 +35,7 @@ ActiveRecord::Schema.define(version: 2024_01_27_172855) do
   end
 
   create_table "active_storage_variant_records", force: :cascade do |t|
-    t.integer "blob_id", null: false
+    t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end
@@ -76,7 +76,7 @@ ActiveRecord::Schema.define(version: 2024_01_27_172855) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer "grade_type", default: 0, null: false
-    t.string "repository", limit: 255
+    t.string "repository"
     t.integer "group_id"
     t.integer "membership_status", limit: 1, default: 0
     t.integer "version_number"
@@ -117,8 +117,8 @@ ActiveRecord::Schema.define(version: 2024_01_27_172855) do
     t.integer "group_size", default: 1
     t.text "embedded_quiz_form_data"
     t.boolean "embedded_quiz"
-    t.boolean "github_submission_enabled", default: true
     t.boolean "allow_student_assign_group", default: true
+    t.boolean "github_submission_enabled", default: true
     t.boolean "is_positive_grading", default: false
   end
 
@@ -131,7 +131,7 @@ ActiveRecord::Schema.define(version: 2024_01_27_172855) do
     t.integer "course_id"
     t.integer "assessment_id"
     t.string "category_name", default: "General"
-    t.datetime "release_at"
+    t.datetime "release_at", default: -> { "CURRENT_TIMESTAMP" }
     t.index ["assessment_id"], name: "index_attachments_on_assessment_id"
   end
 
@@ -324,14 +324,14 @@ ActiveRecord::Schema.define(version: 2024_01_27_172855) do
 
   create_table "scoreboards", force: :cascade do |t|
     t.integer "assessment_id"
-    t.text "banner", limit: 65535
-    t.text "colspec", limit: 65535
+    t.text "banner"
+    t.text "colspec"
   end
 
   create_table "scores", force: :cascade do |t|
     t.integer "submission_id"
     t.float "score"
-    t.text "feedback", limit: 16777215
+    t.text "feedback", size: :medium
     t.integer "problem_id"
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -357,7 +357,7 @@ ActiveRecord::Schema.define(version: 2024_01_27_172855) do
     t.string "submitter_ip", limit: 40
     t.integer "tweak_id"
     t.boolean "ignored", default: false, null: false
-    t.string "dave", limit: 255
+    t.string "dave"
     t.text "embedded_quiz_form_answer"
     t.integer "submitted_by_app_id"
     t.string "group_key", default: ""
@@ -417,11 +417,4 @@ ActiveRecord::Schema.define(version: 2024_01_27_172855) do
     t.index ["course_user_datum_id"], name: "index_watchlist_instances_on_course_user_datum_id"
     t.index ["risk_condition_id"], name: "index_watchlist_instances_on_risk_condition_id"
   end
-
-  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
-  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
-  add_foreign_key "github_integrations", "users"
-  add_foreign_key "oauth_access_grants", "oauth_applications", column: "application_id"
-  add_foreign_key "oauth_access_tokens", "oauth_applications", column: "application_id"
-  add_foreign_key "oauth_device_flow_requests", "oauth_applications", column: "application_id"
 end


### PR DESCRIPTION
## Description
- Export files inside nested directories when exporting assessments and courses
- Filters out the handin directory when exporting

## Motivation and Context
- When the course had directories that had nested files, the files weren't showing up. 
<img width="622" alt="image" src="https://github.com/autolab/Autolab/assets/38949473/7f997f0a-3e33-4909-9a85-73408fe0f57e">

↑ A nested file in the course directory
<img width="608" alt="image" src="https://github.com/autolab/Autolab/assets/38949473/3240b0ae-c930-46ea-9788-4b4dab5aa5b2">

↑ No file

## How Has This Been Tested?
- Created an assessment with a writeup directory containing a pdf file
- Handed in a few files to the assessment to create files inside the handin directory
- Exported assessment and course with assessments

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have run rubocop and erblint for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting

## Other issues / help required
Should I use Find.find over Dir[].each?

If unsure, feel free to submit first and we'll help you along.
