### PR TITLE
Order assessment attachments correctly

### DIFF
--- a/app/controllers/assessments_controller.rb
+++ b/app/controllers/assessments_controller.rb
@@ -584,9 +584,9 @@ class AssessmentsController < ApplicationController
                       @cud
                     end
     @attachments = if @cud.instructor?
-                     @assessment.attachments
+                     @assessment.attachments.ordered
                    else
-                     @assessment.attachments.released
+                     @assessment.attachments.released.ordered
                    end
     @submissions = @assessment.submissions.where(course_user_datum_id: @effectiveCud.id)
                               .order("version DESC")

--- a/app/controllers/assessments_controller.rb
+++ b/app/controllers/assessments_controller.rb
@@ -71,9 +71,9 @@ class AssessmentsController < ApplicationController
                                       .or(announcements_tmp.where(system: true)).order(:start_date)
     # Only display course attachments on course landing page
     @course_attachments = if @cud.instructor?
-                            @course.attachments.where(assessment_id: nil)
+                            @course.attachments.where(assessment_id: nil).ordered
                           else
-                            @course.attachments.where(assessment_id: nil).released
+                            @course.attachments.where(assessment_id: nil).released.ordered
                           end
   end
 

--- a/app/views/assessments/index.html.erb
+++ b/app/views/assessments/index.html.erb
@@ -195,7 +195,7 @@
     <div class="row">
       <% attachment_categories = @course_attachments.distinct.pluck(:category_name).sort %>
       <% attachment_categories.each_with_index do |cat| %>
-        <% attachments = @course_attachments.from_category(cat).ordered %>
+        <% attachments = @course_attachments.from_category(cat) %>
         <% if attachments.any? %>
           <div class="col s12 m4 attachments">
             <div class="card hoverable">


### PR DESCRIPTION
## Description

This update fixes the sorting order of assessment attachments.

## Motivation and Context

When rendering attachments on the **assessment** page, they're ordered how the database returns them instead of by the desired "release_at ASC, name ASC" ordering constant. **Course** attachments are correct and it already calls `.ordered` in the same way I did here. If an instructor wants to re-order attachments, they currently need to delete them and re-upload them. This fix would allow them to only update the release date to re-order them. I also believe this was the intended behavior, but forgetting to call `.ordered` was an oversight.

## How Has This Been Tested?
I created two course attachments, A and B, with B's release date after A's. I verified B appears **after** A in the list. I updated B's release date to be before A's. I verified B appears **before** A in the list. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

Potentially breaking change: Some instructors may depend on the "manual" method of ordering attachments as described above. That was ultimately a bug, and it never should have behaved that way, but maybe this should wait until the semester is over.

## Checklist:
- [ ] I have run rubocop and erblint for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://docs.autolabproject.com/)
- [ ] I have updated the documentation accordingly, included in this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated the attachment fetching logic in assessments to include ordering based on user role, enhancing usability and accessibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->