### PR TITLE
Add hooks to documentation

### DIFF
--- a/app/controllers/assessments_controller.rb
+++ b/app/controllers/assessments_controller.rb
@@ -59,6 +59,7 @@ class AssessmentsController < ApplicationController
 
   IMPORT_ASMT_FAILURE_STATUS = "FAIL".freeze
   IMPORT_ASMT_SUCCESS_STATUS = "SUCCESS".freeze
+  DISALLOWED_LIST_OPTIONS = %w[edit reload viewGradesheet].freeze
 
   def index
     @is_instructor = @cud.has_auth_level? :instructor
@@ -554,13 +555,23 @@ class AssessmentsController < ApplicationController
 
     @aud = @assessment.aud_for @cud.id
 
-    @list = {}
-    @list_title = {}
+    # These are the default items displayed
+    @list = {
+      "history" => nil,
+      "writeup" => nil,
+      "handout" => nil,
+      "groups" => nil,
+      "scoreboard" => nil
+    }
 
     if @assessment.overwrites_method?(:listOptions)
       list = @list
       @list = @assessment.config_module.listOptions(list)
     end
+
+    # Explicitly disallow certain options that should not be displayed to students
+    # This list is not exhaustive, but students wouldn't be able to view other links anyway
+    @list.except!(*DISALLOWED_LIST_OPTIONS)
 
     # Remember the student ID in case the user wants visit the gradesheet
     session["gradeUser#{@assessment.id}"] = params[:cud_id] if params[:cud_id]

--- a/app/controllers/scoreboards_controller.rb
+++ b/app/controllers/scoreboards_controller.rb
@@ -347,7 +347,7 @@ private
 
       # In this case, we have an autograded lab for which the
       # instructor has created a custom column specification.  By
-      # default, we sort the first three columns from left to right
+      # default, we sort the columns from left to right
       # in descending order. Lab authors can modify the default
       # direction with the "asc" key in the column spec.
     else

--- a/app/helpers/assessment_autograde_core.rb
+++ b/app/helpers/assessment_autograde_core.rb
@@ -26,7 +26,7 @@ module AssessmentAutogradeCore
       COURSE_LOGGER.log("Dir: #{ass_dir}")
 
       if assessment.overwrites_method?(:autogradeInputFiles)
-        upload_file_list = assessment.config_module.autogradeInputFiles(ass_dir)
+        upload_file_list = assessment.config_module.autogradeInputFiles(ass_dir, assessment, submission)
       else
         upload_file_list = autogradeInputFiles(ass_dir, assessment, submission)
       end

--- a/app/views/assessments/show.html.erb
+++ b/app/views/assessments/show.html.erb
@@ -5,21 +5,6 @@
   <%= javascript_include_tag 'collapsible' %>
 <% end %>
 
-<%# Make sure these options are not on the general user options list.  %>
-<%# We have to do this because we exposed the internal interface for building options lists %>
-<%# and some users have fiddled with this in their assessment.rb file %>
-
-<%# These options have been eliminated %>
-<% @list.delete("listAdmin") %>
-
-<%# These options should only be on the admin list %>
-<% @list.delete("edit") %>
-<% @list.delete("viewGradesheet") %>
-<% @list.delete("attachments") %>
-<% @list.delete("extension") %>
-<% @list.delete("submission") %>
-<% @list.delete("reload") %>
-
 <div>
 <div class="row">
   <div class="col s12 m12">
@@ -118,26 +103,36 @@
         <div class="collapsible-header"><h5>Options</h5></div>
         <div class="collapsible-body">
           <ul class="options">
-            <li><%= link_to "View handin history", history_course_assessment_path(@course, @assessment), { title: "View your submissions, scores, and feedback from the course staff" } %> </li>
-            <% if @assessment.has_writeup? %>
+            <% default_opts = @list.select { |_, v| v.nil? } %>
+            <% if default_opts.key?("history") %>
+              <li><%= link_to "View handin history", history_course_assessment_path(@course, @assessment), { title: "View your submissions, scores, and feedback from the course staff" } %> </li>
+            <% end %>
+            <% if default_opts.key?("writeup") && @assessment.has_writeup? %>
               <li><%= link_to "View writeup", writeup_course_assessment_path(@course, @assessment), { title: "View the assessment writeup" } %> </li>
             <% end %>
-            <% if @assessment.has_handout? %>
+            <% if default_opts.key?("handout") && @assessment.has_handout? %>
               <li><%= link_to "Download handout", handout_course_assessment_path(@course, @assessment), { title: "Download handout materials and starter code" } %> </li>
             <% end %>
-            <% if @assessment.has_groups? %>
+            <% if default_opts.key?("groups") && @assessment.has_groups? %>
               <% if @aud.membership_status != AssessmentUserDatum::UNCONFIRMED %>
                 <li><%= link_to "Group options", course_assessment_group_path(@course, @assessment, @aud.group), title: "Check your group settings." %></li>
               <% else %>
                 <li><%= link_to "Group options", new_course_assessment_group_path(@course, @assessment), title: "Check your group settings." %></li>
               <% end %>
             <% end %>
-            <% if @assessment.has_scoreboard? %>
+            <% if default_opts.key?("scoreboard") && @assessment.has_scoreboard? %>
               <li><%= link_to "View scoreboard", course_assessment_scoreboard_path(@course, @assessment), title: "View the assessment scoreboard" %></li>
             <% end %>
+            <% @list.compact! # Remove the nil values, which correspond to default items %>
             <% @list.sort { |a, b| a[1] <=> b[1] }.each { |key, value| %>
               <% if value.size > 0 %>
-                <li><%= link_to value, { action: key }, { title: @list_title[key] || "" } %> </li>
+                <li>
+                  <% begin %>
+                  <%= link_to value, { action: key }, { title: value } %>
+                  <% rescue %>
+                  Invalid option "<%= key %>"
+                  <% end %>
+                </li>
               <% end %>
             <% } %>
           </ul>

--- a/docs/features/schedulers.md
+++ b/docs/features/schedulers.md
@@ -9,7 +9,7 @@ Schedulers are instructor scripts that run periodically. They can be managed via
 Schedulers must define a `update` method within a class or module. Changes made to the scheduler file take effect immediately.
 
 **Using a module**
-```
+```ruby
 module Updater
     def self.update(course)
         # code goes here
@@ -17,7 +17,7 @@ module Updater
 end
 ```
 **Using a class**
-```
+```ruby
 class Updater
     def self.update(course)
         # code goes here
@@ -31,7 +31,7 @@ You can run a scheduler manually by clicking the `Run` button. This is useful fo
 To assist in debugging, you can return a string from the `update` method, which will be displayed as output in the browser.
 
 **Example file**
-```
+```ruby
 module Updater
     def self.update(course)
         out = ""

--- a/docs/instructors.md
+++ b/docs/instructors.md
@@ -101,34 +101,6 @@ _Grades_ come in a number of different forms:
 
 Submissions can be classified as one of three types: "Normal", "No Grade" or "Excused". A "No Grade" submission will show up in the gradebook as NG and a zero will be used when calculating averages. An "Excused" submission will show up in the gradebook as EXC and will not be used when calculating averages.
 
-## Overriding Raw Score Calculations
-
-Autolab computes raw scores for a lab with a Ruby function called `raw_score`. The default is the sum of the individual problem scores. But you can change this by providing your own `raw_score` function in `<labname>.rb` file. For example, to override the raw_score calculation for a lab called `malloclab`, you might add the following `raw_score` function to `malloclab/malloclab.rb`:
-
-```ruby
-# In malloclab/malloclab.rb file
-def raw_score(score)
-    perfindex = score["Autograded Score"].to_f()
-    heap = score["Heap Checker"].to_f()
-    style = score["Style"].to_f()
-    deduct = score["CorrectnessDeductions"].to_f()
-    perfpoints = perfindex
-
-    # perfindex below 50 gets autograded score of 0.
-    if perfindex < 50.0 then
-        perfpoints = 0
-    else
-        perfpoints = perfindex
-    end
-
-    return perfpoints + heap + style + deduct
-end
-```
-
-This particular lab has four problems called "Autograded Score", "Heap Checker", "Style", and "CorrectnessDeductions". An "Autograded Score" less than 50 is set to zero when the raw score is calculated.
-
-Note: To make this change live, you must select the "Reload config file" option on the `malloclab` page.
-
 ## Overriding Category and Course Averages
 
 The average for a category `foo` is calculated by a default Ruby function called `fooAverage`, which you can override in the `course.rb` file. For example, in our course, we prefer to report the "average" as the total number of normalized points (out of 100) that the student has accrued so far. This helps them understand where they stand in the class, e.g., "Going into the final exam (worth 30 normalized points), I have 60 normalized points, so the only way to get an A is to get 100% on the final." Here's the Ruby function for category "Lab":
@@ -175,44 +147,6 @@ end
 In this course, the course average is the sum of the category averages for "Lab" and "Exam".
 
 Note: To make these changes live, you must select "Reload course config file" on the "Manage course" page.
-
-## Customizing Submision File MIME Type Check
-
-By default, Autolab does not perform MIME type check for submission files. However, it allows instructors to define their own MIME type check method in the assessment config file. The corresponding function is `checkMimeType` in `<labname>.rb` file. For example, to prevent students from submitting a binary file to the assessment `malloclab`, you might add the following `checkMimeType` function to `malloclab/malloclab.rb`:
-
-```ruby
-# In malloclab/malloclab.rb file
-def checkMimeType(contentType, fileName)
-    return contentType != "application/octet-stream"
-end
-```
-
-As of now, the only way to provide a more informative message to student is to raise an error:
-
-```ruby
-# In malloclab/malloclab.rb file
-def checkMimeType(contentType, fileName)
-    raise "Do not submit binary files!" if contentType == "application/octet-stream"
-    
-    return true
-end
-```
-
-This results in the following error message to students when they attempt to submit binary files.
-
-![MIME Type Check](/images/mime_type_check.png)
-
-Alternatively, you can use the file name to do file type check. The following snippet prevents students from submitting python files:
-
-```ruby
-def checkMimeType(contentType, fileName)
-    return fileName.split(".")[-1] != "py"
-end
-```
-
-Note that this function does not have access to Rails controller attributes such as `flash` or `params`. Attempts to access what's beyond the arguments passed to the function will result in an error.
-
-Note: To make this change live, you must select the "Reload config file" option on the `malloclab` page.
 
 ## Handin History
 

--- a/docs/lab-hooks.md
+++ b/docs/lab-hooks.md
@@ -6,6 +6,8 @@ Lab hooks are defined in the lab's configuration file, `<labname>.rb`. The confi
 
 To make changes live, you must select the "Reload config file" option on the lab's index page. You can also upload a new config file from the lab's setting page.
 
+To debug the hooks, you can make use of the `ASSESSMENT_LOGGER.log(<expr>)` method to print output into the lab's `log.txt` file.
+
 ## Modify Submission Score
 
 Hook: `modifySubmissionScores`
@@ -73,7 +75,7 @@ def raw_score(score)
 end
 ```
 
-This particular lab has four problems called "Autograded Score", "Heap Checker", "Style", and "CorrectnessDeductions". An "Autograded Score" less than 50 is set to zero when the raw score is calculated.
+This particular lab has four problems called "Autograded Score", "Heap Checker", "Style", and "CorrectnessDeductions". The code snippet above sets an "Autograded Score" of less than 50 to zero when the raw score is calculated.
 
 ## Submission File MIME Type Check
 
@@ -114,6 +116,24 @@ Note that this function does not have access to Rails controller attributes such
 ## Lab Handout
 
 Hook: `handout`
+
+By default, the handout provided to students when they click on "Download handout" is the file path or URL specified in the lab settings. This hook allows you to run custom code when the button is clicked and then return a path to the handout. This can be useful in creating customized handouts on a per-student basis.
+
+!!! info "Restrictions on Handout Path"
+    For security reasons, the handout path returned by the hook must reside within the lab folder.
+
+```ruby
+def handout
+    course = @assessment.course.name
+    asmt = @assessment.name
+    file = "autograde-Makefile"
+    
+    file_path = "courses/#{course}/#{asmt}/#{file}"
+    Hash["fullpath", file_path, "filename", "makefile"]
+end
+```
+
+The code snippet above downloads the `autograde-Makefile` (assuming it resides at the root of the lab directory) as the file `makefile`.
 
 ## On Autograde Completion
 

--- a/docs/lab-hooks.md
+++ b/docs/lab-hooks.md
@@ -75,7 +75,7 @@ end
 
 This particular lab has four problems called "Autograded Score", "Heap Checker", "Style", and "CorrectnessDeductions". An "Autograded Score" less than 50 is set to zero when the raw score is calculated.
 
-## Customizing Submission File MIME Type Check
+## Submission File MIME Type Check
 
 Hook: `checkMimeType`
 

--- a/docs/lab-hooks.md
+++ b/docs/lab-hooks.md
@@ -2,7 +2,7 @@
 
 This document provides a summary of all the lab (aka assessment) hooks available to an instructor.
 
-Lab hooks are defined in the lab's configuration file, `<labname>.rb`. The configuration file is located in the lab's directory, `<coursename>/<labname>/<labname>.rb`.
+Lab hooks are defined in the lab's configuration file, `<labname>.rb`. The configuration file is located in the lab's directory, at the path `<coursename>/<labname>/<labname>.rb`.
 
 To make changes live, you must select the "Reload config file" option on the lab's index page. You can also upload a new config file from the lab's setting page.
 
@@ -339,7 +339,7 @@ end
 
 Hook: `parseAutoresult`
 
-By default, the autoresult string from the autograder (the last non-empty line) is assumed to be encode in JSON and is parsed as such.
+By default, the autoresult string from the autograder (the last non-empty line) is assumed to be encoded in JSON and is parsed as such.
 If a different format is used for the autoresult string, this hook allows you to define custom parsing logic.
 
 ```ruby

--- a/docs/lab-hooks.md
+++ b/docs/lab-hooks.md
@@ -1,0 +1,112 @@
+# Lab Hooks
+
+This document provides a summary of all the lab (aka assessment) hooks available to an instructor.
+
+Lab hooks are defined in the lab's configuration file, `<labname>.rb`. The configuration file is located in the lab's directory, `<coursename>/<labname>/<labname>.rb`.
+
+To make changes live, you must select the "Reload config file" option on the lab's index page. You can also upload a new config file from the lab's setting page.
+
+## Modify Submission Score
+
+Hook: `modifySubmissionScores`
+
+By default, the scores output by the autograder will be directly assigned to the individual problem scores. This hook allows you to override the score calculation for a lab.
+
+```ruby
+def assessmentVariables
+    variables = {}
+    variables["previous_submissions_lookback"] = 1000
+    variables["exclude_autograding_in_progress_submissions"] = false
+    variables
+end
+
+def modifySubmissionScores(scores, previous_submissions, problems)
+
+  scores["Score1"] = -(previous_submissions.length)
+  
+  # Get Score1 score for previous submission
+  scores["Score2"] = previous_submissions[0].scores.find_or_initialize_by(:problem_id => problems.find_by(:name => "Score1").id).score
+
+  # Get Score2 score for previous submission
+  scores["Score3"] = previous_submissions[0].scores.find_or_initialize_by(:problem_id => problems.find_by(:name => "Score2").id).score
+  
+  scores
+end
+```
+The code snippet above allows you to create a lab that has a score that is a function of the number of previous submissions, and the scores of previous submissions. This particular lab has four problems called "Autograded Score", "Score1", "Score2", "Score3". It assigns the score of "Score1" to be the negative of the number of previous submissions, and the score of "Score2" to be the score of "Score1" of the previous submission, and the score of "Score3" to be the score of "Score2" of the previous submission.
+
+There are two settings that you can change in the `assessmentVariables` function that will affect the behavior of the `modifySubmissionScores` function:
+
+- `previous_submissions_lookback`: The number of previous submissions to look back when calculating the score. By default, it is set to 1000.
+- `exclude_autograding_in_progress_submissions`: If set to `true`, the submissions that are currently being autograded will be excluded when passed into the `modifySubmissionScores` function. By default, it is set to `false`.
+
+The three arguments passed into the `modifySubmissionScores` function are:
+
+- `scores`: A hash that maps the problem name to the score.
+- `previous_submissions`: A list of previous submissions, sorted by submission time in descending order, it is an ActiveRecord object.
+- `problems`: A list of problems in the lab, it is an ActiveRecord object.
+
+For more information on how to use ActiveRecord, please refer to the [ActiveRecord documentation](http://guides.rubyonrails.org/active_record_querying.html). For the schema of the `Submission` and `Problem` models, please refer to the [Autolab Schema](https://github.com/autolab/Autolab/blob/master/db/schema.rb).
+
+## Raw Score Calculations
+
+Hook: `raw_score`
+
+By default, the raw score for a submission is the sum of the individual problem scores. This hook allows you to override the raw score calculation for a lab.
+
+```ruby
+def raw_score(score)
+    perfindex = score["Autograded Score"].to_f()
+    heap = score["Heap Checker"].to_f()
+    style = score["Style"].to_f()
+    deduct = score["CorrectnessDeductions"].to_f()
+    perfpoints = perfindex
+
+    # perfindex below 50 gets autograded score of 0.
+    if perfindex < 50.0 then
+        perfpoints = 0
+    else
+        perfpoints = perfindex
+    end
+
+    return perfpoints + heap + style + deduct
+end
+```
+
+This particular lab has four problems called "Autograded Score", "Heap Checker", "Style", and "CorrectnessDeductions". An "Autograded Score" less than 50 is set to zero when the raw score is calculated.
+
+## Customizing Submission File MIME Type Check
+
+Hook: `checkMimeType`
+
+By default, Autolab does not perform MIME type check for submission files. This hook allows you to define a MIME type check method. For example, to prevent students from submitting a binary file to the assessment, you might add the following `checkMimeType` function:
+
+```ruby
+def checkMimeType(contentType, fileName)
+    return contentType != "application/octet-stream"
+end
+```
+
+As of now, the only way to provide a more informative message to student is to raise an error:
+
+```ruby
+def checkMimeType(contentType, fileName)
+    raise "Do not submit binary files!" if contentType == "application/octet-stream"
+    
+    return true
+end
+```
+
+This results in the following error message to students when they attempt to submit binary files.
+
+![MIME Type Check](/images/mime_type_check.png)
+
+Alternatively, you can use the file name to do file type check. The following snippet prevents students from submitting python files:
+
+```ruby
+def checkMimeType(contentType, fileName)
+    return fileName.split(".")[-1] != "py"
+end
+```
+
+Note that this function does not have access to Rails controller attributes such as `flash` or `params`. Attempts to access what's beyond the arguments passed to the function will result in an error.

--- a/docs/lab-hooks.md
+++ b/docs/lab-hooks.md
@@ -79,7 +79,7 @@ def raw_score(score)
 end
 ```
 
-This particular lab has four problems called "Autograded Score", "Heap Checker", "Style", and "CorrectnessDeductions". The code snippet above sets an "Autograded Score" of less than 50 to zero when the raw score is calculated.
+This particular lab has four problems called "Autograded Score", "Heap Checker", "Style", and "CorrectnessDeductions". The code snippet above sets an "Autograded Score" of less than 50 to 0 when the raw score is calculated.
 
 ## Submission File MIME Type Check
 
@@ -93,7 +93,7 @@ def checkMimeType(contentType, fileName)
 end
 ```
 
-As of now, the only way to provide a more informative message to student is to raise an error:
+As of now, the only way to provide a more informative message to students is to raise an error:
 
 ```ruby
 def checkMimeType(contentType, fileName)
@@ -103,11 +103,11 @@ def checkMimeType(contentType, fileName)
 end
 ```
 
-This results in the following error message to students when they attempt to submit binary files.
+This results in the following error message being displayed to students when they attempt to submit binary files.
 
 ![MIME Type Check](/images/mime_type_check.png)
 
-Alternatively, you can use the file name to do file type check. The following snippet prevents students from submitting python files:
+Alternatively, you can use the file name to do file type checks. The following snippet prevents students from submitting python files:
 
 ```ruby
 def checkMimeType(contentType, fileName)
@@ -308,7 +308,7 @@ By default, the following autograding input files are sent to Tango
 
 1. The student's handin file
 2. The makefile that runs the process
-3. The tarfile with all of the first needed by the autograder
+3. The tarfile with all of the files needed by the autograder
 
 This hook allows you to define a custom list of input files to be sent instead.
 

--- a/docs/lab-hooks.md
+++ b/docs/lab-hooks.md
@@ -240,7 +240,7 @@ By default, each scoreboard row, corresponding to a user, follows the following 
 
 This hook allows for greater flexibility in the values displayed for each student.
 In particular, the values displayed for the columns beyond `Rank`, `Nickname`, `Version`, and `Time` can be configured.
-This hook should most likely be used in conjunction with the `scoreboardHeader` hook or a custom column specification.
+This hook should most likely be used in conjunction with the `scoreboardHeader` hook or a [custom column specification](/features/scoreboards/#custom-scoreboards).
 
 ```ruby
 def createScoreboardEntry(scores, autoresult)
@@ -265,6 +265,40 @@ with the other problems.
 ## Scoreboard Ordering
 
 Hook: `scoreboardOrderSubmissions`
+
+By default, scoreboard rows are sorted as follows:
+
+- If a [custom column specification](/features/scoreboards/#custom-scoreboards) is provided (and an autograder is defined): Sort the columns from left to right in descending/ascending order (depending on the column specification) 
+- Otherwise: Sort by decreasing total score, followed by increasing submission time
+
+This hook allows for greater flexibility in the sorting logic.
+
+```ruby
+# The hash contains the following keys:
+# {:nickname, :andrewID, :fullName, :problems, :time, :version, :autoresult, :entry}
+# where :entry is the scoreboard entry array returned by createScoreboardEntry
+def scoreboardOrderSubmissions(a, b)
+    # In this example, assume that each entry has the format [defused, explosions, totalscore]
+
+    # Entry A ranks higher than entry B if it has more defused phases.
+    rank = -(a[:entry][0] <=> b[:entry][0])
+    if rank != 0
+        return rank
+    end
+
+    # If defused phases are equal, entry A ranks higher than entry
+    # B if it has _fewer_ explosions.
+    rank = a[:entry][1] <=> b[:entry][1]
+    if rank != 0
+        return -rank
+    end
+
+    # As a final tiebreaker, earlier submissions rank higher.
+    -(a[:time] <=> b[:time])
+end
+```
+
+The code snippet above sorts by the first column (`defused`) in decreasing order, followed by the second column (`explosions`) in increasing order. As a final tiebreaker, it sorts by time.
 
 ## Autograding Input Files
 

--- a/docs/lab-hooks.md
+++ b/docs/lab-hooks.md
@@ -147,6 +147,27 @@ Hook: `listOptions`
 
 Hook: `scoreboardHeader`
 
+By default, the scoreboard header follows the following format:
+
+- If a [custom column specification](/features/scoreboards/#custom-scoreboards) is provided: `Rank`, `Nickname`, `Version`, `Time`, followed by the columns defined in the column specification
+- Otherwise: `Rank`, `Nickname`, `Version`, `Time`, `Total`, followed by the name of each problem in the assessment
+
+This hook allows for even greater flexibility in the definition of the scoreboard header.
+If defined, it takes precedence over a custom column specification.
+
+!!! info "Restrictions on HTML tags"
+    Only `th` and `td` tags can be used, all other tags will be stripped.
+
+```ruby
+def scoreboardHeader
+    "<th>Nickname</th><th>Version</th><th>Time</th><th>Total</th><th>Problem 1</th><th>Problem 2</th>"
+end
+```
+
+The code snippet above defines a scoreboard whose header consists of the fields `Rank`, `Nickname`, `Version`, `Time`, `Total`, `Problem 1`, `Problem 2`.
+
+Thus, other than the `Rank` column, the number of columns and their names can be fully customized.
+
 ## Scoreboard Entries
 
 Hook: `createScoreboardEntry`

--- a/docs/lab-hooks.md
+++ b/docs/lab-hooks.md
@@ -110,3 +110,35 @@ end
 ```
 
 Note that this function does not have access to Rails controller attributes such as `flash` or `params`. Attempts to access what's beyond the arguments passed to the function will result in an error.
+
+## Lab Handout
+
+Hook: `handout`
+
+## On Autograde Completion
+
+Hook: `autogradeDone`
+
+## List Options
+
+Hook: `listOptions`
+
+## Scoreboard Header
+
+Hook: `scoreboardHeader`
+
+## Scoreboard Entries
+
+Hook: `createScoreboardEntry`
+
+## Scoreboard Ordering
+
+Hook: `scoreboardOrderSubmissions`
+
+## Autograding Input Files
+
+Hook: `autogradeInputFiles`
+
+## Autoresult parsing
+
+Hook: `parseAutoresult`

--- a/docs/lab.md
+++ b/docs/lab.md
@@ -342,49 +342,6 @@ The `hello/writeup` contains the detailed lab writeup, either html or pdf file, 
 ## Other sample autograders
 We have a [repository for sample autograders](https://github.com/autolab/autograders-examples) written for popular languages, which includes Python, Java, C++, Golang, and Javascript.
 
-## Overriding Modify Submission Score
-
-By default, the score output by the autograder will directly assigned to the individual problem scores. But you can change this by providing your own `modifySubmissionScores` function in `<labname>.rb` file. For example, to override the score calculation for a lab called `malloclab`, you might add the following `modifySubmissionScores` function to `malloclab/malloclab.rb`:
-
-```ruby
-# In malloclab/malloclab.rb file
-  def assessmentVariables
-    variables = {}
-    variables["previous_submissions_lookback"] = 1000
-    variables["exclude_autograding_in_progress_submissions"] = false
-    variables
-  end
-
-  def modifySubmissionScores(scores, previous_submissions, problems)
-
-    scores["Score1"] = -(previous_submissions.length)
-    
-    # Get Score1 score for previous submission
-    scores["Score2"] = previous_submissions[0].scores.find_or_initialize_by(:problem_id => problems.find_by(:name => "Score1").id).score
-
-    # Get Score2 score for previous submission
-    scores["Score3"] = previous_submissions[0].scores.find_or_initialize_by(:problem_id => problems.find_by(:name => "Score2").id).score
-    
-    scores
-  end
-```
-This overriding allows you to create a lab that has a score that is a function of the number of previous submissions, and the scores of previous submissions. This particular lab has four problems called "Autograded Score", "Score1", "Score2", "Score3". It assigns the score of "Score1" to be the negative of the number of previous submissions, and the score of "Score2" to be the score of "Score1" of the previous submission, and the score of "Score3" to be the score of "Score2" of the previous submission. 
-
-There are two settings that you can change in the `assessmentVariables` function that will affect the behavior of the `modifySubmissionScores` function:
-
-- `previous_submissions_lookback`: The number of previous submissions to look back when calculating the score. By default, it is set to 1000.
-- `exclude_autograding_in_progress_submissions`: If set to `true`, the submissions that are currently being autograded will be excluded when passed into the `modifySubmissionScores` function. By default, it is set to `false`.
-
-The three arguments passed into the `modifySubmissionScores` function are:
-
-- `scores`: A hash that maps the problem name to the score.
-- `previous_submissions`: A list of previous submissions, sorted by submission time in descending order, it is an ActiveRecord object.
-- `problems`: A list of problems in the lab, it is an ActiveRecord object.
-
-For more information on how to use ActiveRecord, please refer to the [ActiveRecord documentation](http://guides.rubyonrails.org/active_record_querying.html). For the schema of the `Submission` and `Problem` models, please refer to the [Autolab Schema](https://github.com/autolab/Autolab/blob/master/db/schema.rb).
-
-To make this change live, you must select the "Reload config file" option on the assessment page.
-
 ## Troubleshooting
 
 #### Why is Autolab not displaying my stdout output?

--- a/docs/lab.md
+++ b/docs/lab.md
@@ -39,7 +39,7 @@ After you've written and tested the autograder, you then use the Autolab website
 
 #### Step 1: Create the new lab.
 
-Create a new lab by clicking the "Install Assessment" button and choosing "Option 1: Create a New Assessment from Scratch." For course `<course>` and lab `<lab>`, this will create a <i>lab directory</i> in the Autolab file hierarchy called `courses/<course>/<lab>`. This initial directory contains a couple of config files and a directory called `<lab>/handin` that will contain all of the student handin files. In general, you should never modify any of these.
+Create a new lab by clicking the "Install Assessment" button and choosing "Option 1: Create a New Assessment from Scratch." For course `<course>` and lab `<lab>`, this will create a <i>lab directory</i> in the Autolab file hierarchy called `courses/<course>/<lab>`. This initial directory contains a couple of config files and a directory called `<lab>/handin` that will contain all student handin files. In general, you should never modify any of these.
 
 !!! warning "Attention CMU Lab Authors"
 	At CMU, the lab directory is called `/afs/cs/academic/class/<course>/autolab/<lab>`. For example: `/afs/cs/academic/class/15213-f16/autolab/foo` is the lab directory for the lab named `foo` for the Fall 2016 instance of 15-213. All lab-related files must go in this `autolab` directory to avoid permissions issues.

--- a/docs/lab.md
+++ b/docs/lab.md
@@ -350,7 +350,7 @@ Autolab always shows the stdout output of running make, even when the program cr
 
 #### Why is Autolab not able to stream my stdout output? The output only seems to be displayed when autograding is completed.
 
-Autolab can only stream stdout. Many programming languages do buffered writes to `stdout`, so you would have to guarantee that you are writing to stdout by flushing the buffer accordingly (e.g. [Python `print`'s flush flag](https://docs.python.org/3/library/functions.html#print), [C's `fflush`](https://www.tutorialspoint.com/c_standard_library/c_function_fflush.htm), [CPP's `fflush` ](https://en.cppreference.com/w/cpp/io/c/fflush))
+Autolab can only stream stdout. Many programming languages do buffered writes to `stdout`, so you would have to guarantee that you are writing to stdout by flushing the buffer accordingly (e.g. [Python `print`'s flush flag](https://docs.python.org/3/library/functions.html#print), [C's `fflush`](https://www.tutorialspoint.com/c_standard_library/c_function_fflush.htm), [CPP's `fflush`](https://en.cppreference.com/w/cpp/io/c/fflush))
 
 #### Why is my assessment failing to be imported?
 

--- a/docs/lab.md
+++ b/docs/lab.md
@@ -7,7 +7,7 @@ This guide explains how to create autograded programming assignments (labs) for 
 An _autograder_ is a program that takes a student's work as input, and generates some quantitative evaluation of that work as output. The student's work consists of one or more source files written in an arbitrary programming language. The autograder processes these files and generates arbitrary text lines on stdout. What's written to stdout will be displayed to the students as **autograder feedback**.
 
 !!! info "Streaming Output"
-	As of Autolab v2.10, any output written into the stdout will be streamed directly for students to see, so students can see the live progress of the autograding. Many programming languages do buffered writes to `stdout`, so if you want live progress, you would have to guarantee that you are writing to stdout by flushing the buffer accordingly (e.g. [Python `print`'s flush flag](https://docs.python.org/3/library/functions.html#print), [C's `fflush`](https://www.tutorialspoint.com/c_standard_library/c_function_fflush.htm), [CPP's `fflush` ](https://en.cppreference.com/w/cpp/io/c/fflush)) 
+	As of Autolab v2.10, any output written into the stdout will be streamed directly for students to see, so students can see the live progress of the autograding. Many programming languages do buffered writes to `stdout`, so if you want live progress, you would have to guarantee that you are writing to stdout by flushing the buffer accordingly (e.g. [Python `print`'s flush flag](https://docs.python.org/3/library/functions.html#print), [C's `fflush`](https://www.tutorialspoint.com/c_standard_library/c_function_fflush.htm), [CPP's `fflush`](https://en.cppreference.com/w/cpp/io/c/fflush)) 
 
 The last text line on stdout must be a JSON string, called an _autoresult_, that assigns an autograded score to one or more problems, and optionally, generates the scoreboard entries for this submission.
 
@@ -19,7 +19,7 @@ The JSON autoresult is a "scores" hash that assigns a numerical score to one or 
 
 assigns 10 points to "Prob1" and 5 points to "Prob2" for this submission. The names of the problems must exactly match the names of the problems for this lab on the Autolab website. Not all problems need to be autograded. For example, there might be a problem for this assessment called "Style" that you grade manually after the due date.
 
-If you used the Autolab web site to configure a scoreboard for this lab with three columns called "Prob1", "Prob2", and "Total", then the autoresult might be:
+If you used the Autolab website to configure a scoreboard for this lab with three columns called "Prob1", "Prob2", and "Total", then the autoresult might be:
 
 ```json
 { "scores": { "Prob1": 10, "Prob2": 5 }, "scoreboard": [10, 5, 15] }
@@ -33,7 +33,7 @@ To format your autoresult feedback provided to the students, use the [formatted 
 
 ## Installing Autograded Labs
 
-After you've written and tested the autograder, you then use the Autolab web site to create the autograded lab. Autolab supports creating new labs from scratch, or reusing labs from previous semesters. We'll describe each of these in turn.
+After you've written and tested the autograder, you then use the Autolab website to create the autograded lab. Autolab supports creating new labs from scratch, or reusing labs from previous semesters. We'll describe each of these in turn.
 
 ### Creating an Autograded Lab from Scratch
 

--- a/docs/lab.md
+++ b/docs/lab.md
@@ -17,7 +17,7 @@ The JSON autoresult is a "scores" hash that assigns a numerical score to one or 
 { "scores": { "Prob1": 10, "Prob2": 5 } }
 ```
 
-assigns 10 points to "Prob1" and 5 points to "Prob2" for this submission. The names of the problems must exactly match the names of the problems for this lab on the Autolab web site. Not all problems need to be autograded. For example, there might be a problem for this assessment called "Style" that you grade manually after the due date.
+assigns 10 points to "Prob1" and 5 points to "Prob2" for this submission. The names of the problems must exactly match the names of the problems for this lab on the Autolab website. Not all problems need to be autograded. For example, there might be a problem for this assessment called "Style" that you grade manually after the due date.
 
 If you used the Autolab web site to configure a scoreboard for this lab with three columns called "Prob1", "Prob2", and "Total", then the autoresult might be:
 

--- a/lib/__defaultAssessment.rb
+++ b/lib/__defaultAssessment.rb
@@ -27,7 +27,7 @@ module ##NAME_CAMEL##
   #   brief: reject files that are not of the correct type
   #   params: contentType (string), fileName (string)
   #   returns: boolean, true if the file is of the correct type, false otherwise
-  #   details: https://docs.autolabproject.com/lab-hooks/#raw-score-calculations
+  #   details: https://docs.autolabproject.com/lab-hooks/#submission-file-mime-type-check
   #
   # handout
   #   brief: provide a handout file for the assessment

--- a/lib/__defaultAssessment.rb
+++ b/lib/__defaultAssessment.rb
@@ -13,7 +13,9 @@ module ##NAME_CAMEL##
   # ===================================
   # modifySubmissionScores
   #   brief: modify calculated scores for a submission
-  #   params: scores, previous_submissions, problems
+  #   params: scores (hash of problem names to problem scores),
+  #           previous_submissions (array of ActiveRecord Submission objects),
+  #           problems (array of ActiveRecord Problem objects)
   #   returns: hash of problem names to problem scores, the new submission scores
   #   details: https://docs.autolabproject.com/lab-hooks/#modify-submission-score
   #
@@ -70,7 +72,9 @@ module ##NAME_CAMEL##
   #
   # autogradeInputFiles
   #   brief: define list of input files for the autograder
-  #   params: ass_dir (Pathname)
+  #   params: ass_dir (Pathname),
+  #           assessment (ActiveRecord Assessment object),
+  #           submission (ActiveRecord Submission object)
   #   returns: array of hashes, the list of input files for the autograder
   #            The hash contains the following keys: {:localFile, :remoteFile, :destFile}
   #            - localFile: path to file on local machine

--- a/lib/__defaultAssessment.rb
+++ b/lib/__defaultAssessment.rb
@@ -33,32 +33,32 @@ module ##NAME_CAMEL##
   #   brief: provide a handout file for the assessment
   #   params: none
   #   returns: hash with keys "fullpath" (path to handout file relative to Rails.root), and "filename" (handout name)
-  #   details: (undocumented)
+  #   details: https://docs.autolabproject.com/lab-hooks/#lab-handout
   #
   # autogradeDone
   #   brief: provide a method to be called when autograding is done.
   #          This replaces the default behavior of saving feedback files and updating scores.
   #   params: submissions (array of Submission objects), feedback_str (string)
   #   returns: none
-  #   details: (undocumented)
+  #   details: https://docs.autolabproject.com/lab-hooks/#on-autograde-completion
   #
   # listOptions
   #   brief: define items for the assessment's options menu
   #   params: list (hash of path to title)
   #   returns: hash of path to title
-  #   details: (undocumented)
+  #   details: https://docs.autolabproject.com/lab-hooks/#list-options
   #
   # scoreboardHeader
   #   brief: define the scoreboard header
   #   params: none
   #   returns: string, HTML for the header of the scoreboard
-  #   details: (undocumented)
+  #   details: https://docs.autolabproject.com/lab-hooks/#scoreboard-header
   #
   # createScoreboardEntry
   #   brief: create a row in the scoreboard
   #   params: scores (hash of problem names to problem scores), autoresult (string)
   #   returns: float array, the value for each column in the scoreboard for this entry
-  #   details: (undocumented)
+  #   details: https://docs.autolabproject.com/lab-hooks/#scoreboard-entries
   #
   # scoreboardOrderSubmissions
   #   brief: define ordering for the scoreboard
@@ -66,7 +66,7 @@ module ##NAME_CAMEL##
   #           The hash contains the following keys: {:uid, :andrewID, :version, :time, :problems, :entry}
   #           where :entry is the scoreboard entry array
   #   returns: integer, -1 if a should be ranked higher, 1 if b should be ranked higher, 0 if they are tied
-  #   details: (undocumented)
+  #   details: https://docs.autolabproject.com/lab-hooks/#scoreboard-ordering
   #
   # autogradeInputFiles
   #   brief: define list of input files for the autograder
@@ -78,13 +78,13 @@ module ##NAME_CAMEL##
   #              If this file is unique per-submission (e.g. the student's code), then the filename should also be unique per-submission
   #              If undefined, value of localFile will be used instead
   #            - destFile: name of the file on the destination machine
-  #   details: (undocumented)
+  #   details: https://docs.autolabproject.com/lab-hooks/#autograding-input-files
   #
   # parseAutoresult
   #   brief: extract problem scores from the JSON autoresult string
   #   params: autoresult (string), _isOfficial (boolean)
   #           _isOfficial is true except for log submissions. If "Allow unofficial" is disabled, don't worry about this.
   #   returns: Hash of problem names to problems scores
-  #   details: (undocumented)
+  #   details: https://docs.autolabproject.com/lab-hooks/#autoresult-parsing
 
 end

--- a/lib/__defaultAssessment.rb
+++ b/lib/__defaultAssessment.rb
@@ -65,7 +65,7 @@ module ##NAME_CAMEL##
   # scoreboardOrderSubmissions
   #   brief: define ordering for the scoreboard
   #   params: a (hash), b (hash)
-  #           The hash contains the following keys: {:uid, :andrewID, :version, :time, :problems, :entry}
+  #           The hash contains the following keys: {:nickname, :andrewID, :fullName, :problems, :time, :version, :autoresult, :entry}
   #           where :entry is the scoreboard entry array
   #   returns: integer, -1 if a should be ranked higher, 1 if b should be ranked higher, 0 if they are tied
   #   details: https://docs.autolabproject.com/lab-hooks/#scoreboard-ordering

--- a/lib/__defaultAssessment.rb
+++ b/lib/__defaultAssessment.rb
@@ -15,19 +15,19 @@ module ##NAME_CAMEL##
   #   brief: modify calculated scores for a submission
   #   params: scores, previous_submissions, problems
   #   returns: hash of problem names to problem scores, the new submission scores
-  #   details: https://docs.autolabproject.com/lab/#overriding-modify-submission-score
+  #   details: https://docs.autolabproject.com/lab-hooks/#modify-submission-score
   #
   # raw_score
   #   brief: modify how raw scores are calculated
   #   params: score (hash of problem names to problem scores)
   #   returns: float, score on this assessment excluding any penalties
-  #   details: https://docs.autolabproject.com/instructors/#overriding-raw-score-calculations
+  #   details: https://docs.autolabproject.com/lab-hooks/#raw-score-calculations
   #
   # checkMimeType
   #   brief: reject files that are not of the correct type
   #   params: contentType (string), fileName (string)
   #   returns: boolean, true if the file is of the correct type, false otherwise
-  #   details: https://docs.autolabproject.com/instructors/#customizing-submision-file-mime-type-check
+  #   details: https://docs.autolabproject.com/lab-hooks/#raw-score-calculations
   #
   # handout
   #   brief: provide a handout file for the assessment

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -66,12 +66,6 @@ extra:
         property: G-PH5EYTKBNQ
 markdown_extensions:
     - admonition
-    - pymdownx.highlight:
-          anchor_linenums: true
-          line_spans: __span
-          pygments_lang_class: true
-    - pymdownx.inlinehilite
-    - pymdownx.snippets
     - pymdownx.superfences
 strict: true
 plugins:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -22,6 +22,7 @@ nav:
         - Autolab Frontend:
             - Guide for Instructors: instructors.md
             - Guide for Lab Authors: lab.md
+            - Lab Hooks: lab-hooks.md
             - Features:
                 - Formatted Feedback: features/formatted-feedback.md
                 - Scoreboards: features/scoreboards.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -52,21 +52,27 @@ theme:
     features:
         - navigation.tabs
         - toc.integrate
+        - content.code.copy
 repo_name: "Autolab"
 repo_url: "https://github.com/Autolab/autolab"
 extra:
     social:
         - icon: fontawesome/brands/github-alt
           link: https://github.com/Autolab
-        - icon: fontawesome/brands/facebook
-          link: "https://facebook.com/autolabproject"
+        - icon: fontawesome/brands/slack
+          link: https://communityinviter.com/apps/autolab/autolab-project
     analytics:
         provider: google
         property: G-PH5EYTKBNQ
 markdown_extensions:
     - admonition
-    - codehilite
-      #linenums: true
+    - pymdownx.highlight:
+          anchor_linenums: true
+          line_spans: __span
+          pygments_lang_class: true
+    - pymdownx.inlinehilite
+    - pymdownx.snippets
+    - pymdownx.superfences
 strict: true
 plugins:
   - search


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Adds a lab hooks section to the documentation

Updates some hooks
- `listOptions`: backwards compatible change that lets default options be correctly hidden. Also adds error handling.
- `autogradeInputFiles`: additionally pass it `assessment` and `submission` as params. A breaking change, but a necessary one and it doesn't seem to be used.

Also makes the following changes to Docs
- Fix syntax highlighting
- Make "code copy" button work locally
- Replace Facebook link with Slack

Adds references to docs in `__defaultAssessment.rb` and fixes errors.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Closes #1926

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- View documentation locally, read through lab hooks section and check for any glaring issues.
- Verify that comments in `__defaultAssessment.rb` link (would) link to the right pages.
- Verify new behavior of `listOptions` by viewing documentation and trying to hide default options and/or defining your own options. Also test the error handling for invalid options.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have run rubocop and erblint for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [x] My change requires a change to the documentation, which is located at [Autolab Docs](https://docs.autolabproject.com/)
- [x] I have updated the documentation accordingly, included in this PR
