### PR TITLE
Restores line between code numbers and code

### DIFF
--- a/app/assets/stylesheets/annotations.scss
+++ b/app/assets/stylesheets/annotations.scss
@@ -939,7 +939,3 @@ span > .material-icons {
 .hljs-comment span {
   color: var($autolab-highlight-comments) !important;
 }
-
-.code-line div {
-  background: none !important;
-}


### PR DESCRIPTION
Restores line between code and code numbers

Before:
![Screenshot 2024-06-28 at 10 26 55 PM](https://github.com/autolab/Autolab/assets/65066221/11fcb149-365a-4885-aeac-4877b109cc90)

After:
![Screenshot 2024-06-28 at 10 26 30 PM](https://github.com/autolab/Autolab/assets/65066221/33d76227-645b-422b-8754-4cba5e86cc29)

## How Has This Been Tested?
- Run through multiple files and add annotations, check that the line still exists

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have run rubocop and erblint for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://docs.autolabproject.com/)
- [ ] I have updated the documentation accordingly, included in this PR
