### PR TITLE
Additional documentation for etc/hosts configuration issue

### DIFF
--- a/docs/installation/docker-compose.md
+++ b/docs/installation/docker-compose.md
@@ -308,3 +308,5 @@ You can resolve this by changing the owner of the files to be your current user,
 This happens when you are accessing Autolab via localhost, as Tango will attempt to send the autograder logs to its own localhost instead.
 
 To remedy this, add `127.0.0.1 autolab` to `/etc/hosts` and access Autolab via `http://autolab` instead of `http://localhost`.
+
+If you are accessing Autolab on a different host, add `<your public_ip> <your fqdn> autolab` to your `/etc/hosts` file and access Autolab via `http://autolab`.    

--- a/docs/installation/tango-troubleshoot.md
+++ b/docs/installation/tango-troubleshoot.md
@@ -11,3 +11,10 @@ $ redis-cli
 OK
 127.0.0.1:6379> 
 ```
+
+## Tango jobs completed but scores are not updated
+If you are accessing Autolab on localhost, Tango will attempt to send the autograder logs to its own localhost instead. 
+
+To fix this, add `127.0.0.1 autolab` to your `/etc/hosts` file and access Autolab via `http://autolab` instead of `http://localhost`.
+
+If you are accessing Autolab on a different host, add `<your public_ip> <your fqdn> autolab` to your `/etc/hosts` file and access Autolab via `http://autolab`.


### PR DESCRIPTION
## Description
Adds clearer documentation for #2260.

The same documentation appears in troubleshooting of docker compose but I think searching in Tango's documentation when facing this issue is also an equally valid response.

## How Has This Been Tested?
Ran `python3 -m mkdocs serve`.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have run rubocop and erblint for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [x] My change requires a change to the documentation, which is located at [Autolab Docs](https://docs.autolabproject.com/)
- [x] I have updated the documentation accordingly, included in this PR
