### PR TITLE
Tweaked Confirmation Prompt and Added Test

### DIFF
--- a/app/views/assessments/_handin_form.html.erb
+++ b/app/views/assessments/_handin_form.html.erb
@@ -53,7 +53,7 @@
               <div id="submission_error" style="color:red" class="col s6 m8 center-align"></div>
               <% if @aud.past_due_at? then %>
                 <div class="col s6 m4 center-align">
-                  <%= f.submit("Submit Late", id: "fake-submit", class: "btn primary handin-btn disabled") %>
+                  <%= f.submit("Submit Late", id: "fake-submit", class: "btn primary handin-btn disabled", data: { confirm: "You are #{grace_late_info}. Are you sure you want to continue?" }) %>
                 </div>
               <% else %>
                 <div class="col s6 m4 center-align">

--- a/app/views/assessments/_handin_form.html.erb
+++ b/app/views/assessments/_handin_form.html.erb
@@ -53,7 +53,7 @@
               <div id="submission_error" style="color:red" class="col s6 m8 center-align"></div>
               <% if @aud.past_due_at? then %>
                 <div class="col s6 m4 center-align">
-                  <%= f.submit("Submit Late", id: "fake-submit", class: "btn primary handin-btn disabled", data: { confirm: "Autolab Notification: You are #{grace_late_info}. Continue?" }) %>
+                  <%= f.submit("Submit Late", id: "fake-submit", class: "btn primary handin-btn disabled", data: { confirm: "Autolab Notification: You are #{grace_late_info}. Click to confirm!" }) %>
                 </div>
               <% else %>
                 <div class="col s6 m4 center-align">

--- a/app/views/assessments/_handin_form.html.erb
+++ b/app/views/assessments/_handin_form.html.erb
@@ -9,14 +9,14 @@
       <% days_late = (days_late / 1.day).ceil %>
       <% grace_days_left = @aud.grace_days_usable %>
       <% if grace_days_left >= days_late %>
-        <% grace_late_info = "submitting #{pluralize(days_late, 'day')} late using #{pluralize(days_late, 'grace day')}" %>
+        <% grace_late_info = "#{pluralize(days_late, 'day')} late using #{pluralize(days_late, 'grace day')}" %>
       <% elsif grace_days_left > 0 %>
-        <% grace_late_info = "submitting #{pluralize(days_late, 'day')} late using #{pluralize(grace_days_left, 'grace day')} with #{pluralize(days_late - grace_days_left, 'penalty late day')}" %>
+        <% grace_late_info = "#{pluralize(days_late, 'day')} late using #{pluralize(grace_days_left, 'grace day')} and #{pluralize(days_late - grace_days_left, 'penalty late day')}" %>
       <% else %>
-        <% grace_late_info = "submitting #{pluralize(days_late, 'day')} late using #{pluralize(days_late, 'penalty late day')}" %>
+        <% grace_late_info = "#{pluralize(days_late, 'day')} late using #{pluralize(days_late, 'penalty late day')}" %>
       <% end %>
-      <% late_confirm = " and that I am #{grace_late_info} under the late policy as defined in the syllabus" %>
-      <p><b>Warning:</b> Submitting late may result in the usage of a grace day or a grade penalty!</p>
+      <% late_confirm = " and are #{grace_late_info}" %>
+      <p><b>Warning:</b> Submitting late will result in grace day usage or penalties as per the syllabus!</p>
     <% end %>
 
     <div class="row">
@@ -44,8 +44,8 @@
             <% end %>
             <%= label_tag(:integrity_checkbox) do %>
               <%= check_box_tag(:integrity_checkbox) %>
-              <%= content_tag("span", "I affirm that I have complied with this course's academic
-              integrity policy as defined in the syllabus#{late_confirm}.") %>
+              <%= content_tag("span", "I affirm that I comply with this course's academic
+              integrity policy#{late_confirm}.") %>
             <% end %>
 
             <%= f.file_field :file %>
@@ -53,11 +53,11 @@
               <div id="submission_error" style="color:red" class="col s6 m8 center-align"></div>
               <% if @aud.past_due_at? then %>
                 <div class="col s6 m4 center-align">
-                  <%= f.submit("Submit Late", id: "fake-submit", class: "btn primary handin-btn disabled", data: { confirm: "You are #{grace_late_info}. Are you sure you want to continue?" }) %>
+                  <%= f.submit("Submit Late", id: "fake-submit", class: "btn primary handin-btn disabled", data: { confirm: "Autolab Notification: You are #{grace_late_info}. Continue?" }) %>
                 </div>
               <% else %>
                 <div class="col s6 m4 center-align">
-                  <%= f.submit("Submit", id: "fake-submit", class: "btn primary handin-btn disabled") %>
+                  <%= f.submit("Submit", id: "fake-submit", class: "btn primary handin-btn disabled", data: { confirm: "Autolab Notification: Confirm submission?" }) %>
                 </div>
               <% end %>
             </div>

--- a/spec/models/handin_form_spec.rb
+++ b/spec/models/handin_form_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe "handin_form", type: :view do
+  let(:assessment) { create(:assessment) }
+  let(:aud) { create(:assessment_user_datum, assessment: assessment, past_due_at: true) }
+  let(:grace_late_info) { "using 1 late day" } 
+
+  before do
+    assign(:aud, aud)
+    allow(view).to receive(:grace_late_info).and_return(grace_late_info)
+    render partial: "assessments/handin_form", locals: { f: ActionView::Helpers::FormBuilder.new(nil, nil, self, {}) }
+  end
+
+  it "renders the Submit Late button with a confirmation prompt" do
+    expect(rendered).to have_selector("input[type='submit'][id='fake-submit']")
+    expect(rendered).to have_selector("input[data-confirm='You are #{grace_late_info}. Are you sure you want to continue?']")
+  end
+end
+

--- a/spec/models/handin_form_spec.rb
+++ b/spec/models/handin_form_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "handin_form", type: :view do
 
   it "renders the Submit Late button with a confirmation prompt" do
     expect(rendered).to have_selector("input[type='submit'][id='fake-submit']")
-    expect(rendered).to have_selector("input[data-confirm='You are #{grace_late_info}. Are you sure you want to continue?']")
+    expect(rendered).to have_selector("input[data-confirm='Autolab Notification: You are #{grace_late_info}. Click to confirm!']")
   end
 end
 


### PR DESCRIPTION
Tested Confirmation Prompt

Description
This update modifies the data-confirm attribute for the "Submit Late" button in the handin_form. When students attempt to submit an assignment late, they are now prompted with a custom confirmation message that includes dynamic details about their late submission, such as the number of grace days or penalty late days being used. This change enhances the user experience by providing clearer, more informative feedback relevant to Autolab's policies. The test is used to ensure that the updated confirmation message appears correctly in the rendered handin_form view. It checks that the "Submit Late" button renders with the correct data-confirm attribute, ensuring the confirmation prompt dynamically includes the grace_late_info.
<img width="537" alt="Screenshot 2024-12-08 at 9 53 27 PM" src="https://github.com/user-attachments/assets/fb51c6a6-1712-4061-85c6-f61ea6a958f2">


Motivation and Context
Students mistakenly submit to the wrong assignments, either wasting late days unnecessarily or submitting to assignments where late days are not allowed. As a solution, we can add a confirmation prompt when students are about to use late days. This should be tested to verify that it shows up. Fixes https://github.com/autolab/Autolab/issues/2211

How Has This Been Tested?
Tested locally to make sure that the confirmation prompt appears when submitting (see screenshots) and ran 
rspec spec/models/handin_form_spec.rb

Types of changes
Bug fix (non-breaking change which fixes an issue)
 New feature (non-breaking change which adds functionality)
 Breaking change (fix or feature that would cause existing functionality to change)

Checklist:
[ x ] I have run rubocop and erblint for style check. If you haven't, run overcommit --install && overcommit --sign to use pre-commit hook for linting
 My change requires a change to the documentation, which is located at [Autolab Docs](https://docs.autolabproject.com/)
 I have updated the documentation accordingly, included in this PR
