### PR TITLE
Remove redundant and outdated shibboleth gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,7 +60,6 @@ gem 'omniauth', '>=1.2.2'
 gem 'omniauth-facebook', '>=2.0.0'
 gem 'omniauth-google-oauth2', '>=0.2.5'
 gem 'omniauth-rails_csrf_protection', '~> 1.0'
-gem 'omniauth-shibboleth', '>=1.1.2'
 gem 'omniauth-shibboleth-redux', '~> 2.0', require: 'omniauth-shibboleth'
 
 # OAuth2 authentication

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -277,8 +277,6 @@ GEM
     omniauth-rails_csrf_protection (1.0.1)
       actionpack (>= 4.2)
       omniauth (~> 2.0)
-    omniauth-shibboleth (1.3.0)
-      omniauth (>= 1.0.0)
     omniauth-shibboleth-redux (2.0.0)
       omniauth (>= 2.0.0)
     orm_adapter (0.5.0)
@@ -519,7 +517,6 @@ DEPENDENCIES
   omniauth-facebook (>= 2.0.0)
   omniauth-google-oauth2 (>= 0.2.5)
   omniauth-rails_csrf_protection (~> 1.0)
-  omniauth-shibboleth (>= 1.1.2)
   omniauth-shibboleth-redux (~> 2.0)
   overcommit
   populator (>= 1.0.0)


### PR DESCRIPTION
Remove the `omniauth-shibboleth` gem, which was already removed in #1934 but was unintentionally re-introduced in #2028. 

Not really able to test on our end, but is pretty much the same as #1934, so shouldn't cause issues.