### PR TITLE
Hotfix: Fix scoreboard check of index on base case

### DIFF
--- a/app/views/scoreboards/show.html.erb
+++ b/app/views/scoreboards/show.html.erb
@@ -75,7 +75,7 @@
             <% end %>
           <% else %>
             <%# this should be guaranteed to be an array, but for redundancy, check that entry is array %>
-            <% if grade[:entry].is_a?(Array) && grade[:entry].length > i %>
+            <% if grade[:entry].is_a?(Array) %>
               <% grade[:entry].each do |column| %>
                 <td><%= column %></td>
               <% end %>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
#2092 introduced various error-checking mechanisms to prevent accidentally rendering bad scoreboard data. However, it introduced a bug where for assessments without column specifications that use the problem scores to populate the scoreboard, if the number of students on the scoreboard exceeds the number of problems, then further student submissions would show that their scoreboard entry errored, when in reality their scoreboard data is fine. 

This PR removes the faulty check.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

1. Use the following autograded assessment with 1 problem:
[randomlab5_20240830.tar.zip](https://github.com/user-attachments/files/16821462/randomlab5_20240830.tar.zip)

2. Submit submissions for at least 3 students

3. On master, see that there is a display error when viewing the scoreboard

<img width="1512" alt="Screenshot 2024-08-30 at 3 35 05 PM" src="https://github.com/user-attachments/assets/2261618f-556c-44fc-98cf-bdf1489abd31">

4. On this branch, see that the error icon goes away and a score is displayed:

<img width="1512" alt="Screenshot 2024-08-30 at 3 35 32 PM" src="https://github.com/user-attachments/assets/84004337-d1e4-482e-a877-3d5d0db37593">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)