### PR TITLE
Better error messages for autograder settings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -75,9 +75,6 @@ gem 'doorkeeper'
 # For block and throttling abusive requests
 gem 'rack-attack'
 
-# Adds It also adds f.error_messages and f.error_message_on to form builders
-gem 'dynamic_form'
-
 # Supports zip file generation.
 gem 'rubyzip'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -139,9 +139,6 @@ GEM
     dotenv-rails (2.8.1)
       dotenv (= 2.8.1)
       railties (>= 3.2)
-    dynamic_form (1.3.1)
-      actionview (> 5.2.0)
-      activemodel (> 5.2.0)
     erb_lint (0.5.0)
       activesupport
       better_html (>= 2.0.1)
@@ -490,7 +487,6 @@ DEPENDENCIES
   diffy
   doorkeeper
   dotenv-rails
-  dynamic_form
   erb_lint
   exception_notification (>= 4.1.0)
   factory_bot_rails

--- a/app/controllers/assessments_controller.rb
+++ b/app/controllers/assessments_controller.rb
@@ -839,7 +839,9 @@ class AssessmentsController < ApplicationController
                           without grace days are not penalized"
       end
       unless warn_messages.empty?
-        flash.now[:error] = "Late submissions are allowed, but<br>#{warn_messages.join('<br>')}"
+        flash.now[:notice] = "Late submissions are allowed, but<br>"
+        flash.now[:notice] += warn_messages.join('<br>')
+        flash.now[:notice] += "<br>Please make sure that this was intended."
         flash.now[:html_safe] = true
       end
     end
@@ -888,7 +890,8 @@ class AssessmentsController < ApplicationController
 
       redirect_to(tab_index) && return
     rescue ActiveRecord::RecordInvalid
-      flash[:error] = @assessment.errors.full_messages.join("<br>")
+      flash[:error] = "Assessment configuration could not be updated.<br>"
+      flash[:error] += @assessment.errors.full_messages.join("<br>")
       flash[:html_safe] = true
 
       redirect_to(tab_index) && return

--- a/app/controllers/autograders_controller.rb
+++ b/app/controllers/autograders_controller.rb
@@ -16,11 +16,13 @@ class AutogradersController < ApplicationController
       a.release_score = true
     end
     if @autograder.save
-      flash[:success] = "Autograder Created"
-      redirect_to([:edit, @course, @assessment, :autograder]) and return
+      flash[:success] = "Autograder created."
+      redirect_to(edit_course_assessment_autograder_path(@course, @assessment))
     else
-      flash[:error] = "Autograder could not be created"
-      redirect_to([:edit, @course, @assessment]) and return
+      flash[:error] = "Autograder could not be created.<br>"
+      flash[:error] += @autograder.errors.full_messages.join("<br>")
+      flash[:html_safe] = true
+      redirect_to(edit_course_assessment_path(@course, @assessment))
     end
   end
 
@@ -30,26 +32,30 @@ class AutogradersController < ApplicationController
   action_auth_level :update, :instructor
   def update
     if @autograder.update(autograder_params)
-      flash[:success] = "Autograder saved!"
+      flash[:success] = "Autograder saved."
       begin
         upload
       rescue StandardError
         flash[:error] = "Autograder could not be uploaded."
       end
     else
-      flash[:error] = "Autograder could not be saved."
+      flash[:error] = "Autograder could not be saved.<br>"
+      flash[:error] += @autograder.errors.full_messages.join("<br>")
+      flash[:html_safe] = true
     end
-    redirect_to([:edit, @course, @assessment, :autograder]) and return
+    redirect_to(edit_course_assessment_autograder_path(@course, @assessment))
   end
 
   action_auth_level :destroy, :instructor
   def destroy
     if @autograder.destroy
       flash[:success] = "Autograder destroyed."
-      redirect_to([:edit, @course, @assessment]) and return
+      redirect_to(edit_course_assessment_path(@course, @assessment))
     else
       flash[:error] = "Autograder could not be destroyed."
-      redirect_to([:edit, @course, @assessment, :autograder]) and return
+      flash[:error] += @autograder.errors.full_messages.join("<br>")
+      flash[:html_safe] = true
+      redirect_to(edit_course_assessment_autograder_path(@course, @assessment))
     end
   end
 
@@ -76,7 +82,7 @@ private
 
   def set_autograder
     @autograder = @assessment.autograder
-    redirect_to([@course, @assessment]) if @autograder.nil?
+    redirect_to(course_assessment_path(@course, @assessment)) if @autograder.nil?
   end
 
   def autograder_params

--- a/app/models/autograder.rb
+++ b/app/models/autograder.rb
@@ -8,7 +8,8 @@ class Autograder < ApplicationRecord
   trim_field :autograde_image
 
   # extremely short timeout values cause the backend to throw system errors
-  validates :autograde_timeout, numericality: { greater_than: 10, less_than: 900 }
+  validates :autograde_timeout,
+            numericality: { greater_than_or_equal_to: 10, less_than_or_equal_to: 900 }
   validates :autograde_image, :autograde_timeout, presence: true
   validates :autograde_image, length: { maximum: 64 }
 

--- a/app/views/assessment_user_data/edit.html.erb
+++ b/app/views/assessment_user_data/edit.html.erb
@@ -2,8 +2,6 @@
   <h5>Grade type for <%= @aud.course_user_datum.user.email %> on <%= @aud.assessment.display_name %></h5>
 
   <%= form_for @aud, url: { action: :update } do |f| %>
-    <%= f.error_messages %>
-
       <p>
         <%= f.label(:grade_type, value: AssessmentUserDatum::NORMAL) do %>
           <%= f.radio_button :grade_type, AssessmentUserDatum::NORMAL %>

--- a/app/views/autograders/_form.html.erb
+++ b/app/views/autograders/_form.html.erb
@@ -1,25 +1,3 @@
-<% content_for :javascripts do %>
-  <script>
-    $(function() {
-      $(document).on('change', ':file', function() {
-        var input = $(this),
-          numFiles = input.get(0).files ? input.get(0).files.length : 1,
-          label = input.val().replace(/\\/g, '/').replace(/.*\//, '');
-          input.trigger('fileselect', [numFiles, label]);
-      });
-
-      $(document).ready( function() {
-        $('#autograder_makefile:file').on('fileselect', function(event, numFiles, label) {
-          $('#makefile_name').val(label);
-        });
-        $('#autograder_tar:file').on('fileselect', function(event, numFiles, label) {
-            $('#tar_name').val(label);
-        });
-      });
-    });
-  </script>
-<% end %>
-
 <%= form_for @autograder, url: course_assessment_autograder_path(@course, @assessment, @autograder),
                           builder: FormBuilderWithDateTimeInput,
                           html: { multipart: true } do |f| %>
@@ -29,8 +7,8 @@
                                      help_text: "VM image for autograding (e.g. <kbd>rhel.img</kbd>). #{link_to 'Click here', tango_status_course_jobs_path} to view the list of VM images and pools currently being used".html_safe +
                                                 (Rails.configuration.x.docker_image_upload_enabled.presence ? ", or #{link_to 'click here', course_dockers_path} to upload a new docker image.".html_safe : ".") %>
 
-  <%= f.text_field :autograde_timeout, display_name: "Timeout",
-                                       help_text: "Timeout for autograding jobs (secs)" %>
+  <%= f.number_field :autograde_timeout, display_name: "Timeout",
+                                         help_text: "Timeout for autograding jobs (secs). Must be between 10s and 900s.", min: 10, max: 900 %>
   <%= f.check_box :release_score,
                   display_name: "Release Scores?",
                   help_text: "Check to release autograded scores to students immediately after autograding (strongly recommended)." %>

--- a/app/views/autograders/_form.html.erb
+++ b/app/views/autograders/_form.html.erb
@@ -3,10 +3,11 @@
                           html: { multipart: true } do |f| %>
   <%= f.text_field :autograde_image, display_name: "VM Image",
                                      help_text: "VM image for autograding (e.g. <kbd>rhel.img</kbd>). #{link_to 'Click here', tango_status_course_jobs_path} to view the list of VM images and pools currently being used".html_safe +
-                                                (Rails.configuration.x.docker_image_upload_enabled.presence ? ", or #{link_to 'click here', course_dockers_path} to upload a new docker image.".html_safe : ".") %>
+                                                (Rails.configuration.x.docker_image_upload_enabled.presence ? ", or #{link_to 'click here', course_dockers_path} to upload a new docker image.".html_safe : "."),
+                                     required: true, maxlength: 64 %>
 
   <%= f.number_field :autograde_timeout, display_name: "Timeout",
-                                         help_text: "Timeout for autograding jobs (secs). Must be between 10s and 900s.", min: 10, max: 900 %>
+                                         help_text: "Timeout for autograding jobs (secs). Must be between 10s and 900s, inclusive.", min: 10, max: 900 %>
   <%= f.check_box :release_score,
                   display_name: "Release Scores?",
                   help_text: "Check to release autograded scores to students immediately after autograding (strongly recommended)." %>

--- a/app/views/autograders/_form.html.erb
+++ b/app/views/autograders/_form.html.erb
@@ -1,8 +1,6 @@
 <%= form_for @autograder, url: course_assessment_autograder_path(@course, @assessment, @autograder),
                           builder: FormBuilderWithDateTimeInput,
                           html: { multipart: true } do |f| %>
-  <%= f.error_messages %>
-
   <%= f.text_field :autograde_image, display_name: "VM Image",
                                      help_text: "VM image for autograding (e.g. <kbd>rhel.img</kbd>). #{link_to 'Click here', tango_status_course_jobs_path} to view the list of VM images and pools currently being used".html_safe +
                                                 (Rails.configuration.x.docker_image_upload_enabled.presence ? ", or #{link_to 'click here', course_dockers_path} to upload a new docker image.".html_safe : ".") %>

--- a/app/views/courses/_create_new_course.html.erb
+++ b/app/views/courses/_create_new_course.html.erb
@@ -1,8 +1,6 @@
 <h3>Create New Course</h3>
 
 <%= form_for :newCourse, url: courses_path, builder: FormBuilderWithDateTimeInput do |f| %>
-  <%= f.error_messages %>
-
   <%= f.text_field :name, required: true,
                           help_text: "The course ID used in URLs and DB keys. This field must be unique
   and URL-able. Typically includes the course number and semester. Examples:

--- a/app/views/problems/_fields.html.erb
+++ b/app/views/problems/_fields.html.erb
@@ -1,5 +1,3 @@
-<%= f.error_messages %>
-
 <%= f.text_field :name, help_text: "Each problem has a name that is unique to the assessment.",
                         placeholder: "problem1", required: true %>
 

--- a/app/views/schedulers/edit.html.erb
+++ b/app/views/schedulers/edit.html.erb
@@ -7,7 +7,6 @@
 
 <%= form_for @scheduler, url: course_scheduler_path(@course, @scheduler),
                          method: "patch", builder: FormBuilderWithDateTimeInput do |f| %>
-  <%= f.error_messages %>
   <%= f.text_field :action, help_text: "Path to scheduler file relative to Autolab root",
                             placeholder: "(scheduler action)" %>
   <%= f.datetime_select :next, help_text: "Time of next run" %>

--- a/app/views/schedulers/new.html.erb
+++ b/app/views/schedulers/new.html.erb
@@ -6,7 +6,6 @@
 <h4>New scheduler</h4>
 
 <%= form_for :scheduler, url: course_schedulers_path(@course), builder: FormBuilderWithDateTimeInput do |f| %>
-  <%= f.error_messages %>
   <%= f.text_field :action, help_text: "Path to scheduler file relative to Autolab root",
                             placeholder: "(scheduler action)" %>
   <%= f.datetime_select :next, help_text: "Time of next run" %>

--- a/app/views/submissions/edit.html.erb
+++ b/app/views/submissions/edit.html.erb
@@ -6,7 +6,6 @@
 <%= form_for @submission, url: [@submission.course_user_datum.course, @assessment, @submission],
                           builder: FormBuilderWithDateTimeInput,
                           method: :patch do |f| %>
-<%= f.error_messages %>
 <table class="verticalTable">
   <tr>
     <th>User:</th>

--- a/app/views/submissions/new.html.erb
+++ b/app/views/submissions/new.html.erb
@@ -7,8 +7,6 @@
                           builder: FormBuilderWithDateTimeInput,
                           html: { multipart: true } do |f| %>
 
-    <%= f.error_messages %>
-
 <table class="verticalTable">
 <tr>
   <th>User:</th>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Change bounds of autograder timeout to be inclusive (10 to 900 seconds)
- Remove unnecessary javascript code from form (handled by Materialize)
- Change to new style path helpers
- Better frontend validation of `autograde_image` (present and length <= 64) and `autograde_timeout` (numeric field + bounds), show bounds in help text
- Remove unmaintained/deprecated `dynamic_form` gem + all occurrences of `error_messages`
- Make edit assessment update failure message consistent
- Use `notice` instead of `error` for warn messages so that it doesn't overwrite update failure messages

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Removes all `f.error_messages` occurrences + removes the `dynamic_form` gem as the gem has not really been maintained since Rails 3 (https://rubygems.org/gems/dynamic_form/versions/1.1.4?locale=en)

Besides, it isn't particularly necessary.

Closes #2141

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Autograde timeout can now be set to 10s / 900s inclusive
- Observe helptext explaining that timeout "Must be between 10s and 900s, inclusive."
- When choosing a Autograder Makefile or Autograder Tar, the file name still updates correctly
- Make frontend validation better reflect backend validation
  - `autograde_image` can't be empty
  - `autograde_image` can't be longer than 64 chars
  - `autograde_timeout` must be numeric, and between 10 and 900 inclusive
- If backend validation fails (you have to disable the frontend validation first), helpful error message displayed
<img width="275" alt="Screenshot 2024-04-06 at 12 22 22" src="https://github.com/autolab/Autolab/assets/9074856/d7f5b052-bd15-4f7d-bdf4-a1b55be67668">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have run rubocop and erblint for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://docs.autolabproject.com/)
- [ ] I have updated the documentation accordingly, included in this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added more structured and informative feedback for late submissions and assessment configuration errors.
	- Enhanced validation for autograder timeout settings, ensuring values are between 10 and 900 seconds.
- **Bug Fixes**
	- Updated flash messages across various actions for clearer communication.
	- Improved form validation and error messaging, particularly for autograder configurations.
- **Refactor**
	- Removed outdated `dynamic_form` gem and associated error message calls in forms, streamlining error handling.
- **Style**
	- Updated form fields for autograder configurations, including changing input types and adding constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->