### PR TITLE
Fix student download submission bug to have unique names

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -192,8 +192,14 @@ class UsersController < ApplicationController
       # track counts of each file name
       track_duplicate_counts = Hash.new(0)
       submissions.each do |s|
-        entry_name = download_filename(s.handin_file_path, s.assessment.name)
-        track_duplicate_counts[entry_name] += 1
+        p = s.handin_file_path
+        course_name = s.course_user_datum.course.name
+        assignment_name = s.assessment.name
+        course_directory = "#{filename}/#{course_name}"
+        assignment_directory = "#{course_directory}/#{assignment_name}"
+        entry_name = download_filename(p, assignment_name)
+        final_path = "#{assignment_directory}/#{entry_name}"
+        track_duplicate_counts[final_path] += 1
       end
 
       # track which version is being processed (for naming purposes)
@@ -205,10 +211,11 @@ class UsersController < ApplicationController
         course_directory = "#{filename}/#{course_name}"
         assignment_directory = "#{course_directory}/#{assignment_name}"
         entry_name = download_filename(p, assignment_name)
-        filename_counts[entry_name] += 1
+        final_path = "#{assignment_directory}/#{entry_name}"
+        filename_counts[final_path] += 1
         # append version number to submission if more than one of same name
-        if track_duplicate_counts[entry_name] > 1
-          version_suffix = "_ver#{filename_counts[entry_name]}"
+        if track_duplicate_counts[final_path] > 1
+          version_suffix = "_ver#{filename_counts[final_path]}"
           extname = File.extname(entry_name)
           basename = File.basename(entry_name, extname)
           entry_name = "#{basename}#{version_suffix}#{extname}"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fix bug missed by #2137.
If a file has multiple files with the same name, will add unique identifier at end to differentiate files and ensure zipping for download all submissions feature for students does not run into issues.
Note: Could be made more efficient if in the case of multiple of the same name, the first has the normal name and the future ones have _ver# attached. For aesthetic purposes, appended _ver# to all those with same name.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
If a student has multiple submissions with the same submission file name, downloading the submissions will run into issues because there are multiple files of the same name being zipped together. Issue occurred in production.

The change will append "_ver{#}" to the name of the file if there are multiple files with that same name to differentiate the different files and allow for smooth folder compression.

Fixes #2188.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
To test, duplicates some of the files when downloading (so file names had multiples) to ensure version naming worked.
![image](https://github.com/user-attachments/assets/18d22412-59bd-4b61-837b-458745f2df06)
For files that don't have duplicate file names, feature does not add the unique name modification (what it was like previously).
![Screen Shot 2024-11-20 at 2 09 09 AM](https://github.com/user-attachments/assets/f770f9e2-4a68-4693-99cc-7dbbcba792c5)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have run rubocop and erblint for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://docs.autolabproject.com/)
- [ ] I have updated the documentation accordingly, included in this PR

## Other issues / help required
<!--- Do you have any other relevant issues / questions? --->
<!--- For example, if you require assistance for a certain part of your PR --->
<!--- or are facing specific issues while creating the pull request that you would like to highlight --->

If unsure, feel free to submit first and we'll help you along.
