### PR TITLE
Added confirmation prompt for late days

### DIFF
--- a/app/views/assessments/_handin_form.html.erb
+++ b/app/views/assessments/_handin_form.html.erb
@@ -53,7 +53,7 @@
               <div id="submission_error" style="color:red" class="col s6 m8 center-align"></div>
               <% if @aud.past_due_at? then %>
                 <div class="col s6 m4 center-align">
-                  <%= f.submit("Submit Late", id: "fake-submit", class: "btn primary handin-btn disabled") %>
+                  <%= f.submit("Submit Late", id: "fake-submit", class: "btn primary handin-btn disabled", data: { confirm: "You are #{grace_late_info}. Are you sure you want to continue?" }) %>
                 </div>
               <% else %>
                 <div class="col s6 m4 center-align">


### PR DESCRIPTION
Added a Confirmation Prompt for Late Days

## Description
Adjusted UI by adding a confirmation prompt for the use of late days that appears when pressing the late submit button. 

Changed UI:
<img width="829" alt="Screenshot 2024-12-07 at 10 27 59 PM" src="https://github.com/user-attachments/assets/eabcdb47-bfe1-4408-8933-ba3e84b0c2ce">

To implement the confirmation feature, I first identified the handin HTML erb form where users submit assignments and inspected the DOM to trace the submit button’s functionality. Debugging revealed that the button was a "fake" submit, controlled by a JavaScript event listener, preventing direct interaction with the controller. Through console logging in the Javascript file I found that I had no access to the database. I also did not have the ability to modify the controller’s redirect-heavy logic. I focused on the ERB file and discovered an embedded Ruby method that creates a confirmation popup before clicking the button would be processed. By leveraging existing code that calculated late day usage and using the embedded method, I implemented a solution that provided users with accurate feedback in a confirmation prompt.

## Motivation and Context
Students mistakenly submit to the wrong assignments, either wasting late days unnecessarily or submitting to assignments where late days are not allowed. As a solution, we can add a confirmation prompt when students are about to use late days. Fixes #2211 

## How Has This Been Tested?
Tested locally to make sure that the confirmation prompt appears when submitting (see screenshots).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have run rubocop and erblint for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://docs.autolabproject.com/)
- [ ] I have updated the documentation accordingly, included in this PR