### PR TITLE
When installing existing assessment, don't autoselect all

### DIFF
--- a/app/assets/stylesheets/install_assessment.css.scss
+++ b/app/assets/stylesheets/install_assessment.css.scss
@@ -19,6 +19,11 @@
   background-color: $autolab-light-red !important;
 }
 
+.assessment-checkbox {
+  display: flex;
+  justify-content: center;
+}
+
 .assessment-import-table {
   overflow: hidden;
   width: 100%;

--- a/app/views/assessments/_install_assessment_table.html.erb
+++ b/app/views/assessments/_install_assessment_table.html.erb
@@ -45,8 +45,8 @@
               <b class="install-failure-p">
                 Failed to Install
               </b>
-              <label>
-                <%= check_box_tag asmt_file, asmt_file, true, class: 'cbox', id: "#{asmt_file}_checkbox" %>
+              <label class="assessment-checkbox">
+                <%= check_box_tag asmt_file, asmt_file, false, class: 'cbox', id: "#{asmt_file}_checkbox" %>
                 <span />
               </label>
               <%= asmt_file %>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* title

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Resolves #2220 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Go to an assessment, delete it, then go to "Install Assessment" and view that the uninstalled assessments aren't automatically checked.
**BEFORE:**
![image](https://github.com/user-attachments/assets/0492f34d-eb53-430a-b16a-bac4cd5dba60)
**AFTER:**
![image](https://github.com/user-attachments/assets/c05a1860-fd22-4083-9371-ae26f9d49581)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have run rubocop and erblint for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://docs.autolabproject.com/)
- [ ] I have updated the documentation accordingly, included in this PR

