### PR TITLE
Add backwards compatibility for svn yaml field 

### DIFF
--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -684,8 +684,9 @@ private
                  "handout_filename" => "handout",
                  "writeup_filename" => "writeup",
                  "has_autograde" => nil,
-                 "has_scoreboard" => nil }.freeze
-  BACKWORDS_COMPATIBILITY = { "autograding_setup" => "autograder",
+                 "has_scoreboard" => nil,
+                 "has_svn" => nil }.freeze
+  BACKWARDS_COMPATIBILITY = { "autograding_setup" => "autograder",
                               "scoreboard_setup" => "scoreboard" }.freeze
   def backwards_compatibility(props)
     GENERAL_BC.each do |old, new|
@@ -694,7 +695,7 @@ private
       props["general"][new] = props["general"][old] unless new.nil?
       props["general"].delete(old)
     end
-    BACKWORDS_COMPATIBILITY.each do |old, new|
+    BACKWARDS_COMPATIBILITY.each do |old, new|
       next unless props.key?(old)
 
       props[new] = props[old]


### PR DESCRIPTION
## Description
- `has_svn` field is now removed from yaml configurations
- Fixed typo in `assessment.rb` 

## Motivation and Context
Due to #2078, importing an existing course (made before the deprecation of `has_svn`) would cause an error.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
