### PR TITLE
Added max_total_score and max_scores to /assessment_details

### DIFF
--- a/app/controllers/api/v1/assessments_controller.rb
+++ b/app/controllers/api/v1/assessments_controller.rb
@@ -22,8 +22,9 @@ class Api::V1::AssessmentsController < Api::V1::BaseApiController
   end
 
   def show
-    allowed = [:name, :display_name, :description, :start_at, :due_at, :end_at, :updated_at, :max_grace_days, :max_submissions,
-      :disable_handins, :category_name, :group_size, :writeup_format, :handout_format, :has_scoreboard, :has_autograder, :max_unpenalized_submissions]
+    allowed = [:name, :display_name, :description, :start_at, :due_at, :end_at, :updated_at, :max_grace_days,
+               :max_submissions, :disable_handins, :category_name, :group_size, :writeup_format, :handout_format,
+               :has_scoreboard, :has_autograder, :max_unpenalized_submissions, :max_score, :max_scores]
 
     result = @assessment.attributes.symbolize_keys
     result.merge!(:has_scoreboard => @assessment.has_scoreboard?)
@@ -44,7 +45,19 @@ class Api::V1::AssessmentsController < Api::V1::BaseApiController
       result.merge!(:handout_format => "none")
     end
 
-    respond_with result, only: allowed
+    result.merge!(:max_score => @assessment.default_total_score)
+
+    result.filter! do |member|
+      allowed.include?(member)
+    end
+
+    max_scores = {}
+    @assessment.problems.each do |prob|
+      max_scores[prob.name] = prob.max_score
+    end
+    result.merge!(:max_scores => max_scores)
+
+    respond_with result
   end
 
   # endpoint for obtaining the writeup

--- a/app/controllers/api/v1/assessments_controller.rb
+++ b/app/controllers/api/v1/assessments_controller.rb
@@ -24,7 +24,7 @@ class Api::V1::AssessmentsController < Api::V1::BaseApiController
   def show
     allowed = [:name, :display_name, :description, :start_at, :due_at, :end_at, :updated_at, :max_grace_days,
                :max_submissions, :disable_handins, :category_name, :group_size, :writeup_format, :handout_format,
-               :has_scoreboard, :has_autograder, :max_unpenalized_submissions, :max_score, :max_scores]
+               :has_scoreboard, :has_autograder, :max_unpenalized_submissions, :max_total_score, :max_scores]
 
     result = @assessment.attributes.symbolize_keys
     result.merge!(:has_scoreboard => @assessment.has_scoreboard?)
@@ -45,7 +45,7 @@ class Api::V1::AssessmentsController < Api::V1::BaseApiController
       result.merge!(:handout_format => "none")
     end
 
-    result.merge!(:max_score => @assessment.default_total_score)
+    result.merge!(:max_total_score => @assessment.default_total_score)
 
     result.filter! do |member|
       allowed.include?(member)

--- a/docs/api-interface.md
+++ b/docs/api-interface.md
@@ -120,25 +120,27 @@ Show detailed information of an assessment.
 
 **Response:**
 
-| key              | type     | description                                                                                               |
-| ---------------- | -------- | --------------------------------------------------------------------------------------------------------- |
-| name             | string   | The unique url-safe name.                                                                                 |
-| display_name     | string   | The full name of the assessments.                                                                         |
-| description      | string   | A short description of the assessment.                                                                    |
-| start_at         | datetime | The time this assessment is released to students.                                                         |
-| due_at           | datetime | Students can submit before this time without being penalized or using grace days.                         |
-| end_at           | datetime | Last possible time that students can submit (except those granted extensions.)                            |
-| updated_at       | datetime | The last time an update was made to the assessment.                                                       |
-| max_grace_days   | integer  | Maximum number of grace days that a student can spend on this assessment.                                 |
-| max_submissions  | integer  | The maximum number of times a student can submit the assessment.<br>-1 means unlimited submissions.       |
-| max_unpenalized_submissions  | integer  | The maximum number of times the assessment can be submitted without incurring a penalty.<br>-1 means unlimited submissions.|
-| disable_handins  | boolean  | Are handins disallowed by students?                                                                       |
-| category_name    | string   | Name of the category this assessment belongs to.                                                          |
-| group_size       | integer  | The maximum size of groups for this assessment.                                                           |
-| writeup_format   | string   | The format of this assessment's writeup.<br>One of 'none', 'url', or 'file'.                              |
-| handout_format   | string   | The format of this assessment's handout.<br>One of 'none', 'url', or 'file'.                              |
-| has_scoreboard   | boolean  | Does this assessment have a scoreboard?                                                                   |
-| has_autograder   | boolean  | Does this assessment use an autograder?                                                                   |
+| key                         | type     | description                                                                                                                 |
+|-----------------------------|----------|-----------------------------------------------------------------------------------------------------------------------------|
+| name                        | string   | The unique url-safe name.                                                                                                   |
+| display_name                | string   | The full name of the assessments.                                                                                           |
+| description                 | string   | A short description of the assessment.                                                                                      |
+| start_at                    | datetime | The time this assessment is released to students.                                                                           |
+| due_at                      | datetime | Students can submit before this time without being penalized or using grace days.                                           |
+| end_at                      | datetime | Last possible time that students can submit (except those granted extensions.)                                              |
+| updated_at                  | datetime | The last time an update was made to the assessment.                                                                         |
+| max_grace_days              | integer  | Maximum number of grace days that a student can spend on this assessment.                                                   |
+| max_submissions             | integer  | The maximum number of times a student can submit the assessment.<br>-1 means unlimited submissions.                         |
+| max_unpenalized_submissions | integer  | The maximum number of times the assessment can be submitted without incurring a penalty.<br>-1 means unlimited submissions. |
+| disable_handins             | boolean  | Are handins disallowed by students?                                                                                         |
+| category_name               | string   | Name of the category this assessment belongs to.                                                                            |
+| group_size                  | integer  | The maximum size of groups for this assessment.                                                                             |
+| writeup_format              | string   | The format of this assessment's writeup.<br>One of 'none', 'url', or 'file'.                                                |
+| handout_format              | string   | The format of this assessment's handout.<br>One of 'none', 'url', or 'file'.                                                |
+| has_scoreboard              | boolean  | Does this assessment have a scoreboard?                                                                                     |
+| has_autograder              | boolean  | Does this assessment use an autograder?                                                                                     |
+| max_total_score             | float    | The maximum total score for this assessment                                                                                 |
+| max_scores                  | object   | An object with the problem name as the key, and the maximum score for the problem as the value                              |
 
 ---
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Added max_total_score to /assessment_details
- Added max_scores to /assessment_details
- Changed API documentation accordingly

## Motivation and Context
Issue #2113. 

## How Has This Been Tested?
Tested in local environment by accessing http://localhost:3000/api/v1/courses/test_course/assessments/Fizz with access token.
![image](https://github.com/autolab/Autolab/assets/38949473/224193ee-39fd-4d84-9677-5434ae7ec722)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have run rubocop and erblint for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [x] My change requires a change to the documentation, which is located at [Autolab Docs](https://docs.autolabproject.com/)
- [x] I have updated the documentation accordingly, included in this PR
