### PR TITLE
Allow SMTP auth to be nil

### DIFF
--- a/app/controllers/smtp_config_controller.rb
+++ b/app/controllers/smtp_config_controller.rb
@@ -84,9 +84,9 @@ private
       address: params['address'],
       port: params['port'],
       enable_starttls_auto: params['enable_starttls_auto'] == 'true',
-      authentication: params['authentication'],
-      user_name: params['username'],
-      password: params['password']
+      authentication: params['authentication'] == 'none' ? nil : params['authentication'],
+      user_name: params['username'] == "" ? nil : params['username'],
+      password: params['password'] == "" ? nil : params['password']
     }
 
     if params.key?(:domain) && !params[:domain].empty?

--- a/app/views/admins/_smtp_integration.html.erb
+++ b/app/views/admins/_smtp_integration.html.erb
@@ -54,7 +54,7 @@
     <span class="helper-text">Specify mail server password if necessary</span>
   </div>
   <div class="input-field">
-    <%= form.select :authentication, [:plain, :login, :cram_md5], selected: @smtp_config_hash.nil? ? "plain" : @smtp_config_hash[:authentication], required: true %>
+    <%= form.select :authentication, [:none, :plain, :login, :cram_md5], selected: @smtp_config_hash.nil? ? "plain" : @smtp_config_hash[:authentication], required: true %>
     <%= form.label :authentication, "Mail Server authentication method" %>
     <span class="helper-text">Specify mail Server authentication method</span>
   </div>

--- a/docs/installation/mailing.md
+++ b/docs/installation/mailing.md
@@ -61,7 +61,7 @@ To set Autolab up to use a custom SMTP Server, you will need to make edits to th
                 address:              'smtp.example.com',
                 port:                 25,
                 enable_starttls_auto: true,
-                authentication:       'plain', # Other options include: 'login', 'cram_md5'
+                authentication:       'plain', # Other options include: 'login', 'cram_md5', 'none'
                 user_name:            'example',
                 password:             'example',
                 domain:               'example.com',


### PR DESCRIPTION
## Description
Resolves #2172 

Previously, users had no way of specifying smtp authentication in smtp config to be nil. However, with this fix, users can do so by clicking the option and not specifying a username and password.

![Screenshot 2024-09-20 at 3 42 43 AM](https://github.com/user-attachments/assets/17f74a81-162b-47a3-86d2-8aa3ccb1e410)

## How Has This Been Tested?
1. To test this out, configure a local SMTP without auth. To do so, I ran this command:
`sudo python -m smtpd -n -c DebuggingServer localhost:25`.
2. You then fill in the Mail Server Address as localhost, Mail Server Port as 25 and click none for authentication. You should also fill in the information about your Autolab URL deployment under Autolab URL.
3. Try out a test email and see that it is it dumped to the console.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have run rubocop and erblint for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [x] My change requires a change to the documentation, which is located at [Autolab Docs](https://docs.autolabproject.com/)
- [x] I have updated the documentation accordingly, included in this PR
