### PR TITLE
Allow students to download all of their submitted files

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -154,7 +154,8 @@ class UsersController < ApplicationController
     submissions = Submission.where(course_user_datum: CourseUserDatum.where(user_id: user))
     submissions = submissions.select do |s|
       p = s.handin_file_path
-      !p.nil? && File.exist?(p) && File.readable?(p)
+      is_disabled = s.course_user_datum.course.disabled
+      !p.nil? && File.exist?(p) && File.readable?(p) && !is_disabled
     end
     if submissions.empty?
       flash[:error] = "There are no submissions to download."

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -162,8 +162,9 @@ class UsersController < ApplicationController
     ###
     filedata = submissions.collect do |s|
       p = s.handin_file_path
-      email = s.course_user_datum.user.email
-      [p, download_filename(p, email)]
+      course_name = s.course_user_datum.course.name
+      assignment_name = s.assessment.name
+      [p, download_filename(p, course_name, assignment_name)]
     end
     result = Archive.create_zip filedata
     if result.nil?
@@ -173,7 +174,7 @@ class UsersController < ApplicationController
     send_data(result.read, # to read from stringIO object returned by create_zip
               type: "application/zip",
               disposition: "attachment", # tell browser to download
-              filename: "submissions.zip")
+              filename: "autolab_submissions.zip")
   end
 
   # PATCH users/:id/
@@ -419,11 +420,13 @@ private
 
   # Given the path to a file, return the filename to use when the user downloads it
   # path should be of the form .../<ver>_<handin> or .../annotated_<ver>_<handin>
-  # returns <email>_<ver>_<handin> or annotated_<email>_<ver>_<handin>
-  def download_filename(path, student_email)
+  # returns <course_name>_<assignment_name>_<ver>_<handin>
+  # or annotated_<course_name>_<assignment_name>_<ver>_<handin>
+  def download_filename(path, course_name, assignment_name)
     basename = File.basename path
     basename_parts = basename.split("_")
-    basename_parts.insert(-3, student_email)
+    basename_parts.insert(-3, course_name)
+    basename_parts.insert(-3, assignment_name)
     basename_parts.join("_")
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -151,7 +151,11 @@ class UsersController < ApplicationController
   action_auth_level :download_all_submissions, :student
   def download_all_submissions
     user = User.find(params[:id])
-    submissions = Submission.where(course_user_datum: CourseUserDatum.where(user_id: user))
+    submissions = if params[:final]
+                    Submission.latest.where(course_user_datum: CourseUserDatum.where(user_id: user))
+                  else
+                    Submission.where(course_user_datum: CourseUserDatum.where(user_id: user))
+                  end
     submissions = submissions.select do |s|
       p = s.handin_file_path
       is_disabled = s.course_user_datum.course.disabled

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -152,14 +152,14 @@ class UsersController < ApplicationController
   def download_all_submissions
     user = User.find(params[:id])
     submissions = Submission.where(course_user_datum: CourseUserDatum.where(user_id: user))
-    ###
-    # submissions = submissions.select do |s|
-    #  p = s.handin_file_path
-    #  !p.nil? && File.exist?(p) && File.readable?(p)
-    #  puts "HELLO"
-    #  puts p
-    # end
-    ###
+    submissions = submissions.select do |s|
+      p = s.handin_file_path
+      !p.nil? && File.exist?(p) && File.readable?(p)
+    end
+    if submissions.empty?
+      flash[:error] = "There are no submissions to download."
+      return
+    end
     filedata = submissions.collect do |s|
       p = s.handin_file_path
       course_name = s.course_user_datum.course.name
@@ -427,7 +427,8 @@ private
     basename_parts = basename.split("_")
     basename_parts.insert(-3, course_name)
     basename_parts.insert(-3, assignment_name)
-    basename_parts.join("_")
+    download_name = basename_parts[-4..]
+    download_name.join("_")
   end
 
   def new_user_params

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -166,14 +166,20 @@ class UsersController < ApplicationController
       redirect_to(user_path(user)) && return
     end
 
+    current_time = Time.current
+    filename = if params[:final]
+                 "autolab_final_submissions_#{current_time.strftime('%Y-%m-%d')}"
+               else
+                 "autolab_all_submissions_#{current_time.strftime('%Y-%m-%d')}"
+               end
+
     temp_file = Tempfile.new("autolab_submissions.zip")
     Zip::File.open(temp_file.path, Zip::File::CREATE) do |zipfile|
       submissions.each do |s|
         p = s.handin_file_path
         course_name = s.course_user_datum.course.name
         assignment_name = s.assessment.name
-        wrapper_directory = "auto_submissions"
-        course_directory = "#{wrapper_directory}/#{course_name}"
+        course_directory = "#{filename}/#{course_name}"
         assignment_directory = "#{course_directory}/#{assignment_name}"
         entry_name = download_filename(p, assignment_name)
         zipfile.add(File.join(assignment_directory, entry_name), p)
@@ -182,8 +188,8 @@ class UsersController < ApplicationController
 
     send_file(temp_file.path,
               type: "application/zip",
-              disposition: "attachment",
-              filename: "autolab_submissions.zip")
+              disposition: "attachment", # tell browser to download
+              filename: "#{filename}.zip")
   end
 
   # PATCH users/:id/

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -158,7 +158,7 @@ class UsersController < ApplicationController
     end
     if submissions.empty?
       flash[:error] = "There are no submissions to download."
-      return
+      redirect_to(user_path(user)) && return
     end
     filedata = submissions.collect do |s|
       p = s.handin_file_path

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -105,18 +105,18 @@
     <%= f.submit 'Save', { class: "btn primary" } %>
   <% end %>
   <h4>Download Submissions</h4>
-  <%= link_to download_all_submissions_user_path(@user),
-              { title: "Download all your submissions",
-                class: "" } do %>
-    <span class="btn primary">
-      Download All
-    </span>
-  <% end %>
   <%= link_to download_all_submissions_user_path(@user, final: true),
               { title: "Download all your final submissions",
                 class: "" } do %>
     <span class="btn primary">
       Download Final
+    </span>
+  <% end %>
+  <%= link_to download_all_submissions_user_path(@user),
+              { title: "Download all your submissions",
+                class: "" } do %>
+    <span class="btn primary">
+      Download All
     </span>
   <% end %>
 <% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -104,4 +104,13 @@
     </ul>
     <%= f.submit 'Save', { class: "btn primary" } %>
   <% end %>
+  <h4>Download All Submissions</h4>
+  <%= link_to download_all_submissions_user_path(@user),
+              { title: "Download all your submissions",
+                class: "" } do %>
+    <span class="btn primary">
+      Download
+    </span>
+  <% end %>
+
 <% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -104,13 +104,19 @@
     </ul>
     <%= f.submit 'Save', { class: "btn primary" } %>
   <% end %>
-  <h4>Download All Submissions</h4>
+  <h4>Download Submissions</h4>
   <%= link_to download_all_submissions_user_path(@user),
               { title: "Download all your submissions",
                 class: "" } do %>
     <span class="btn primary">
-      Download
+      Download All
     </span>
   <% end %>
-
+  <%= link_to download_all_submissions_user_path(@user, final: true),
+              { title: "Download all your final submissions",
+                class: "" } do %>
+    <span class="btn primary">
+      Download Final
+    </span>
+  <% end %>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -75,6 +75,7 @@ Rails.application.routes.draw do
 
   resources :users do
     get "admin"
+    get "download_all_submissions", on: :member
     get "github_oauth", on: :member
     get "lti_launch_initialize", on: :member
     post "lti_launch_link_course", on: :member


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- added buttons on user's account page that when clicked, will either download all user's submissions from non-disabled courses in a zip file or flash a message if there are no submissions to download (give user option of downloading only final submissions or all submissions)
<img width="875" alt="Screen Shot 2024-04-08 at 6 34 45 PM" src="https://github.com/autolab/Autolab/assets/85699876/1a303cf9-9fc9-44d2-a1b7-b0b3f1adbc85">
- saves each submitted valid file in zip file for easy interpretation of contents
Only final submissions:
<img width="768" alt="Screen Shot 2024-04-08 at 6 25 33 PM" src="https://github.com/autolab/Autolab/assets/85699876/d12b034b-74bb-4875-a874-c345f2668abe">
All submisisons:
<img width="769" alt="Screen Shot 2024-04-08 at 6 26 32 PM" src="https://github.com/autolab/Autolab/assets/85699876/08610aed-fcbf-4c67-999e-bd63cb0325a5">

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This PR was motivated by a feature request. Previously, students had to download hand in files individually in order to save. With this new feature, students can, with one click, download all of their downloadable submissions in one zip file.
Resolves #2068 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested the feature with normal course settings (no disabled courses), disabled courses (no download of submissions allowed), and no submissions to download (flashed message instead).
Also tested in case where user is instructor of one class and a student enrolled in another. In this case, the downloaded zip file should only contain the user's submissions as a student, not any of the submissions in the course they are an instructor of.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have run rubocop and erblint for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://docs.autolabproject.com/)
- [ ] I have updated the documentation accordingly, included in this PR

## Other issues / help required
<!--- Do you have any other relevant issues / questions? --->
<!--- For example, if you require assistance for a certain part of your PR --->
<!--- or are facing specific issues while creating the pull request that you would like to highlight --->

If unsure, feel free to submit first and we'll help you along.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced the ability for users to download all their submissions from their profile page.
- **Enhancements**
	- Updated user display settings for a more intuitive user experience.
- **Bug Fixes**
	- Made improvements to handle submission downloads and filenames in the `UsersController`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->