### PR TITLE
Make annotation UI more compact

### DIFF
--- a/app/assets/stylesheets/annotations.scss
+++ b/app/assets/stylesheets/annotations.scss
@@ -260,6 +260,11 @@
   width: 100%;
 }
 
+.code-table .annotation-line .annotation-form .row .input-field {
+  margin-bottom: 0;
+  margin-top: 0.75rem !important;
+}
+
 .code-table .float-left {
   float: left;
 }

--- a/app/assets/stylesheets/annotations.scss
+++ b/app/assets/stylesheets/annotations.scss
@@ -249,6 +249,10 @@
   border: 1px solid red;
 }
 
+.code-table .annotation-line .annotation-form .row {
+  margin-bottom: 0;
+}
+
 .code-table .annotation-line .annotation-preview {
   border: 1px solid $autolab-highlight-gray;
   padding: 5px;

--- a/app/views/submissions/_annotation_form.html.erb
+++ b/app/views/submissions/_annotation_form.html.erb
@@ -2,7 +2,7 @@
   <div class="error" style="display: none;"></div>
   <form>
     <div class="row">
-      <div class="input-field col s12 annotation-comment">
+      <div class="input-field col s12 annotation-comment no-padding-bottom">
         <textarea class="comment materialize-textarea" id="comment-textarea" placeholder=""></textarea>
         <label for="comment-textarea">Comment</label>
         <p>
@@ -17,21 +17,21 @@
 
     <div class="row annotation-problem-score">
       <% if global %>
-        <div class="input-field col s12">
+        <div class="input-field col s12 no-padding-bottom">
           <input class="score" type="number" value="0" placeholder="0" step="any" id="comment-score" autocomplete="on">
           <label for="comment-score">Score</label>
           <span> Grading style: <b><%= @assessment.is_positive_grading ? "Positive grading" : "Negative grading" %></b>
             <i class="material-icons" title="<%= "#{@assessment.is_positive_grading ? 'Score is added, starting from 0.' : 'Score is deducted from the total points.'} Change this setting in Edit Assessment > Problems" %>">info_outline</i> </span>
         </div>
       <% else %>
-        <div class="input-field col s6">
+        <div class="input-field col s6 no-padding-bottom">
           <input class="score" type="number" value="0" placeholder="0" step="any" id="comment-score" autocomplete="on">
           <label for="comment-score">Score</label>
           <span> Grading style: <b><%= @assessment.is_positive_grading ? "Positive grading" : "Negative grading" %></b>
               <i class="material-icons" title="<%= "#{@assessment.is_positive_grading ? 'Score is added, starting from 0.' : 'Score is deducted from the total points.'} Change this setting in Edit Assessment > Problems" %>">info_outline</i> </span>
         </div>
 
-        <div class="input-field col s6">
+        <div class="input-field col s6 no-padding-bottom">
           <select class="browser-default problem-id">
           </select>
         </div>
@@ -39,7 +39,7 @@
     </div>
 
     <div class="row">
-      <div class="input-field col s12">
+      <div class="input-field col s12 no-padding-bottom">
         <input type="submit" class="btn" value="Add annotation">
         <button class="btn grey annotation-cancel-button">Cancel</button>
       </div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Remove extraneous padding and margins to reduce size of annotation UI
* Annotation UI used to take up entire code block space on smaller laptop screens

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Resolves #2202 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Go to speedgrader and add annotations, also view that adding multiple annotations to the same line + opening annotations in multiple lines looks fine

**BEFORE:**
![image](https://github.com/user-attachments/assets/b7eb7d9f-4c13-410d-9878-8a80661dc12d)

**AFTER:**
![image](https://github.com/user-attachments/assets/58cbe467-b7a2-4af0-983e-9331213d6c4c)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have run rubocop and erblint for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://docs.autolabproject.com/)
- [ ] I have updated the documentation accordingly, included in this PR
