### PR TITLE
Fix login screen accessibility: add form labels, lang attribute, and update link contrast (#1373)

### DIFF
--- a/app/assets/stylesheets/_variables.scss
+++ b/app/assets/stylesheets/_variables.scss
@@ -7,7 +7,7 @@ $autolab-light-red: #ffbec0;
 $autolab-subtle-gray: #eee;
 $autolab-highlight-gray: #ccc;
 $autolab-black-text: #212121;
-$autolab-blue-text: #0869af;
+$autolab-blue-text: #0056b3;
 $autolab-green: #3a862d;
 $autolab-light-green: #ebffd2;
 $autolab-white: #fff;

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,4 +1,4 @@
-<div class="sign-in-panel home">
+<div class="sign-in-panel home" lang="en">
 <br>
 
 <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
@@ -6,8 +6,14 @@
   <img src="/images/autolab.svg" alt="" class="valign login-logo">
   <h5>Login to Autolab</h5>
 
-  <div><%= f.email_field :email, autofocus: true, placeholder: "Email Address" %></div>
-  <div><%= f.password_field :password, placeholder: "Password" %></div>
+  <div>
+    <%= f.label :email, "Email Address" %>
+    <%= f.email_field :email, autofocus: true, placeholder: "Email Address" %>
+  </div>
+  <div>
+    <%= f.label :password, "Password" %>
+    <%= f.password_field :password, placeholder: "Password" %>
+  </div>
 
   <% if devise_mapping.rememberable? -%>
   <label>


### PR DESCRIPTION
…update link contrast (#1373)

<!--- Provide a general summary of your changes in the Title above -->

## Description
Added accessibility improvements to the login screen:
- Added form labels for email and password fields
- Added lang="en" attribute for proper language identification
- Updated link color to #0056b3 to meet WCAG AA contrast requirements

## Motivation and Context
Fixes #1373
These changes improve accessibility for users relying on screen readers and those with visual impairments by providing proper form labels, language identification, and sufficient color contrast.

## How Has This Been Tested?
Tested locally by:
- Verifying form labels are properly associated with input fields
- Confirming lang attribute is present in the HTML
- Checking the new link color meets contrast requirements

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ x] I have run rubocop and erblint for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://docs.autolabproject.com/)
- [ ] I have updated the documentation accordingly, included in this PR
