### PR TITLE
Fix an incorrect setting name (SMTP authentication)

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -111,7 +111,7 @@ Rails.application.configure do
       address: config_hash['address'],
       port: config_hash['port'],
       enable_starttls_auto: config_hash['enable_starttls_auto'],
-      authentication: config_hash['plain'],
+      authentication: config_hash['authentication'],
       user_name: config_hash['user_name'],
       password: config_hash['password']
     }

--- a/config/environments/production.rb.template
+++ b/config/environments/production.rb.template
@@ -129,7 +129,7 @@ Autolab3::Application.configure do
       address: config_hash['address'],
       port: config_hash['port'],
       enable_starttls_auto: config_hash['enable_starttls_auto'],
-      authentication: config_hash['plain'],
+      authentication: config_hash['authentication'],
       user_name: config_hash['user_name'],
       password: config_hash['password']
     }

--- a/docs/installation/mailing.md
+++ b/docs/installation/mailing.md
@@ -52,7 +52,7 @@ To set Autolab up to use a custom SMTP Server, you will need to make edits to th
                 address:              'smtp.example.com',
                 port:                 25,
                 enable_starttls_auto: true,
-                authentication:       'login',
+                authentication:       'plain', # Other options include: 'login', 'cram_md5'
                 user_name:            'example',
                 password:             'example',
                 domain:               'example.com',


### PR DESCRIPTION
## Description
In the smtp yaml file, the setting is called 'authentication', however in config/environments/ it is looked up as 'plain'. Fix this issue by correcting the look-up to use the correct name.



## Motivation and Context
This solves an issue with e-mail when the SMTP server requires a different authentication method, such as cram_md5.

(Note it appears the name plain may come from a time at which the setting was a boolean plain)

## How Has This Been Tested?
Verified on my production server that this change fixed the ability to send e-mail (which resulted in error 500 otherwise)
My server requires cram_md5.

I would recommend this change be tested on a test environment with a different SMTP server.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] I have run rubocop and erblint for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://docs.autolabproject.com/)
- [ ] I have updated the documentation accordingly, included in this PR

## Other issues / help required

If unsure, feel free to submit first and we'll help you along.
