### PR TITLE
Improve scheduler visual run handling of return value from update method

### DIFF
--- a/app/controllers/schedulers_controller.rb
+++ b/app/controllers/schedulers_controller.rb
@@ -56,7 +56,7 @@ class SchedulersController < ApplicationController
         begin
           require mod_name
           output = Updater.update(action.course)
-          if output
+          if output.respond_to?(:to_str)
             fork_log << "----- Script Output -----\n"
             fork_log << output
             fork_log << "\n----- End Script Output -----"

--- a/docs/features/schedulers.md
+++ b/docs/features/schedulers.md
@@ -29,6 +29,12 @@ end
 You can run a scheduler manually by clicking the `Run` button. This is useful for ensuring the code's correctness. 
 
 To assist in debugging, you can return a string from the `update` method, which will be displayed as output in the browser.
+You should return `nil` to represent no output.
+
+!!! info "Output String"
+    If you do not explicitly return a value, this might lead to unexpected outputs due to Ruby's implicit return values.
+
+    The return value will be converted to a string if possible, else it will be treated as no output.
 
 **Example file**
 ```ruby


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Check whether return value of `update` method has a `to_str` method (used for implicit conversions), rather than just if it's non-`nil`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The scheduler visual run output feature introduced in #1916 expects that users either return a string or `nil` from the `update` method.

However, if an existing user was not aware of the change, they may not have an explicit return. As a result of Ruby's implicit returns, they might return a value that is non-`nil` yet can not be converted to a string, leading to an error.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

(Follow the steps in #1916 if unsure how to set up a scheduler)

**returning a string**
```rb
module Updater
    def self.update(course)
        out = ""
        out << "my output\n"

        out
    end
end
```
<img width="463" alt="Screenshot 2024-05-23 at 08 17 19" src="https://github.com/autolab/Autolab/assets/9074856/de248140-676a-452f-87ef-9dacabba7161">

**returning nil**
```rb
module Updater
    def self.update(course)
        nil
    end
end
```
<img width="476" alt="Screenshot 2024-05-23 at 08 17 00" src="https://github.com/autolab/Autolab/assets/9074856/dcc1acf2-4edd-42e9-8cd7-05ab99ccaaf0">

**returning non-nil value that can't be converted to a string**
```rb
module Updater
    def self.update(course)
        true
    end
end
```
Note: `true` has a `to_s` method but NOT a `to_str` method. So implicit conversions fail.
(same picture as above)

### Updated documentation
<img width="971" alt="Screenshot 2024-05-23 at 08 16 50" src="https://github.com/autolab/Autolab/assets/9074856/e6dac146-949a-4609-8f4c-e077a32f2226">


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have run rubocop and erblint for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [x] My change requires a change to the documentation, which is located at [Autolab Docs](https://docs.autolabproject.com/)
- [x] I have updated the documentation accordingly, included in this PR

## Other issues / help required
<!--- Do you have any other relevant issues / questions? --->
<!--- For example, if you require assistance for a certain part of your PR --->
<!--- or are facing specific issues while creating the pull request that you would like to highlight --->

If unsure, feel free to submit first and we'll help you along.
