### PR TITLE
Fix maximized code navigation

### DIFF
--- a/app/views/submissions/_golden-layout.html.erb
+++ b/app/views/submissions/_golden-layout.html.erb
@@ -158,8 +158,10 @@
   });
 
   myLayout.on( 'stateChanged', function(){
-    var state = JSON.stringify( myLayout.toConfig() );
-    localStorage.setItem( 'savedState', state );
+    if (myLayout.isInitialised) {
+      var state = JSON.stringify( myLayout.toConfig() );
+      localStorage.setItem( 'savedState', state );
+    }
     resizeGradeList();
   });
 


### PR DESCRIPTION
This fixes a very niche bug discovered by a professor at UB that hindered viewing student submissions.

## Motivation and Context
Prior to this fix, if you maximized the code view from a submission and then refreshed the page, it wouldn't load properly due to a JavaScript exception. You would need to reset the layout before being able to view any submissions.

## Description
I used a technique from a similar issue I found at https://github.com/golden-layout/golden-layout/issues/253#issuecomment-295172009, where we only call `toConfig` if the layout has been fully initialized. This prevents the exception from being raised and allows the page to load properly.

## How Has This Been Tested?
After making these changes, I opened a student's submission and maximized the code view. I refreshed the page and verified it loaded properly and preserved my maximized layout. I reset the layout and verified it behaved how I'd expect.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] I have run rubocop and erblint for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://docs.autolabproject.com/)
- [ ] I have updated the documentation accordingly, included in this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved stability by ensuring layout state is saved only when the layout is initialized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->