### PR TITLE
Create endpoint for public LTI JWKs

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -798,6 +798,7 @@ private
   def write_cuds(cuds)
     rowNum = 0
     rosterErrors = {}
+    rosterWarnings = {}
     rowCUDs = []
     duplicates = Set.new
 
@@ -863,7 +864,7 @@ private
         new_cud.delete(:year)
 
         # Build cud
-        if !user.nil?
+        if !user.nil? && !existing
           cud = @course.course_user_data.new
           cud.user = user
           params = ActionController::Parameters.new(
@@ -945,11 +946,11 @@ private
     rowCUDs.each do |cud|
       next unless duplicates.include?(cud[:email])
 
-      msg = "Validation failed: Duplicate email #{cud[:email]}"
-      if !rosterErrors.key?(msg)
-        rosterErrors[msg] = []
+      msg = "Warning : Duplicate email #{cud[:email]}"
+      if !rosterWarnings.key?(msg)
+        rosterWarnings[msg] = []
       end
-      rosterErrors[msg].push(cud)
+      rosterWarnings[msg].push(cud)
     end
 
     return if rosterErrors.empty?

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -553,10 +553,6 @@ class CoursesController < ApplicationController
       begin
         save_uploaded_roster
         flash[:success] = "Successfully updated roster!"
-        unless @roster_warnings.nil?
-          w = @roster_warnings.keys.join('\n')
-          flash[:error] = w
-        end
         redirect_to(action: "users") && return
       rescue StandardError => e
         if e != "Roster validation error"
@@ -955,8 +951,6 @@ private
       end
       rosterErrors[msg].push(cud)
     end
-
-    @roster_warnings = rosterWarnings
 
     return if rosterErrors.empty?
 

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -802,7 +802,6 @@ private
   def write_cuds(cuds)
     rowNum = 0
     rosterErrors = {}
-    rosterWarnings = {}
     rowCUDs = []
     duplicates = Set.new
 
@@ -868,7 +867,7 @@ private
         new_cud.delete(:year)
 
         # Build cud
-        if !user.nil? && !existing
+        if !user.nil?
           cud = @course.course_user_data.new
           cud.user = user
           params = ActionController::Parameters.new(
@@ -950,11 +949,11 @@ private
     rowCUDs.each do |cud|
       next unless duplicates.include?(cud[:email])
 
-      msg = "Warning : Duplicate email #{cud[:email]}"
-      if !rosterWarnings.key?(msg)
-        rosterWarnings[msg] = []
+      msg = "Validation failed: Duplicate email #{cud[:email]}"
+      if !rosterErrors.key?(msg)
+        rosterErrors[msg] = []
       end
-      rosterWarnings[msg].push(cud)
+      rosterErrors[msg].push(cud)
     end
 
     @roster_warnings = rosterWarnings

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -553,6 +553,10 @@ class CoursesController < ApplicationController
       begin
         save_uploaded_roster
         flash[:success] = "Successfully updated roster!"
+        unless @roster_warnings.nil?
+          w = @roster_warnings.keys.join('\n')
+          flash[:error] = w
+        end
         redirect_to(action: "users") && return
       rescue StandardError => e
         if e != "Roster validation error"
@@ -952,6 +956,8 @@ private
       end
       rosterWarnings[msg].push(cud)
     end
+
+    @roster_warnings = rosterWarnings
 
     return if rosterErrors.empty?
 

--- a/app/controllers/lti_launch_controller.rb
+++ b/app/controllers/lti_launch_controller.rb
@@ -4,7 +4,7 @@ class LtiLaunchController < ApplicationController
   skip_before_action :authorize_user_for_course
   skip_before_action :update_persistent_announcements
   skip_before_action :authenticate_for_action
-  skip_before_action :authenticate_user!, only: [:launch, :oidc_login, :tool_keys]
+  skip_before_action :authenticate_user!, only: [:launch, :oidc_login, :jwks]
   # have to do because we are making a POST request from Canvas
   skip_before_action :verify_authenticity_token
 

--- a/app/controllers/lti_launch_controller.rb
+++ b/app/controllers/lti_launch_controller.rb
@@ -236,8 +236,8 @@ class LtiLaunchController < ApplicationController
     )
   end
 
-  # return keys as jwk
-  def tool_keys
+  # public endpoint to return our public JWKs for LTI authentication
+  def jwks
     unless File.size?("#{Rails.configuration.config_location}/lti_tool_jwk.json")
       raise LtiError, "No JWK found on Autolab"
     end

--- a/app/controllers/lti_launch_controller.rb
+++ b/app/controllers/lti_launch_controller.rb
@@ -239,7 +239,7 @@ class LtiLaunchController < ApplicationController
   # return keys as jwk
   def tool_keys
     unless File.size?("#{Rails.configuration.config_location}/lti_tool_jwk.json")
-      raise LtiError("No JWK found on Autolab")
+      raise LtiError, "No JWK found on Autolab"
     end
 
     jwk_json = File.read("#{Rails.configuration.config_location}/lti_tool_jwk.json")
@@ -247,7 +247,7 @@ class LtiLaunchController < ApplicationController
       jwk_hash = JSON.parse(jwk_json)
     rescue JSON::ParserError => e
       Rails.logger.error("Error Parsing JWK JSON: #{e}")
-      raise LtiError("Error parsing Autolab JWK file")
+      raise LtiError, "Error parsing Autolab JWK file"
     end
 
     # import could fail b/c we only support one key, not multiple
@@ -255,7 +255,7 @@ class LtiLaunchController < ApplicationController
       tool_JWK_keypair = JWT::JWK.import(jwk_hash)
     rescue StandardError => e
       Rails.logger.error("Error importing private JWK: #{e}")
-      raise LtiError("Error parsing Autolab JWK file as keypair")
+      raise LtiError, "Error parsing Autolab JWK file as keypair"
     end
 
     render json: JWT::JWK::Set.new(tool_JWK_keypair).export

--- a/app/controllers/lti_launch_controller.rb
+++ b/app/controllers/lti_launch_controller.rb
@@ -4,7 +4,7 @@ class LtiLaunchController < ApplicationController
   skip_before_action :authorize_user_for_course
   skip_before_action :update_persistent_announcements
   skip_before_action :authenticate_for_action
-
+  skip_before_action :authenticate_user!, only: [:launch, :oidc_login, :tool_keys]
   # have to do because we are making a POST request from Canvas
   skip_before_action :verify_authenticity_token
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
     get 'lti_launch/oidc_login', to: "lti_launch#oidc_login"
     post 'lti_launch/launch', to: "lti_launch#launch"
     get 'lti_launch/launch', to: "lti_launch#launch"
-    get 'lti_launch/tool_keys', to: "lti_launch#tool_keys"
+    get 'lti_launch/jwks', to: "lti_launch#jwks"
     post 'lti_nrps/sync_roster', to: "lti_nrps#sync_roster"
   get 'lti_config/index', to: "lti_config#index"
   post 'github_config/update_config', to: "github_config#update_config"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
     get 'lti_launch/oidc_login', to: "lti_launch#oidc_login"
     post 'lti_launch/launch', to: "lti_launch#launch"
     get 'lti_launch/launch', to: "lti_launch#launch"
+    get 'lti_launch/tool_keys', to: "lti_launch#tool_keys"
     post 'lti_nrps/sync_roster', to: "lti_nrps#sync_roster"
   get 'lti_config/index', to: "lti_config#index"
   post 'github_config/update_config', to: "github_config#update_config"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Create a way for other LTI providers to discover LTI's public JWKs so that they don't need to be manually uploaded to the tool provider, which simplifies setup and makes switching out the JWT convenient.

documentation to be updated after we update the canvas flow / other LTI changes.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Part of upgrades to support better LTI integration with Canvas. This should also make setting up Autolab on Canvas easier.

There is now a public endpoint `/lti_launch/jwks` to support querying Autolab for its public JWKs.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

This testing was done on Nightly since it seems that the LTI testing tool really doesn't like http requests for making a request to get the public JWK.


Use the following platform: [https://lti-ri.imsglobal.org/platforms/5276](https://lti-ri.imsglobal.org/platforms/5276)

Verify that platform has correct JWK url:
![Screenshot 2024-10-04 at 4 14 29 PM](https://github.com/user-attachments/assets/4b051322-a006-4c07-ab14-41bfebe65bbc)

Use the following configuration:
![Screenshot 2024-10-04 at 4 11 55 PM](https://github.com/user-attachments/assets/0354c53b-74d9-423f-bef3-66deaf63f6ee)

Upload whatever JWK keypair you want on nightly. Then go to the following link:
[https://nightly.autolabproject.com/lti_launch/jwks](https://nightly.autolabproject.com/lti_launch/jwks)

See that you see the public JWK (not the private one):
![Screenshot 2024-10-04 at 4 12 58 PM](https://github.com/user-attachments/assets/29b7a5f3-a282-44b3-a788-254d29076ccf)

Also see that you can be logged out and still view the JWK (as it should be public-facing)

Then try synchronizing the course roster here (for now the LTI link is here): [https://nightly.autolabproject.com/courses/hackingsession-david/users](https://nightly.autolabproject.com/courses/hackingsession-david/users)

See that link succeeds
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have run rubocop and erblint for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [x] My change requires a change to the documentation, which is located at [Autolab Docs](https://docs.autolabproject.com/)
