### PR TITLE
Fix viewing GitHub submissions

### DIFF
--- a/lib/archive.rb
+++ b/lib/archive.rb
@@ -71,7 +71,7 @@ module Archive
 
       # edge case for removing "./" from pathnames
       if file[:pathname].include?("./")
-        file[:pathname] = File.cleanpath(file[:pathname], rel_root = true).gsub("..", "__PARENT__")
+        file[:pathname] = Pathname.new(file[:pathname]).cleanpath.to_s.gsub("..", "__PARENT__")
       end
 
       if(file[:directory])


### PR DESCRIPTION
(cherry picked from commit 78f79335407e08172c495fb74aedae5bfc9666ef)

## Description
The `File.cleanpath` method used in `Archive.sanitize_directories` comes from the Yard package, which is only installed in development. This results in errors in production when viewing a GitHub submission. I rewrote a line in `sanitize_directories` to avoid using that library.

Here's a demonstration of the method not existing in production using a debugger:

![2025-02-17_12_04](https://github.com/user-attachments/assets/730dc54d-f57d-451e-b3dc-4b6d380b9de3)

And here's the generic error displayed on Autolab when attempting to view a GitHub submission's contents:

![image](https://github.com/user-attachments/assets/76fe75a2-03a4-4d79-94c6-1a6dc12b44ad)

## How Has This Been Tested?
After making the change to use the Pathname class instead, I verified I'm able to view the contents of a GitHub submission through the UI.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
