### PR TITLE
Fixed Speedgrader file outline on unconventional tar files

### DIFF
--- a/lib/archive.rb
+++ b/lib/archive.rb
@@ -45,7 +45,7 @@ module Archive
     end
     subFiles = []
     filesNestedSomewhere = files.select{|entry| entry[:pathname].start_with?(root[:pathname]) && !(entry[:pathname] == root[:pathname])}
-    for file in filesNestedSomewhere
+    filesNestedSomewhere.each do |file|
       fileDepth = file[:pathname].chomp("/").count "/"
       if(fileDepth == depth+1)
         subFiles << recoverHierarchy(filesNestedSomewhere, file)
@@ -67,11 +67,12 @@ module Archive
     starting_header = -1
 
     # add pre-existing directories to the set
-    for file in files
+    files.each do |file|
 
       # edge case for removing "./" from pathnames
+      # file[:pathname] = file[:pathname].gsub(/\.\.\//) {'..-'}
       if file[:pathname].include?("./")
-        file[:pathname] = file[:pathname].split("./")[1]
+        file[:pathname] = file[:pathname].split("./").last
       end
 
       if(file[:directory])
@@ -79,13 +80,13 @@ module Archive
       end
     end
 
-    for file in files
+    files.each do |file|
       # for each file, check if each of its directories and subdir
       # exist. If it does not, create and add them
       if(!file[:directory])
         paths = file[:pathname].split("/")
         mac_bs_file = false
-        for path in paths do
+        paths.each do |path|
           # note that __MACOSX is actually a folder
           # need to check whether the path includes that
           # for the completeness of cleaned_files
@@ -96,7 +97,7 @@ module Archive
              break
           end
         end
-        for i in 1..(paths.size - 1) do
+        (1..(paths.size - 1)).each do |i|
           new_path = paths[0,paths.size-i].join("/") + "/"
           if(!file_path_set.include?(new_path))
             cleaned_files.append({


### PR DESCRIPTION
## Description
- Changed it so the filename of a path is the last element instead of the 2nd element

## Motivation and Context
The filenames in tar files made using `..` are weird, like [tartraversal2.tar.zip](https://github.com/autolab/Autolab/files/14410963/tartraversal2.tar.zip) made with `tar -cf tartraversal2.tar ../../Desktop/MossTest/autograde-Makefile ../../Desktop/MossTest/dave.c ../../Desktop/MossTest/hello.c`. See screenshot below:
![image](https://github.com/autolab/Autolab/assets/38949473/6c8b45ec-ff1b-4fb1-a342-3570316a3d7f)

See issue #2111.

## How Has This Been Tested?
After:
![image](https://github.com/autolab/Autolab/assets/38949473/3194d561-8517-45a2-b0a9-a0da7c444a9b)

- Tested with  [tartraversal2.tar.zip](https://github.com/autolab/Autolab/files/14410963/tartraversal2.tar.zip) ↑
- Tested with tar files made with both bsdtar and gnutar: bsdtars made on mac specifically have metadata that also appear in the file outline
  - I could not find a way to fix this, so one way to fix this might be to limit the tar command to be gnutar
- Tested with tar files with various directory levels

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have run rubocop and erblint for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting

## Other issues / help required
Do you think this is enough, or should I try to hide the metadata in the tar files?
