### PR TITLE
Fixed LTI duplicate roster error

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -798,6 +798,7 @@ private
   def write_cuds(cuds)
     rowNum = 0
     rosterErrors = {}
+    rosterWarnings = {}
     rowCUDs = []
     duplicates = Set.new
 
@@ -863,7 +864,7 @@ private
         new_cud.delete(:year)
 
         # Build cud
-        if !user.nil?
+        if !user.nil? && !existing
           cud = @course.course_user_data.new
           cud.user = user
           params = ActionController::Parameters.new(
@@ -945,11 +946,11 @@ private
     rowCUDs.each do |cud|
       next unless duplicates.include?(cud[:email])
 
-      msg = "Validation failed: Duplicate email #{cud[:email]}"
-      if !rosterErrors.key?(msg)
-        rosterErrors[msg] = []
+      msg = "Warning : Duplicate email #{cud[:email]}"
+      if !rosterWarnings.key?(msg)
+        rosterWarnings[msg] = []
       end
-      rosterErrors[msg].push(cud)
+      rosterWarnings[msg].push(cud)
     end
 
     return if rosterErrors.empty?

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -554,7 +554,7 @@ class CoursesController < ApplicationController
         save_uploaded_roster
         flash[:success] = "Successfully updated roster!"
         unless @roster_warnings.nil?
-          w = @roster_warnings.keys.join('\n')
+          w = "Warning: " + @roster_warnings.keys.join(', ')
           flash[:error] = w
         end
         redirect_to(action: "users") && return
@@ -947,10 +947,10 @@ private
       rowNum += 1
     end
 
-    rowCUDs.each do |cud|
+    rowCUDs.each_with_index do |cud, line|
       next unless duplicates.include?(cud[:email])
 
-      msg = "Warning : Duplicate email #{cud[:email]}"
+      msg = "#{cud[:email]} is a duplicate email at line #{line}"
       if !rosterWarnings.key?(msg)
         rosterWarnings[msg] = []
       end

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -554,7 +554,7 @@ class CoursesController < ApplicationController
         save_uploaded_roster
         flash[:success] = "Successfully updated roster!"
         unless @roster_warnings.nil?
-          w = "Warning: " + @roster_warnings.keys.join(', ')
+          w = "Warning: #{@roster_warnings.keys.join(', ')}"
           flash[:error] = w
         end
         redirect_to(action: "users") && return

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -553,6 +553,10 @@ class CoursesController < ApplicationController
       begin
         save_uploaded_roster
         flash[:success] = "Successfully updated roster!"
+        unless @roster_warnings.nil?
+          w = @roster_warnings.keys.join('\n')
+          flash[:error] = w
+        end
         redirect_to(action: "users") && return
       rescue StandardError => e
         if e != "Roster validation error"
@@ -952,6 +956,8 @@ private
       end
       rosterWarnings[msg].push(cud)
     end
+
+    @roster_warnings = rosterWarnings
 
     return if rosterErrors.empty?
 


### PR DESCRIPTION
An error occurs when we have a roster with duplicate email addresses, so changed it to only a warning. 

## Description
Before: When we sync the roster to a LTI course that has duplicate users, an error occured.
After: When we sync the roster, the sync works, but a warning is produced. 
![image](https://github.com/user-attachments/assets/0323c1f3-4c19-48a4-ba54-643569598ad0)

## Motivation and Context
The LTI Test Course has duplicate users, and the roster sync was failing. 

## How Has This Been Tested?
I created a new course in my development environment, and linked the [LTI test course](https://lti-ri.imsglobal.org/platforms/3644/resource_links/74024/rosters), and synced the roster. 
![image](https://github.com/user-attachments/assets/6f8478bc-7de1-4a60-8b08-438db8c64035)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have run rubocop and erblint for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://docs.autolabproject.com/)
- [ ] I have updated the documentation accordingly, included in this PR

## Other issues / help required
<!--- Do you have any other relevant issues / questions? --->
<!--- For example, if you require assistance for a certain part of your PR --->
<!--- or are facing specific issues while creating the pull request that you would like to highlight --->

If unsure, feel free to submit first and we'll help you along.
