### PR TITLE
Edited documentation and removed SMTP configs from env

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -115,7 +115,7 @@ module Autolab3
     config.site_version = "3.0.0"
 
     # Set application host for mailer
-    config.action_mailer.default_url_options = { host: ENV['MAILER_HOST'] || "YOUR_APP_HOST" }
+    config.action_mailer.default_url_options = { host: "YOUR_APP_HOST" }
 
     # Configure the host and port of generated urls
     config.action_controller.default_url_options = {}

--- a/config/environments/production.rb.template
+++ b/config/environments/production.rb.template
@@ -76,7 +76,7 @@ Autolab3::Application.configure do
   # config.active_record.auto_explain_threshold_in_seconds = 0.5
 
   # default from 
-  ActionMailer::Base.default :from => ENV.fetch('SMTP_DEFAULT_FROM','something@example.com') 
+  ActionMailer::Base.default :from => config_hash['from']
 
   # option for using sendmail
   # config.action_mailer.delivery_method = :sendmail

--- a/config/environments/production.rb.template
+++ b/config/environments/production.rb.template
@@ -75,9 +75,6 @@ Autolab3::Application.configure do
   # with SQLite, MySQL, and PostgreSQL)
   # config.active_record.auto_explain_threshold_in_seconds = 0.5
 
-  # default from 
-  ActionMailer::Base.default :from => config_hash['from']
-
   # option for using sendmail
   # config.action_mailer.delivery_method = :sendmail
 
@@ -111,6 +108,9 @@ Autolab3::Application.configure do
   # Use a custom smtp server, such as gmail, mailgun, sendgrid
   if File.size?("#{Rails.configuration.config_location}/smtp_config.yml")
     config_hash = YAML.safe_load(File.read("#{Rails.configuration.config_location}/smtp_config.yml"))
+
+    # default from
+    ActionMailer::Base.default :from => config_hash['from']
 
     config.action_mailer.perform_deliveries = true
     config.action_mailer.raise_delivery_errors = true

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -6,12 +6,6 @@ Devise.setup do |config|
   # confirmation, reset password and unlock tokens in the database.
   config.secret_key = ENV['DEVISE_SECRET_KEY']
 
-  # ==> Mailer Configuration
-  # Configure the e-mail address which will be shown in Devise::Mailer,
-  # note that it will be overwritten if you use your own mailer class
-  # with default "from" parameter.
-  config.mailer_sender = ENV['SMTP_DEFAULT_FROM']
-
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'
 

--- a/docs/installation/mailing.md
+++ b/docs/installation/mailing.md
@@ -4,6 +4,7 @@ Autolab requires mailing to allow users to register accounts and reset passwords
 
 We intend these instructions mainly for production usage.
 
+## Mailing for Autolab version >=3.0.0
 To set up Autolab (>=3.0.0) for a custom SMTP Server, configure settings by clicking `Manage Autolab` > `Configure Autolab` > `SMTP Config`.
 
 ## I don't have a domain name, will mailing work?

--- a/docs/installation/mailing.md
+++ b/docs/installation/mailing.md
@@ -2,10 +2,18 @@
 
 Autolab requires mailing to allow users to register accounts and reset passwords. You will also be able to make announcements through Autolab as well. The recommended approach is to setup Autolab to use a SMTP server, such as [mailgun](https://mailgun.com), [SendGrid](https://sendgrid.com), [Amazon SES](https://aws.amazon.com/ses/) or any other valid SMTP mail servers to send out email.
 
-We intend this instructions mainly for production usage. 
+We intend this instructions mainly for production usage.
 
-## Mailing for Autolab Docker Installation
-To set Autolab Docker up for a custom SMTP Server, update the following in `.env` that was created for you. 
+To set up Autolab for a custom SMTP Server, configure settings by clicking `Manage Autolab` > `Configure Autolab` > `SMTP Config`.
+
+## I don't have a domain name, will mailing work?
+Mailing has been tested to work with SendGrid without a domain name (using the IP of the server as the domain name for the purposes of the configuration above), although the absence of a domain name will likely result in the email to be flagged as spam. For the purpose of testing, a testing mailbox service like [MailTrap](https://mailtrap.io/) is recommended.
+
+## What if I'm running an outdated version of Autolab?
+If you are running an Autolab version less than v3.0.0, refer to the documentation down below to configure SMTP.
+
+### Mailing for Autolab Docker Installation
+To set Autolab Docker up for a custom SMTP Server, update the following in `.env` that was created for you.
 
 1. Update the host domain
 
@@ -35,7 +43,7 @@ To set Autolab Docker up for a custom SMTP Server, update the following in `.env
 
 After which, doing a `docker-compose down` followed by `docker-compose up -d` will allow you to see the changes.
 
-## Mailing for Autolab Manual Installation
+### Mailing for Autolab Manual Installation
 To set Autolab up to use a custom SMTP Server, you will need to make edits to the `.env` and `production.rb` files that you have created. (If you would like to test it in development, add the following settings into `development.rb`). Both `production.rb` and `development.rb` are located under `config/environments`
 
 1. Update the host domain of your Autolab instance in `.env`
@@ -46,7 +54,7 @@ To set Autolab up to use a custom SMTP Server, you will need to make edits to th
        The value should be the domain in which Autolab is hosted on. (e.g. `autolab.andrew.cmu.edu`)
 
 2. Update the custom smtp server settings in `production.rb`
-   
+
         :::ruby
         config.action_mailer.smtp_settings = {
                 address:              'smtp.example.com',
@@ -57,17 +65,14 @@ To set Autolab up to use a custom SMTP Server, you will need to make edits to th
                 password:             'example',
                 domain:               'example.com',
         }
-        
-      Refer to the SMTP settings instructions that your selected service provides you such as [SendGrid SMTP for Ruby on Rails](https://sendgrid.com/docs/for-developers/sending-email/rubyonrails/), [Amazon SES](https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-email-smtp.html).
+
+   Refer to the SMTP settings instructions that your selected service provides you such as [SendGrid SMTP for Ruby on Rails](https://sendgrid.com/docs/for-developers/sending-email/rubyonrails/), [Amazon SES](https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-email-smtp.html).
 
 3. Update the "from" setting in `production.rb`
-   
+
         :::ruby
         ActionMailer::Base.default :from => 'something@example.com'
-  
-      Here the from address **must** be a address that your SMTP service permits you to send from. Oftentimes it is the same as your user_name in the smtp settings.
+
+   Here the from address **must** be a address that your SMTP service permits you to send from. Oftentimes it is the same as your user_name in the smtp settings.
 
 Make sure to restart your Autolab client to see the changes.
-
-# I don't have a domain name, will mailing work?
-Mailing has been tested to work with SendGrid without a domain name (using the IP of the server as the domain name for the purposes of the configuration above), although the absence of a domain name will likely result in the email to be flagged as spam. For the purpose of testing, a testing mailbox service like [MailTrap](https://mailtrap.io/) is recommended.

--- a/docs/installation/mailing.md
+++ b/docs/installation/mailing.md
@@ -2,9 +2,9 @@
 
 Autolab requires mailing to allow users to register accounts and reset passwords. You will also be able to make announcements through Autolab as well. The recommended approach is to setup Autolab to use a SMTP server, such as [mailgun](https://mailgun.com), [SendGrid](https://sendgrid.com), [Amazon SES](https://aws.amazon.com/ses/) or any other valid SMTP mail servers to send out email.
 
-We intend this instructions mainly for production usage.
+We intend these instructions mainly for production usage.
 
-To set up Autolab for a custom SMTP Server, configure settings by clicking `Manage Autolab` > `Configure Autolab` > `SMTP Config`.
+To set up Autolab (>=3.0.0) for a custom SMTP Server, configure settings by clicking `Manage Autolab` > `Configure Autolab` > `SMTP Config`.
 
 ## I don't have a domain name, will mailing work?
 Mailing has been tested to work with SendGrid without a domain name (using the IP of the server as the domain name for the purposes of the configuration above), although the absence of a domain name will likely result in the email to be flagged as spam. For the purpose of testing, a testing mailbox service like [MailTrap](https://mailtrap.io/) is recommended.

--- a/docs/installation/mailing.md
+++ b/docs/installation/mailing.md
@@ -40,7 +40,7 @@ To set Autolab Docker up for a custom SMTP Server, update the following in `.env
         :::
         SMTP_DEFAULT_FROM=from@example.com
 
-       Here the from address **must** be a address that your SMTP service permits you to send from. Oftentimes it is the same as your user_name in the smtp settings.
+       Here the from address **must** be an address that your SMTP service permits you to send from. Oftentimes it is the same as your user_name in the smtp settings.
 
 After which, doing a `docker-compose down` followed by `docker-compose up -d` will allow you to see the changes.
 
@@ -74,6 +74,6 @@ To set Autolab up to use a custom SMTP Server, you will need to make edits to th
         :::ruby
         ActionMailer::Base.default :from => 'something@example.com'
 
-   Here the from address **must** be a address that your SMTP service permits you to send from. Oftentimes it is the same as your user_name in the smtp settings.
+   Here the from address **must** be an address that your SMTP service permits you to send from. Oftentimes it is the same as your user_name in the smtp settings.
 
 Make sure to restart your Autolab client to see the changes.


### PR DESCRIPTION
## Description
This resolves #2177. With the recent change, SMTP configs are no longer taken from the env file but are configured using the UI and saved in the config. For more information see #2168. This PR updates the documentation with instructions to use the UI to configure SMTP and for application and production.rb files to reference the config instead.

## How Has This Been Tested?
- Test manual installation and docker installation of Autolab with these changes, check that you can save configuration and when you send an email, it works and its received which shows that SMTP configuration is a success. 

![Screenshot 2024-09-02 at 11 50 00 PM](https://github.com/user-attachments/assets/4e0af795-19c5-4a0b-b95e-660c5cb2abdd)
![Screenshot 2024-09-02 at 11 50 09 PM](https://github.com/user-attachments/assets/dfcbaaaa-b54d-41eb-9e8f-78c0633e4c49)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have run rubocop and erblint for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [x] My change requires a change to the documentation, which is located at [Autolab Docs](https://docs.autolabproject.com/)
- [x] I have updated the documentation accordingly, included in this PR
