### PR TITLE
Update LTI documentation to correct URLs for redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,13 +89,13 @@ pip install --user mkdocs-material
 To run and preview this locally, run:
 
 ```bash
-mkdocs serve
+python3 -m mkdocs serve
 ```
 
 Once your updated documentation is in `master`, Jenkins will automatically run a job to update the docs. You can trigger a manual update with
 
 ```bash
-mkdocs gh-deploy
+python3 -m mkdocs gh-deploy
 ```
 
 This will build the site using the branch you are currently in (hopefully `master`), place the built HTML files into the `gh-pages` branch, and push them to GitHub. GitHub will then automatically deploy the new content in `gh-pages`.

--- a/docs/installation/lti_integration.md
+++ b/docs/installation/lti_integration.md
@@ -63,8 +63,8 @@ on Autolab's end as well.
     {
       "title": "Autolab Integration",
       "description": "Autolab is an open-source autograding service developed by students, for students",
-      "oidc_initiation_url":"https://<your-autolab-domain>/lti_launch/oidc_login/",
-      "target_link_uri":"https://<your-autolab-domain>/lti_launch/launch/",
+      "oidc_initiation_url":"https://<your-autolab-domain>/lti_launch/oidc_login",
+      "target_link_uri":"https://<your-autolab-domain>/lti_launch/launch",
       "scopes": [
         "https://purl.imsglobal.org/spec/lti-nrps/scope/contextmembership.readonly"
       ],
@@ -83,7 +83,7 @@ on Autolab's end as well.
                 "enabled": true,
                 "placement":"course_navigation",
                 "message_type": "LtiResourceLinkRequest",
-                "target_link_uri": "https://<your-autolab-domain>/lti_launch/launch/",
+                "target_link_uri": "https://<your-autolab-domain>/lti_launch/launch",
                 "icon_url":"<your-icon>",
                 "windowTarget": "_blank"
                }


### PR DESCRIPTION
Update `target_link_uri`, `oidc_initiation_url` in LTI integration pages so that the examples doesn't have ending forward-slashes.

Also update README.md commands for documentation to use `python3 -m` in front of `mkdocs` commands. This command is more likely to work out of the box compared to just `mkdocs`

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #2179

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Run the documentation server locally, see the following for example configuration where url/uris don't have ending forward-slashes

![Screenshot 2024-08-23 at 11 29 58 PM](https://github.com/user-attachments/assets/badd0872-0b42-4576-bc81-16274258894b)
