### PR TITLE
Enhance Export Functionality with PLD and GDU Metrics

### DIFF
--- a/app/controllers/assessments_controller.rb
+++ b/app/controllers/assessments_controller.rb
@@ -506,13 +506,14 @@ class AssessmentsController < ApplicationController
         @assessment.load_dir_to_tar(dir_path, asmt_dir, tar, filter)
 
         # Add PLD and GDU data to the tarball as separate files
-        tar.add_file_simple("PLD.yml", 0644, pld_data.bytesize) do |io|
+        tar.add_file_simple("PLD.yml", 0o644, pld_data.bytesize) do |io|
           io.write pld_data
         end
 
-        tar.add_file_simple("GDU.yml", 0644, gdu_data.bytesize) do |io|
+        tar.add_file_simple("GDU.yml", 0o644, gdu_data.bytesize) do |io|
           io.write gdu_data
         end
+
         
       end
       tarStream.rewind

--- a/app/controllers/assessments_controller.rb
+++ b/app/controllers/assessments_controller.rb
@@ -489,6 +489,10 @@ class AssessmentsController < ApplicationController
   def export
     dir_path = @course.directory_path.to_s
     asmt_dir = @assessment.name
+
+    pld_data = @assessment.calculate_pld.to_yaml
+    gdu_data = @assessment.calculate_gdu.to_yaml
+
     begin
       # Update the assessment config YAML file.
       @assessment.dump_yaml
@@ -500,6 +504,16 @@ class AssessmentsController < ApplicationController
         tar.mkdir asmt_dir, File.stat(File.join(dir_path, asmt_dir)).mode
         filter = [@assessment.handin_directory_path]
         @assessment.load_dir_to_tar(dir_path, asmt_dir, tar, filter)
+
+        # Add PLD and GDU data to the tarball as separate files
+        tar.add_file_simple("PLD.yml", 0644, pld_data.bytesize) do |io|
+          io.write pld_data
+        end
+
+        tar.add_file_simple("GDU.yml", 0644, gdu_data.bytesize) do |io|
+          io.write gdu_data
+        end
+        
       end
       tarStream.rewind
       tarStream.close


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This pull request enhances the export functionality of assessments by including Presumably Late Days (PLD) and Grade Distribution Usage (GDU) metrics. These metrics are now calculated for each assessment and included in the exported tarball as separate YAML files, `PLD.yml` and `GDU.yml`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This change provides educators and administrators with more detailed insights into assessment performance and submission timeliness, aiding in better academic decision-making. This enhancement does not fix a specific issue but adds significant functionality to the existing export capabilities.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The new export functionality was tested in a local development environment where:
- Multiple assessments with varied due dates and submission times were used to generate the PLD

Attempt for issue: #1733 
