### PR TITLE
Revert "Display start and due date-time for assessment according to system timezone (#2170)"

### DIFF
--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -430,7 +430,7 @@ class Assessment < ApplicationRecord
   end
 
   def date_to_s(date)
-    date.getlocal.strftime("%b %e at %l:%M%P")
+    date.strftime("%b %e at %l:%M%P")
   end
 
   def load_dir_to_tar(dir_path, asmt_dir, tar, filters = [], export_dir = "")


### PR DESCRIPTION
This reverts commit b6a4387d703c95b5c29819871af80515baed62bf.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

#2170 changed visual cues such that they would display due-dates based on the system's local time. However, this causes deployments which are located in a different timezone from the user to display a visual cue with the time of that deployment's timezone instead of the user's timezone, with no indication of the timezone. The timezone is shown on the handin page using the user's timezone, so the difference between the two is bound to cause confusion and thus the previous commit should be reverted for the time being.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

With the timezone change, see that the visual cue times are shown in EDT but the user is in PDT, causing the times to be different, but importantly the visual cue does not show a timezone and does not match the user's timezone.
![Screenshot 2024-07-25 at 12 02 29 AM](https://github.com/user-attachments/assets/203c0998-c103-469a-9dfc-e2933295c506)
![Screenshot 2024-07-24 at 11 56 24 PM](https://github.com/user-attachments/assets/4fdc972e-67ad-4bfc-bb00-28710568e3eb)

Reverting the change, see that there is no longer a mismatch of the user timezone values (in PDT):
![Screenshot 2024-07-24 at 11 56 21 PM](https://github.com/user-attachments/assets/c3b0cd36-f2aa-4b66-93a2-52eae38df382)
![Screenshot 2024-07-24 at 11 56 24 PM](https://github.com/user-attachments/assets/4fdc972e-67ad-4bfc-bb00-28710568e3eb)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


