### PR TITLE
Update description under name in assessments/edit to reflect new naming rules

### DIFF
--- a/app/views/assessments/_edit_basic.html.erb
+++ b/app/views/assessments/_edit_basic.html.erb
@@ -1,7 +1,7 @@
 <%= f.text_field :name, disabled: true, class: "",
                         help_text: "The unique (for this course) name of the assessment. Must be
-  lowercase alphanumeric (no punctuation). E.g.,
-  <kbd>malloclab</kbd>".html_safe %>
+  a valid Ruby Identifier. See
+  <a href='https://docs.autolabproject.com/lab/#assessment-naming-rules'>documentation</a> for details".html_safe %>
 
 <%= f.text_field :display_name, placeholder: "Homework0",
                                 help_text: "Name that will be displayed on the course home page. E.g.,


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
#1987 greatly expanded the possible range of assessment names from lowercase alphanumeric characters. However, the description in `assessments/edit` still referred to the old naming rules. This change simply updates the description to properly reflect the new rules

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- pointed out by Iliano

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Before:
![Screenshot 2024-08-23 at 4 42 06 PM](https://github.com/user-attachments/assets/8eb3596f-6a76-4764-b731-52497d6d1e4c)

After:
![Screenshot 2024-08-23 at 4 41 46 PM](https://github.com/user-attachments/assets/8904c5c1-e6d2-4da6-9d3d-97e5c0e7f5b0)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
