### PR TITLE
Fix "Group options" link

### DIFF
--- a/app/views/assessments/show.html.erb
+++ b/app/views/assessments/show.html.erb
@@ -127,7 +127,7 @@
             <% end %>
             <% if @assessment.has_groups? %>
               <% if @aud.membership_status != AssessmentUserDatum::UNCONFIRMED %>
-                <li><%= link_to "Group options", course_assessment_groups_path(@course, @assessment, @aud.group), title: "Check your group settings." %></li>
+                <li><%= link_to "Group options", course_assessment_group_path(@course, @assessment, @aud.group), title: "Check your group settings." %></li>
               <% else %>
                 <li><%= link_to "Group options", new_course_assessment_group_path(@course, @assessment), title: "Check your group settings." %></li>
               <% end %>


### PR DESCRIPTION
This changes `course_assessment_groups_path` to `course_assessment_group_path` in a place where the wrong path was used.

## Motivation and Context
The "Group options" link under the "Options" collapsible on the assessment page linked to an invalid URL.

Previously:

![2024-03-12_10_02](https://github.com/autolab/Autolab/assets/32116122/4ccfd243-4282-41e3-b627-febd6ac6fdcc)

Updated:
![2024-03-12_10_04](https://github.com/autolab/Autolab/assets/32116122/00dd8da9-d0be-4147-8f04-0e07b97bcb67)

## How Has This Been Tested?
I verified the link points to the correct page.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [ ] I have run rubocop and erblint for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://docs.autolabproject.com/)
- [ ] I have updated the documentation accordingly, included in this PR
