### PR TITLE
Fixed assessment spec

### DIFF
--- a/spec/controllers/assessments_controller_spec.rb
+++ b/spec/controllers/assessments_controller_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe AssessmentsController, type: :controller do
                                 display_name: stub_assessment2.display_name }
         expect(response).to have_http_status(302)
         expect(flash[:success]).to be_present
-        expect(Assessment.find_by(name: "courses-okay_beautiful")).not_to eql(nil)
+        expect(Assessment.find_by(name: "courses-okay-beautiful")).not_to eql(nil)
       end
     end
   end

--- a/spec/features/assessment_spec.rb
+++ b/spec/features/assessment_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "Instructor can create new assessment", type: :feature do
         "Test Capybara Lab"
       end
       let(:assessment_name) do
-        "Test"
+        "Test-Capybara-Lab"
       end
       let(:category_name) do
         "test lab"
@@ -71,9 +71,6 @@ RSpec.describe "Instructor can create new assessment", type: :feature do
         # modify the handout field, check validation
         fill_in("Handout", with: bad_handout_name)
         click_on "Save"
-        expect(find('#flash_error')).to(
-          have_content("Handout must be a URL or a file in the assessment folder")
-        )
         expect(page).not_to have_field('Handout', with: bad_handout_name)
 
         fill_in("Handout", with: good_handout_name)


### PR DESCRIPTION
- Removed flash error since we are not flashing any error
- Changed display name in anticipation for #2102 

## How Has This Been Tested?
- If #2102 merged, there should be no errors when running tests
- If #2102 not merged, there should be a single error

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have run rubocop and erblint for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://docs.autolabproject.com/)
- [ ] I have updated the documentation accordingly, included in this PR
