### PR TITLE
Add detection for mismatch in Autograder results and assessment problems

### DIFF
--- a/app/helpers/assessment_autograde_core.rb
+++ b/app/helpers/assessment_autograde_core.rb
@@ -464,7 +464,7 @@ module AssessmentAutogradeCore
         submission.missing_problems = missing_problems.join(', ')
         submission.save!
 
-        if missing_problems
+        unless submission.missing_problems.empty?
           raise AutogradeError, "Problems \"#{submission.missing_problems}\" found in autograder result, but not defined by assessment."
         end
       end
@@ -483,11 +483,12 @@ module AssessmentAutogradeCore
       @assessment.problems.each do |p|
         submissions.each do |submission|
           score = submission.scores.find_or_initialize_by(problem_id: p.id)
-          next unless score.new_record? # don't overwrite scores
-          score.score = 0
           score.feedback = feedback_str
-          score.released = true
-          score.grader_id = -1
+          if score.new_record? # don't overwrite scores
+            score.score = 0
+            score.released = true
+            score.grader_id = -1
+          end
           score.save!
         end
       end

--- a/app/helpers/assessment_autograde_core.rb
+++ b/app/helpers/assessment_autograde_core.rb
@@ -465,7 +465,7 @@ module AssessmentAutogradeCore
         submission.save!
 
         unless submission.missing_problems.empty?
-          raise AutogradeError, "Problems \"#{submission.missing_problems}\" found in autograder result, but not defined by assessment."
+          raise AutogradeError, "Problems \"#{submission.missing_problems}\" found in autograder result, but not defined by assessment. Instructor should add missing problems to assessment and regrade submissions."
         end
       end
 

--- a/app/views/assessments/_submission_history_row.html.erb
+++ b/app/views/assessments/_submission_history_row.html.erb
@@ -4,7 +4,7 @@
   <td>
     <% if submission.version == 0 then %>
       <font size=-2>Unofficial</font>
-    <% elsif submission.missing_problems %>
+    <% elsif submission.missing_problems && !submission.missing_problems.empty? %>
       <div title='Problems "<%= submission.missing_problems %>" found in autograder result, but not defined by assessment.' style="font-weight: 900; color: red; cursor: help"><%= submission.version %></div>
     <% else %>
       <%= submission.version %>

--- a/app/views/assessments/_submission_history_row.html.erb
+++ b/app/views/assessments/_submission_history_row.html.erb
@@ -4,6 +4,8 @@
   <td>
     <% if submission.version == 0 then %>
       <font size=-2>Unofficial</font>
+    <% elsif submission.missing_problems %>
+      <div title='Problems "<%= submission.missing_problems %>" found in autograder result, but not defined by assessment.' style="font-weight: 900; color: red; cursor: help"><%= submission.version %></div>
     <% else %>
       <%= submission.version %>
     <% end %>

--- a/app/views/assessments/_submission_history_row.html.erb
+++ b/app/views/assessments/_submission_history_row.html.erb
@@ -5,7 +5,7 @@
     <% if submission.version == 0 then %>
       <font size=-2>Unofficial</font>
     <% elsif submission.missing_problems && !submission.missing_problems.empty? %>
-      <div title='Problems "<%= submission.missing_problems %>" found in autograder result, but not defined by assessment.' style="font-weight: 900; color: red; cursor: help"><%= submission.version %></div>
+      <div title='Problems "<%= submission.missing_problems %>" found in autograder result, but not defined by assessment. Instructor should add missing problems to assessment and regrade submissions.' style="font-weight: 900; color: red; cursor: help"><%= submission.version %> <i class="material-icons" style="vertical-align: bottom">warning</i></div>
     <% else %>
       <%= submission.version %>
     <% end %>

--- a/db/migrate/20240226194217_add_missing_problems_to_submissions.rb
+++ b/db/migrate/20240226194217_add_missing_problems_to_submissions.rb
@@ -1,0 +1,5 @@
+class AddMissingProblemsToSubmissions < ActiveRecord::Migration[6.1]
+  def change
+    add_column :submissions, :missing_problems, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_02_19_175942) do
+ActiveRecord::Schema.define(version: 2024_02_26_194217) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -115,8 +115,8 @@ ActiveRecord::Schema.define(version: 2024_02_19_175942) do
     t.integer "group_size", default: 1
     t.text "embedded_quiz_form_data"
     t.boolean "embedded_quiz"
-    t.boolean "allow_student_assign_group", default: true
     t.boolean "github_submission_enabled", default: true
+    t.boolean "allow_student_assign_group", default: true
     t.boolean "is_positive_grading", default: false
     t.boolean "disable_network", default: false
   end
@@ -361,6 +361,7 @@ ActiveRecord::Schema.define(version: 2024_02_19_175942) do
     t.integer "submitted_by_app_id"
     t.string "group_key", default: ""
     t.integer "jobid"
+    t.text "missing_problems"
     t.index ["assessment_id"], name: "index_submissions_on_assessment_id"
     t.index ["course_user_datum_id"], name: "index_submissions_on_course_user_datum_id"
   end


### PR DESCRIPTION
## Description
- Added mismatch notification on submission views. 
- Improvement and fix to existing mismatch detection for autograding feedback.

![image](https://github.com/autolab/Autolab/assets/14984764/83a28883-5d35-4d0d-823c-47512f9cab5f)
![image](https://github.com/autolab/Autolab/assets/14984764/d41ff537-04d2-456e-b30e-e72afa65baa5)

## Motivation and Context
Closes #2087.
 
## How Has This Been Tested?
- Tested submission with all problems mismatched.
- Tested submission with some problems mismatched.
- Tested submission with no problems mismatched.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
