### PR TITLE
Use File.size? when checking for config files

### DIFF
--- a/app/controllers/admins_controller.rb
+++ b/app/controllers/admins_controller.rb
@@ -37,7 +37,7 @@ class AdminsController < ApplicationController
   def autolab_config
     @github_integration = GithubIntegration.check_github_authorization
 
-    if File.exist?("#{Rails.configuration.config_location}/lti_config.yml")
+    if File.size?("#{Rails.configuration.config_location}/lti_config.yml")
       @lti_config_hash =
         YAML.safe_load(File.read("#{Rails.configuration.config_location}/lti_config.yml"))
     end
@@ -45,7 +45,7 @@ class AdminsController < ApplicationController
     if Rails.cache.exist?(:tmp_smtp_config)
       @smtp_config_hash = Rails.cache.read(:tmp_smtp_config)
       Rails.cache.delete(:tmp_smtp_config)
-    elsif File.exist?("#{Rails.configuration.config_location}/smtp_config.yml")
+    elsif File.size?("#{Rails.configuration.config_location}/smtp_config.yml")
       @smtp_config_hash =
         YAML.safe_load(File.read("#{Rails.configuration.config_location}/smtp_config.yml"))
       @smtp_config_hash.symbolize_keys!

--- a/app/controllers/lti_config_controller.rb
+++ b/app/controllers/lti_config_controller.rb
@@ -25,7 +25,7 @@ class LtiConfigController < ApplicationController
     }
     uploaded_tool_jwk_file = params['tool_jwk']
     # Ensure user uploaded private JWK for config, or it already exists
-    if !File.exist?("#{Rails.configuration.config_location}/lti_tool_jwk.json") &&
+    if !File.size?("#{Rails.configuration.config_location}/lti_tool_jwk.json") &&
        uploaded_tool_jwk_file.nil?
       flash[:error] = "No tool JWK JSON file was uploaded"
       redirect_to(autolab_config_admin_path(active: :lti)) && return

--- a/app/controllers/lti_launch_controller.rb
+++ b/app/controllers/lti_launch_controller.rb
@@ -176,7 +176,7 @@ class LtiLaunchController < ApplicationController
       end
 
       platform_public_jwks = JSON.parse(response.body)["keys"]
-    elsif File.exist?("#{Rails.configuration.config_location}/lti_platform_jwk.json")
+    elsif File.size?("#{Rails.configuration.config_location}/lti_platform_jwk.json")
       # static platform public key, so take key from yml
       platform_public_key_file =
         File.read("#{Rails.configuration.config_location}/lti_platform_jwk.json")
@@ -206,7 +206,7 @@ class LtiLaunchController < ApplicationController
   def launch
     # Code based on:
     # https://github.com/IMSGlobal/lti-1-3-php-library/blob/master/src/lti/LTI_Message_Launch.php
-    unless File.exist?("#{Rails.configuration.config_location}/lti_config.yml")
+    unless File.size?("#{Rails.configuration.config_location}/lti_config.yml")
       raise LtiError.new("LTI configuration not found on Autolab Server", :internal_server_error)
     end
 
@@ -240,7 +240,7 @@ class LtiLaunchController < ApplicationController
   # build our authentication response and redirect back to
   # platform
   def oidc_login
-    unless File.exist?("#{Rails.configuration.config_location}/lti_config.yml")
+    unless File.size?("#{Rails.configuration.config_location}/lti_config.yml")
       raise LtiError.new("LTI configuration not found on Autolab Server", :internal_server_error)
     end
 

--- a/app/controllers/lti_nrps_controller.rb
+++ b/app/controllers/lti_nrps_controller.rb
@@ -13,7 +13,7 @@ class LtiNrpsController < ApplicationController
   action_auth_level :request_access_token, :instructor
   def request_access_token
     # get private key from JSON file to sign Autolab's client assertion as a JWK
-    unless File.exist?("#{Rails.configuration.config_location}/lti_tool_jwk.json")
+    unless File.size?("#{Rails.configuration.config_location}/lti_tool_jwk.json")
       flash[:error] = "Autolab's JWK JSON file was not found"
       redirect_to([:users, @course]) && return
     end
@@ -97,7 +97,7 @@ class LtiNrpsController < ApplicationController
     @lti_context_membership_url = lcd.membership_url
     @course = lcd.course
 
-    unless File.exist?("#{Rails.configuration.config_location}/lti_config.yml")
+    unless File.size?("#{Rails.configuration.config_location}/lti_config.yml")
       flash[:error] = "Could not find LTI Configuration"
       redirect_to([:users, @course]) && return
     end

--- a/app/controllers/oauth_config_controller.rb
+++ b/app/controllers/oauth_config_controller.rb
@@ -18,7 +18,7 @@ class OauthConfigController < ApplicationController
     end
 
     yaml_hash = {}
-    if File.exist?("#{Rails.configuration.config_location}/oauth_config.yml")
+    if File.size?("#{Rails.configuration.config_location}/oauth_config.yml")
       yaml_hash = YAML.safe_load(
         File.read("#{Rails.configuration.config_location}/oauth_config.yml")
       )
@@ -42,7 +42,7 @@ class OauthConfigController < ApplicationController
 
   def self.get_oauth_providers
     Rails.cache.fetch(:oauth_providers) do
-      return [] unless File.exist?("#{Rails.configuration.config_location}/oauth_config.yml")
+      return [] unless File.size?("#{Rails.configuration.config_location}/oauth_config.yml")
 
       config_hash = YAML.safe_load(
         File.read("#{Rails.configuration.config_location}/oauth_config.yml")
@@ -59,7 +59,7 @@ class OauthConfigController < ApplicationController
 
   def self.get_oauth_credentials(provider)
     oauth_config = Rails.cache.fetch(:oauth_config) do
-      return {} unless File.exist?("#{Rails.configuration.config_location}/oauth_config.yml")
+      return {} unless File.size?("#{Rails.configuration.config_location}/oauth_config.yml")
 
       YAML.safe_load(
         File.read("#{Rails.configuration.config_location}/oauth_config.yml")

--- a/app/views/admins/_lti_integration.html.erb
+++ b/app/views/admins/_lti_integration.html.erb
@@ -36,16 +36,16 @@
       <h5>
         Upload Autolab's JWK as a JSON file
       </h5>
-      <% if File.exist?("config/lti_tool_jwk.json") %>
+      <% if File.size?("config/lti_tool_jwk.json") %>
         <p> File already uploaded. Uploading will rewrite the previous JWK </p>
       <% end %>
-      <%= form.file_field :tool_jwk, accept: 'text/json', required: !File.exist?("config/lti_tool_jwk.json") %>
+      <%= form.file_field :tool_jwk, accept: 'text/json', required: !File.size?("config/lti_tool_jwk.json") %>
     </div>
       <div class="lti-upload-container">
         <h5>
           Upload the Platform's Public JWK (Unnecessary if public JWK URL specified)
         </h5>
-        <% if File.exist?("config/lti_platform_jwk.json") %>
+        <% if File.size?("config/lti_platform_jwk.json") %>
           <p> File already uploaded. Uploading will rewrite the previous JWK </p>
         <% end %>
         <%= form.file_field :platform_public_jwk_json, accept: 'text/json', required: false %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -85,13 +85,13 @@ Rails.application.configure do
 
   # OAuth2 Application Configuration for Github
   # See https://docs.autolabproject.com/installation/github_integration/
-  if File.exist?("#{Rails.configuration.config_location}/github_config.yml")
+  if File.size?("#{Rails.configuration.config_location}/github_config.yml")
     config_hash = YAML.safe_load(File.read("#{Rails.configuration.config_location}/github_config.yml"))
     config.x.github.client_id = config_hash['github']['client_id']
     config.x.github.client_secret = config_hash['github']['client_secret']
   end
 
-  if File.exist?("#{Rails.configuration.config_location}/smtp_config.yml")
+  if File.size?("#{Rails.configuration.config_location}/smtp_config.yml")
     config_hash = YAML.safe_load(File.read("#{Rails.configuration.config_location}/smtp_config.yml"))
 
     config.action_mailer.perform_deliveries = true

--- a/config/environments/production.rb.template
+++ b/config/environments/production.rb.template
@@ -99,7 +99,7 @@ Autolab3::Application.configure do
 
   # OAuth2 Application Configuration for Github
   # See https://docs.autolabproject.com/installation/github_integration/
-  if File.exist?("#{Rails.configuration.config_location}/github_config.yml")
+  if File.size?("#{Rails.configuration.config_location}/github_config.yml")
     config_hash = YAML.safe_load(File.read("#{Rails.configuration.config_location}/github_config.yml"))
     config.x.github.client_id = config_hash['github']['client_id']
     config.x.github.client_secret = config_hash['github']['client_secret']
@@ -109,7 +109,7 @@ Autolab3::Application.configure do
   config.config_location = Rails.root.join('config').to_s
 
   # Use a custom smtp server, such as gmail, mailgun, sendgrid
-  if File.exist?("#{Rails.configuration.config_location}/smtp_config.yml")
+  if File.size?("#{Rails.configuration.config_location}/smtp_config.yml")
     config_hash = YAML.safe_load(File.read("#{Rails.configuration.config_location}/smtp_config.yml"))
 
     config.action_mailer.perform_deliveries = true


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Use `File.size?` instead of `File.exist?` when checking the existence of config files, namely
- `smtp_config.yml`
- `github_config.yml`
- `oauth_config.yml`
- `lti_config.yml`
- `lti_platform_jwk.json`
- `lti_tool_jwk.json`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
For Docker compose installs, the `Makefile` automatically creates empty config files (using `touch`) when a user updates their installation. This is to avoid problems where the Docker volume mapping creates a directory instead of a file when the path does not exist.

However, the codebase currently uses `File.exist?` when checking for the existence of config files, which breaks since the empty config files do exist, causing the code to attempt to load configuration from blank files.

By replacing the size with `File.size?` instead, it returns `nil` when the file does not exist OR the file exists but is empty. This is the desired semantics.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Create blank config files in the `config` subdirectory, e.g. `touch smtp_config.yml github_config.yml oauth_config.yml lti_config.yml lti_platform_jwk.json lti_tool_jwk.json`. Run Autolab.

Previously, there would be a variety of errors, starting with a failure to load github config.

After, Autolab should run fine, and e.g. the upload buttons for the LTI `json` files will not have the message saying that the files already exist.

Ensure that all relevant File existence checks in the codebase have been replaced with `File.exist?`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have run rubocop and erblint for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://docs.autolabproject.com/)
- [ ] I have updated the documentation accordingly, included in this PR
