### PR TITLE
Fix page title for app authorization

### DIFF
--- a/app/views/doorkeeper/authorizations/new.html.erb
+++ b/app/views/doorkeeper/authorizations/new.html.erb
@@ -1,4 +1,4 @@
-<% @title = "Authorize @pre_auth.client.name" %>
+<% @title = "Authorize #{@pre_auth.client.name}" %>
 
 <% content_for :stylesheets do %>
   <style type="text/css">


### PR DESCRIPTION
This fixes a string templating error, so the value of the variable is properly displayed in the page title now.

## Description
Before:

![image](https://github.com/autolab/Autolab/assets/32116122/6ae8b62d-a24b-4806-9c85-8f9137c44ab5)

After:
![image](https://github.com/autolab/Autolab/assets/32116122/80f24a47-cb36-477c-b839-40d0d65435bf)

## Motivation and Context
I saw that the page title wasn't set correctly while authorizing an OAuth app.

## How Has This Been Tested?
Just looking at the tab.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [ ] I have run rubocop and erblint for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://docs.autolabproject.com/)
- [ ] I have updated the documentation accordingly, included in this PR
