### PR TITLE
Fix flaky capybara test

### DIFF
--- a/spec/features/assessment_spec.rb
+++ b/spec/features/assessment_spec.rb
@@ -127,13 +127,13 @@ RSpec.describe "Instructor can create new assessment", type: :feature do
         click_on "Add annotation"
 
         # verify that score was changed
+        expect(page).to have_css('div.annotation-badge', text: score_adjust)
         problem_name = page.find(:css, 'div.problem_name', text: /#{problem.name}:/i)
         problem_score = problem_name.find(:xpath, './following-sibling::div')
         within problem_score do
           test = problem_score.find(:css, 'b.student_score')
           expect(test).to have_content(old_score + score_adjust)
         end
-        expect(page).to have_css('div.annotation-badge', text: score_adjust)
       end
     end
   end


### PR DESCRIPTION
Fix capybara test by having expect for css change before trying to find the problem score for an annotation (so capybara waits for ajax to return properly, and for the css to show up). The test was previously failing most likely because it was trying to find the css to compare to the problem score before the ajax returned and the page changed.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- I ran this at least 10 times and it didn't fail locally

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have run rubocop and erblint for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
