### PR TITLE
Moving file manager to manage course

### DIFF
--- a/app/controllers/file_manager_controller.rb
+++ b/app/controllers/file_manager_controller.rb
@@ -197,7 +197,7 @@ private
         rescue StandardError
           '-'
         end,
-        relative: CGI.unescape("/file_manager/#{new_url}#{file}"),
+        relative: "/file_manager/#{new_url}#{file}",
         entry: "#{file}#{is_file ? '' : '/'}",
         absolute: abs_path_str,
         instructor: inst,

--- a/app/views/courses/manage.html.erb
+++ b/app/views/courses/manage.html.erb
@@ -63,7 +63,7 @@
                           { title: "Export course configurations and assessments" } %>
             </li>
             <li>
-              <%= link_to "File Manager", file_manager_index_path + "/" + @course.name, { title: "File manager" } %>
+              <%= link_to "File Manager", "#{file_manager_index_path}/#{@course.name}", { title: "File manager" } %>
             </li>
 
             <li class="collection-item red-text danger-bottom no-hover"><h4>Danger Zone</h4></li>

--- a/app/views/courses/manage.html.erb
+++ b/app/views/courses/manage.html.erb
@@ -62,6 +62,9 @@
               <%= link_to "Export course", export_course_path(@course),
                           { title: "Export course configurations and assessments" } %>
             </li>
+            <li>
+              <%= link_to "File Manager", file_manager_index_path, { title: "File manager" } %>
+            </li>
 
             <li class="collection-item red-text danger-bottom no-hover"><h4>Danger Zone</h4></li>
             <li class="danger-side">

--- a/app/views/courses/manage.html.erb
+++ b/app/views/courses/manage.html.erb
@@ -63,7 +63,7 @@
                           { title: "Export course configurations and assessments" } %>
             </li>
             <li>
-              <%= link_to "File Manager", file_manager_index_path, { title: "File manager" } %>
+              <%= link_to "File Manager", file_manager_index_path + "/" + @course.name, { title: "File manager" } %>
             </li>
 
             <li class="collection-item red-text danger-bottom no-hover"><h4>Danger Zone</h4></li>

--- a/app/views/courses/manage.html.erb
+++ b/app/views/courses/manage.html.erb
@@ -63,7 +63,7 @@
                           { title: "Export course configurations and assessments" } %>
             </li>
             <li>
-              <%= link_to "File Manager", "#{file_manager_index_path}/#{@course.name}", { title: "File manager" } %>
+              <%= link_to "File Manager", path_file_manager_index_path(@course.name), { title: "File manager" } %>
             </li>
 
             <li class="collection-item red-text danger-bottom no-hover"><h4>Danger Zone</h4></li>

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -62,8 +62,6 @@
 
       <li role="presentation"><%= link_to "Clear Cache", clear_cache_admin_url,
                                           title: "Clear Cache", data: { method: "post" } %></li>
-
-      <li role="presentation"><%= link_to "File Manager", file_manager_index_path, title: "File manager" %></li>
     </ul>
   <% end %>
 
@@ -83,8 +81,6 @@
       <li role="presentation"><%= link_to "Configure Autolab", autolab_config_admin_path, title: "Configure Autolab settings" %></li>
 
       <li role="presentation"><%= link_to "Clear Cache", clear_cache_admin_url, title: "Clear Cache", data: { method: "post" } %></li>
-
-      <li role="presentation"><%= link_to "File Manager", file_manager_index_path, title: "File manager" %></li>
     </ul>
   <% end %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -76,7 +76,7 @@ Rails.application.routes.draw do
       post 'upload', to: 'file_manager#upload'
       post '/', to: 'file_manager#upload'
       post 'download_tar', to: 'file_manager#download_tar'
-      get ':path', to: 'file_manager#index', constraints: { path: /.+/ }, as: :path_file_manager
+      get ':path', to: 'file_manager#index', constraints: { path: /.+/ }, as: :path
       put ':path', to: 'file_manager#rename', constraints: { path: /.+/ }, as: :rename_file_manager
       post ':path', to: 'file_manager#upload', constraints: { path: /.+/ }, as: :upload_file_manager
       delete ':path', to: 'file_manager#delete', constraints: { path: /.+/ }, as: :delete_file_manager

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -77,9 +77,9 @@ Rails.application.routes.draw do
       post '/', to: 'file_manager#upload'
       post 'download_tar', to: 'file_manager#download_tar'
       get ':path', to: 'file_manager#index', constraints: { path: /.+/ }, as: :path
-      put ':path', to: 'file_manager#rename', constraints: { path: /.+/ }, as: :rename_file_manager
-      post ':path', to: 'file_manager#upload', constraints: { path: /.+/ }, as: :upload_file_manager
-      delete ':path', to: 'file_manager#delete', constraints: { path: /.+/ }, as: :delete_file_manager
+      put ':path', to: 'file_manager#rename', constraints: { path: /.+/ }, as: :rename
+      post ':path', to: 'file_manager#upload', constraints: { path: /.+/ }, as: :upload_path
+      delete ':path', to: 'file_manager#delete', constraints: { path: /.+/ }, as: :delete
     end
   end
 

--- a/docs/instructors.md
+++ b/docs/instructors.md
@@ -182,7 +182,7 @@ Displays files within a course and allows you to rename, delete, and add files a
 
 You can view all courses that you are an instructor of and all associated files.
 
-You can access the File Manager via the Manage Autolab dropdown.
+You can access the File Manager under Admin Course after clicking Manage Course.
 
 Note:
 


### PR DESCRIPTION
Instructors can't access file manager from manage autolab dropdown since they are not all administrators.

Moved File Manager to manage course. 

## How Has This Been Tested?
- Check that file manager can be accessed after clicking manage course
- File manager cannot be accessed from manage autolab dropdown
- Clicking file manager directly opens up file manager for the course

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have run rubocop and erblint for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [x] My change requires a change to the documentation, which is located at [Autolab Docs](https://docs.autolabproject.com/)
- [x] I have updated the documentation accordingly, included in this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Added a new link to "File Manager" in the course management view for easier access.

- **Documentation**
	- Updated the instructor documentation to reflect the new access path to the File Manager feature.

- **Style**
	- Removed outdated links to "File Manager" from the navigation bar to streamline navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->