### PR TITLE
Added link for score details and regrade flash error

### DIFF
--- a/app/assets/javascripts/manage_submissions.js
+++ b/app/assets/javascripts/manage_submissions.js
@@ -158,9 +158,15 @@ $(document).ready(function() {
                   ${submission.total}
                 </td>
                 ${submission.problems.
-                map((problem) =>
-                  `<td class="submissions-td">${data.scores[submission.id]?.[problem.id]?.['score'] ?? "-"}</td>`
-                ).join('')}
+                    map((problem) =>
+                        `<td class="submissions-td">
+                        ${data.scores[submission.id]?.[problem.id]?.['score'] !== undefined
+                          ? `<a href="viewFeedback?submission_id=${submission.id}&feedback=${problem.id}">
+                        ${data.scores[submission.id][problem.id]['score'].toFixed(1)}
+                     </a>`
+                        : "-"}
+                    </td>`
+                    ).join('')}
                 <td class="submissions-td">
                   ${submission.late_penalty}
                 </td>
@@ -279,7 +285,6 @@ $(document).ready(function() {
       });
       changeButtonStates(!selectedSubmissions.length); // update button states
     }
-
 
     // SELECTED BUTTONS
 

--- a/app/controllers/assessment/autograde.rb
+++ b/app/controllers/assessment/autograde.rb
@@ -90,7 +90,9 @@ module AssessmentAutograde
 
     # Now regrade only the most recent submissions. Keep track of
     # any handins that fail.
-    submissions = submission_ids.map {|sid| @assessment.submissions.find_by_id(sid)}
+    submissions = submission_ids.filter_map do |sid|
+      _is_i?(sid) ? @assessment.submissions.find_by_id(sid) : nil
+    end
 
     begin
       failed_list = sendJob_batch(@course, @assessment, submissions, @cud)
@@ -114,7 +116,7 @@ module AssessmentAutograde
       end
     end
 
-    success_jobs = submission_ids.size - failure_jobs
+    success_jobs = submissions.size - failure_jobs
     if success_jobs > 0
       link = "<a href=\"#{url_for(controller: 'jobs')}\">#{ActionController::Base.helpers.pluralize(success_jobs, "submission")}</a>"
       flash[:success] = ("Regrading #{link}")
@@ -230,4 +232,7 @@ module AssessmentAutograde
     job
   end
 
+  def _is_i?(string)
+    !!(string =~ /\A[-+]?[0-9]+\z/)
+  end
 end


### PR DESCRIPTION
## Description
Added links to autograding job for each submission.
![Screenshot 2025-02-17 at 7 11 13 PM](https://github.com/user-attachments/assets/4f55ae70-ebef-477d-b688-bb08fcbbb22e)

Fixed regrade selected bug by filtering submissions to only include integers.
![Screenshot 2025-02-17 at 7 10 57 PM](https://github.com/user-attachments/assets/8690bb66-279e-41ef-9a0b-2a17b167039e)

## How Has This Been Tested?
- Run regrade selected and check that the right amount of submissions are regraded and none have failed
- Click into score details and click on autograded score and check that it leads you to the right feedback page

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have run rubocop and erblint for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://docs.autolabproject.com/)
- [ ] I have updated the documentation accordingly, included in this PR
