### PR TITLE
Changing the manage submissions button to be ajax requests

### DIFF
--- a/app/assets/javascripts/manage_submissions.js
+++ b/app/assets/javascripts/manage_submissions.js
@@ -313,7 +313,6 @@ $(document).ready(function() {
       buttonIDs.forEach((id) => {
         const button = $(id);
         if (state) {
-          console.log(`Disabling: ${id}`, button);
           if (id === "#download-selected") {
             $(id).prop('href', baseURLs[id]);
           }
@@ -378,7 +377,6 @@ $(document).ready(function() {
         }
       });
     }
-
 
     changeButtonStates(true); // disable all buttons by default
 

--- a/app/assets/javascripts/manage_submissions.js
+++ b/app/assets/javascripts/manage_submissions.js
@@ -370,6 +370,7 @@ $(document).ready(function() {
                 changeButtonStates(true);
               },
               error: function (error) {
+                clearInterval(refreshInterval);
                 alert("An error occurred while processing the request.");
               },
             });

--- a/app/assets/javascripts/manage_submissions.js
+++ b/app/assets/javascripts/manage_submissions.js
@@ -1,5 +1,8 @@
 const manage_submissions_endpoints = {
     'regrade-selected': 'regradeBatch',
+    'delete-selected': 'submissions/destroy_batch',
+    'download-selected': 'submissions/download_batch',
+    'excuse-selected': 'submissions/excuse_batch',
     'score_details': 'submissions/score_details',
 };
 
@@ -307,21 +310,75 @@ $(document).ready(function() {
     });
 
     function changeButtonStates(state) {
-      state ? buttonIDs.forEach((id) => $(id).addClass('disabled')) : buttonIDs.forEach((id) => $(id).removeClass('disabled'));
-
-      // prop each selected button with selected submissions
-      if (!state) {
-        var urlParam = $.param({'submission_ids': selectedSubmissions});
-        buttonIDs.forEach(function(id) {
-          var newHref = baseURLs[id] + '?' + urlParam;
-          $(id).prop('href', newHref);
-        });
-      } else {
-        buttonIDs.forEach(function(id) {
-          $(id).prop('href', baseURLs[id]);
-        });
-      }
+      buttonIDs.forEach((id) => {
+        const button = $(id);
+        if (state) {
+          console.log(`Disabling: ${id}`, button);
+          if (id === "#download-selected") {
+            $(id).prop('href', baseURLs[id]);
+          }
+          button.addClass("disabled");
+          button.off("click").prop("disabled", true);
+        } else {
+          button.removeClass("disabled").prop("disabled", false);
+          if (id == "#download-selected") {
+            var urlParam = $.param({'submission_ids': selectedSubmissions});
+            buttonIDs.forEach(function(id) {
+              var newHref = baseURLs[id] + '?' + urlParam;
+              $(id).prop('href', newHref);
+            });
+            return;
+          }
+          $(document).off("click", id).on("click", id, function (event) {
+            console.log(`${id} button clicked`);
+            event.preventDefault();
+            if (selectedSubmissions.length === 0) {
+              alert("No submissions selected.");
+              return;
+            }
+            const endpoint = manage_submissions_endpoints[id.replace("#", "")];
+            const requestData = { submission_ids: selectedSubmissions };
+            if (id === "#delete-selected") {
+              if (!confirm("Deleting will delete all checked submissions and cannot be undone. Are you sure you want to delete these submissions?")) {
+                return;
+              }
+            }
+            let refreshInterval = setInterval(() => {
+              location.reload();
+            }, 5000);
+            $.ajax({
+              url: endpoint,
+              type: "POST",
+              contentType: "application/json",
+              data: JSON.stringify(requestData),
+              dataType: "json",
+              headers: {
+                "X-CSRF-Token": $('meta[name="csrf-token"]').attr("content"),
+              },
+              success: function (response) {
+                clearInterval(refreshInterval);
+                if (response.redirect) {
+                  window.location.href = response.redirect;
+                  return;
+                }
+                if (response.error) {
+                  alert(response.error);
+                }
+                if (response.success) {
+                  alert(response.success);
+                }
+                selectedSubmissions = [];
+                changeButtonStates(true);
+              },
+              error: function (error) {
+                alert("An error occurred while processing the request.");
+              },
+            });
+          });
+        }
+      });
     }
+
 
     changeButtonStates(true); // disable all buttons by default
 

--- a/app/controllers/assessment/autograde.rb
+++ b/app/controllers/assessment/autograde.rb
@@ -86,7 +86,11 @@ module AssessmentAutograde
   #
   # action_auth_level :regradeBatch, :instructor
   def regradeBatch
-    submission_ids = params[:submission_ids]
+    request_body = request.body.read
+    submission_ids = JSON.parse(request_body)['submission_ids']
+
+    # Ensure submission_ids is an array
+    submission_ids = Array(submission_ids)
 
     # Now regrade only the most recent submissions. Keep track of
     # any handins that fail.
@@ -123,7 +127,10 @@ module AssessmentAutograde
     # For both :success and :error
     flash[:html_safe] = true
 
-    redirect_to([@course, @assessment, :submissions]) && return
+    respond_to do |format|
+      format.html { redirect_to [@course, @assessment, :submissions] }
+      format.json { render json: { redirect: url_for([@course, @assessment, :submissions]) } }
+    end
   end
 
   #

--- a/app/controllers/assessment/autograde.rb
+++ b/app/controllers/assessment/autograde.rb
@@ -87,7 +87,15 @@ module AssessmentAutograde
   # action_auth_level :regradeBatch, :instructor
   def regradeBatch
     request_body = request.body.read
-    submission_ids = JSON.parse(request_body)['submission_ids']
+    submission_ids = begin if request_body.present?
+                             parsed_data = JSON.parse(request_body)
+                         Array(parsed_data['submission_ids'])
+                       else
+                         params[:submission_ids]
+                       end
+                     rescue JSON::ParserError => e
+                       params[:submission_ids] || []
+                     end
 
     # Ensure submission_ids is an array
     submission_ids = Array(submission_ids)

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -200,7 +200,9 @@ class SubmissionsController < ApplicationController
   # remove a given submission for a student
   action_auth_level :destroy_batch, :instructor
   def destroy_batch
-    submission_ids = params[:submission_ids]
+    request_body = request.body.read
+    submission_ids = JSON.parse(request_body)['submission_ids']
+    submission_ids = Array(submission_ids)
     submissions = Submission.where(id: submission_ids)
     scount = 0
     fcount = 0
@@ -241,8 +243,10 @@ class SubmissionsController < ApplicationController
                                                       fcount, 'submission'
                                                     )} failed."
     end
-    redirect_to(course_assessment_submissions_path(submissions[0].course_user_datum.course,
-                                                   submissions[0].assessment)) && return
+    respond_to do |format|
+      format.html { redirect_to [@course, @assessment, :submissions] }
+      format.json { render json: { redirect: url_for([@course, @assessment, :submissions]) } }
+    end
   end
 
   # this is good
@@ -384,7 +388,9 @@ class SubmissionsController < ApplicationController
 
   action_auth_level :excuse_batch, :course_assistant
   def excuse_batch
-    submission_ids = params[:submission_ids]
+    request_body = request.body.read
+    submission_ids = JSON.parse(request_body)['submission_ids']
+    submission_ids = Array(submission_ids)
     flash[:error] = "Cannot index submissions for nil assessment" if @assessment.nil?
 
     unless @assessment.valid?
@@ -434,7 +440,10 @@ class SubmissionsController < ApplicationController
 
     flash[:success] =
       "#{ActionController::Base.helpers.pluralize(auds_to_excuse.size, 'student')} excused."
-    redirect_to course_assessment_submissions_path(@course, @assessment)
+    respond_to do |format|
+      format.html { redirect_to [@course, @assessment, :submissions] }
+      format.json { render json: { redirect: url_for([@course, @assessment, :submissions]) } }
+    end
   end
 
   action_auth_level :unexcuse, :course_assistant

--- a/app/views/submissions/index.html.erb
+++ b/app/views/submissions/index.html.erb
@@ -88,13 +88,13 @@
 <%# Selected buttons, hidden so HTML can be accessed in DataTables %>
 <div class="selected-buttons-placeholder">
   <div id="regrade-batch-html">
-    <a id="regrade-selected" class="btn submissions-selected" title="Regrade selected submissions">
-      <i class="material-icons">cached</i>Regrade Selected
-    </a>
+    <%= link_to "Regrade Selected", class: "btn submissions-selected", title: "Regrade selected submissions" do %>
+      <i class="material-icons">cached</i> Regrade Selected
+    <% end %>
   </div>
 
   <div id="delete-batch-html">
-    <a id="delete-selected" class="btn submissions-selected" title="Delete selected submissions">
+    <a class="btn submissions-selected" title="Delete selected submissions">
       <i class="material-icons">delete_outline</i>Delete Selected
     </a>
   </div>
@@ -102,13 +102,13 @@
   <div id="download-batch-html">
     <%= link_to "<i class='material-icons'>download</i>Download Selected".html_safe,
                 download_batch_course_assessment_submissions_path(@course, @assessment, @submissions),
-                { method: :get,
+                { method: :post,
                   title: "Download selected submissions",
                   class: "btn submissions-selected" } %>
   </div>
 
   <div id="excuse-batch-html">
-    <a id="excuse-selected" class="btn submissions-selected" title="Excuse selected submissions">
+    <a class="btn submissions-selected" title="Excuse selected submissions">
       <i class="material-icons">done</i>Excuse Selected
     </a>
   </div>

--- a/app/views/submissions/index.html.erb
+++ b/app/views/submissions/index.html.erb
@@ -88,20 +88,15 @@
 <%# Selected buttons, hidden so HTML can be accessed in DataTables %>
 <div class="selected-buttons-placeholder">
   <div id="regrade-batch-html">
-    <%= link_to "<i class='material-icons'>cached</i>Regrade Selected".html_safe,
-                regradeBatch_course_assessment_path(@course, @assessment),
-                { method: :post,
-                  title: "Regrade selected submissions",
-                  class: "btn submissions-selected" } %>
+    <a id="regrade-selected" class="btn submissions-selected" title="Regrade selected submissions">
+      <i class="material-icons">cached</i>Regrade Selected
+    </a>
   </div>
 
   <div id="delete-batch-html">
-    <%= link_to "<i class='material-icons'>delete_outline</i>Delete Selected".html_safe,
-                destroy_batch_course_assessment_submissions_path(@course, @assessment, @submissions),
-                { method: :post,
-                  title: "Delete selected submissions",
-                  class: "btn submissions-selected",
-                  data: { confirm: "Deleting will delete all checked submissions and cannot be undone. Are you sure you want to delete these submissions?" } } %>
+    <a id="delete-selected" class="btn submissions-selected" title="Delete selected submissions">
+      <i class="material-icons">delete_outline</i>Delete Selected
+    </a>
   </div>
 
   <div id="download-batch-html">
@@ -113,11 +108,9 @@
   </div>
 
   <div id="excuse-batch-html">
-    <%= link_to "<i class='material-icons'>done</i>Excuse Selected".html_safe,
-                excuse_batch_course_assessment_submissions_path(@course, @assessment, @submissions),
-                { method: :post,
-                  title: "Excuse selected submissions",
-                  class: "btn submissions-selected" } %>
+    <a id="excuse-selected" class="btn submissions-selected" title="Excuse selected submissions">
+      <i class="material-icons">done</i>Excuse Selected
+    </a>
   </div>
 
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -178,7 +178,7 @@ Rails.application.routes.draw do
         collection do
           get "download_all"
           post "destroy_batch"
-          get "download_batch"
+          post "download_batch"
           get "popover"
           post "excuse_batch"
           post "unexcuse"


### PR DESCRIPTION
## Description
- Changed the regrade selected, delete selected, and excuse buttons to be ajax post requests
- Can't do this for download selected because it is a get request, and we shouldn't pass data in request body for get requests

## Motivation and Context
- Previously, all request information was contained in the request url which was not ok for large requests
- Resolves issue #2261 

## How Has This Been Tested?
- Tested in local env in manage submissions

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have run rubocop and erblint for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://docs.autolabproject.com/)
- [ ] I have updated the documentation accordingly, included in this PR

## Other issues / help required
- I am not sure why only the download selected button is properly disabled, when I console.log, the other buttons are the correct class
- Not sure if this is that user friendly, any input would be appreciated

If unsure, feel free to submit first and we'll help you along.
