### PR TITLE
Regrade all and select checkbox message

### DIFF
--- a/app/assets/javascripts/manage_submissions.js
+++ b/app/assets/javascripts/manage_submissions.js
@@ -158,9 +158,15 @@ $(document).ready(function() {
                   ${submission.total}
                 </td>
                 ${submission.problems.
-                map((problem) =>
-                  `<td class="submissions-td">${data.scores[submission.id]?.[problem.id]?.['score'] ?? "-"}</td>`
-                ).join('')}
+                    map((problem) =>
+                        `<td class="submissions-td">
+                        ${data.scores[submission.id]?.[problem.id]?.['score'] !== undefined
+                          ? `<a href="viewFeedback?submission_id=${submission.id}&feedback=${problem.id}">
+                        ${data.scores[submission.id][problem.id]['score'].toFixed(1)}
+                     </a>`
+                        : "-"}
+                    </td>`
+                    ).join('')}
                 <td class="submissions-td">
                   ${submission.late_penalty}
                 </td>
@@ -279,7 +285,6 @@ $(document).ready(function() {
       });
       changeButtonStates(!selectedSubmissions.length); // update button states
     }
-
 
     // SELECTED BUTTONS
 

--- a/app/assets/javascripts/manage_submissions.js
+++ b/app/assets/javascripts/manage_submissions.js
@@ -303,6 +303,7 @@ $(document).ready(function() {
 
     if (!is_autograded) {
       $('#regrade-selected').hide();
+      $('#regrade-all-html').hide();
     }
 
     // base URLs for selected buttons

--- a/app/assets/javascripts/manage_submissions.js
+++ b/app/assets/javascripts/manage_submissions.js
@@ -311,6 +311,20 @@ $(document).ready(function() {
       baseURLs[id] = $(id).prop('href');
     });
 
+    function updateSelectedCount(numericSubmissions) {
+      const allBoxes = $('#submissions tbody .cbox').length;
+      const selectedCountElement = document.getElementById("selected-count-html");
+      const placeholder = document.querySelector(".selected-count-placeholder");
+      if (selectedCountElement) {
+        selectedCountElement.innerText = `All ${numericSubmissions.length} submissions on this page selected.`;
+        if (numericSubmissions.length === allBoxes) {
+          placeholder.style.display = "block";
+        } else if (numericSubmissions.length <= allBoxes) {
+          placeholder.style.display = "none";
+        }
+      }
+    }
+
     function changeButtonStates(state) {
       state ? buttonIDs.forEach((id) => $(id).addClass('disabled')) : buttonIDs.forEach((id) => $(id).removeClass('disabled'));
 
@@ -362,6 +376,7 @@ $(document).ready(function() {
       const numericSelectedSubmissions = selectedSubmissions.filter(submissionId => typeof submissionId === 'number');
       // Update the "Select All" checkbox based on filtered numeric submissions
       $('#cbox-select-all').prop('checked', numericSelectedSubmissions.length === $('#submissions tbody .cbox').length);
+      updateSelectedCount(numericSelectedSubmissions);
       changeButtonStates(disableButtons);
     }
 

--- a/app/assets/stylesheets/style.css.scss
+++ b/app/assets/stylesheets/style.css.scss
@@ -1628,6 +1628,21 @@ table.sub td, th {
   align-items: center;
 }
 
+.selected-count-placeholder {
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  text-align: center;
+  background-color: $autolab-submissions-background;
+  padding-top: 10px;
+  padding-bottom: 10px;
+  border-radius: 4px;
+}
+
+.selected-count-red {
+  color: $autolab-red;
+}
+
 .excused-popover {
   background-color: $autolab-submissions-background;
   border-radius: 11px;

--- a/app/controllers/assessment/autograde.rb
+++ b/app/controllers/assessment/autograde.rb
@@ -166,7 +166,7 @@ module AssessmentAutograde
     success_jobs = last_submissions.size - failure_jobs
     if success_jobs > 0
       link = "<a href=\"#{url_for(controller: 'jobs')}\">#{ActionController::Base.helpers.pluralize(success_jobs, "student")}</a>"
-      flash[:success] = `Regrading the #{success_jobs.count} recent submissions`
+      flash[:success] = `Regrading the #{success_jobs} recent submissions`
     end
 
     # For both :success and :error

--- a/app/controllers/assessment/autograde.rb
+++ b/app/controllers/assessment/autograde.rb
@@ -28,7 +28,7 @@ module AssessmentAutograde
 
     extend_config_module(@assessment, submissions[0], @cud)
 
-    if (@assessment.use_unique_module_name)
+    if @assessment.use_unique_module_name
       require_relative(@assessment.unique_config_file_path)
     else
       require_relative(Rails.root.join("assessmentConfig", "#{@course.name}-#{@assessment.name}.rb"))
@@ -119,7 +119,7 @@ module AssessmentAutograde
     success_jobs = submissions.size - failure_jobs
     if success_jobs > 0
       link = "<a href=\"#{url_for(controller: 'jobs')}\">#{ActionController::Base.helpers.pluralize(success_jobs, "submission")}</a>"
-      flash[:success] = ("Regrading #{link}")
+      flash[:success] = "Regrading #{link}"
     end
 
     # For both :success and :error
@@ -136,7 +136,7 @@ module AssessmentAutograde
   # action_auth_level :regradeAll, :instructor
   def regradeAll
     # Grab all of the submissions for this assessment
-    @submissions = @assessment.submissions.where(special_type: Submission::NORMAL)
+    @submissions = @assessment.submissions.where(special_type: [Submission::NORMAL, nil])
                    .order("version DESC")
 
     last_submissions = @submissions.latest
@@ -166,7 +166,7 @@ module AssessmentAutograde
     success_jobs = last_submissions.size - failure_jobs
     if success_jobs > 0
       link = "<a href=\"#{url_for(controller: 'jobs')}\">#{ActionController::Base.helpers.pluralize(success_jobs, "student")}</a>"
-      flash[:success] = ("Regrading the most recent submissions from #{link}")
+      flash[:success] = `Regrading the #{success_jobs.count} recent submissions`
     end
 
     # For both :success and :error
@@ -226,8 +226,8 @@ module AssessmentAutograde
 
     link = "<a href=\"#{url_for(controller: 'jobs', action: 'getjob', id: job)}\">Job ID = #{job}</a>"
     viewFeedbackLink = "<a href=\"#{url_for(controller: 'assessments', action: 'viewFeedback', submission_id: submissions[0].id, feedback: assessment.problems[0].id)}\">View autograding progress.</a>"
-    flash[:success] = ("Submitted file #{submissions[0].filename} (#{link}) for autograding." \
-      " #{viewFeedbackLink}")
+    flash[:success] = "Submitted file #{submissions[0].filename} (#{link}) for autograding." \
+      " #{viewFeedbackLink}"
     flash[:html_safe] = true
     job
   end

--- a/app/controllers/assessment/autograde.rb
+++ b/app/controllers/assessment/autograde.rb
@@ -165,8 +165,7 @@ module AssessmentAutograde
 
     success_jobs = last_submissions.size - failure_jobs
     if success_jobs > 0
-      link = "<a href=\"#{url_for(controller: 'jobs')}\">#{ActionController::Base.helpers.pluralize(success_jobs, "student")}</a>"
-      flash[:success] = `Regrading the #{success_jobs} recent submissions`
+      flash[:success] = "Regrading #{success_jobs} recent submissions"
     end
 
     # For both :success and :error

--- a/app/controllers/assessment/autograde.rb
+++ b/app/controllers/assessment/autograde.rb
@@ -31,7 +31,8 @@ module AssessmentAutograde
     if @assessment.use_unique_module_name
       require_relative(@assessment.unique_config_file_path)
     else
-      require_relative(Rails.root.join("assessmentConfig", "#{@course.name}-#{@assessment.name}.rb"))
+      require_relative(Rails.root.join("assessmentConfig", 
+"#{@course.name}-#{@assessment.name}.rb"))
     end
 
     if @assessment.overwrites_method?(:autogradeDone)
@@ -106,19 +107,22 @@ module AssessmentAutograde
 
     failure_jobs = failed_list.length
     if failure_jobs > 0
-      flash[:error] = "Warning: Could not regrade #{ActionController::Base.helpers.pluralize(failure_jobs, "submission")}:<br>"
+      flash[:error] = 
+        "Warning: Could not regrade #{ActionController::Base.helpers.pluralize(failure_jobs, 
+"submission")}:<br>"
       failed_list.each do |failure|
-        if failure[:error].error_code == :nil_submission
-          flash[:error] += "Unrecognized submission ID<br>"
-        else
-          flash[:error] += "#{failure[:submission].filename}: #{failure[:error].message}<br>"
-        end
+        flash[:error] += if failure[:error].error_code == :nil_submission
+                           "Unrecognized submission ID<br>"
+                         else
+                           "#{failure[:submission].filename}: #{failure[:error].message}<br>"
+                         end
       end
     end
 
     success_jobs = submissions.size - failure_jobs
     if success_jobs > 0
-      link = "<a href=\"#{url_for(controller: 'jobs')}\">#{ActionController::Base.helpers.pluralize(success_jobs, "submission")}</a>"
+      link = "<a href=\"#{url_for(controller: 'jobs')}\">#{ActionController::Base.helpers.pluralize(
+success_jobs, "submission")}</a>"
       flash[:success] = "Regrading #{link}"
     end
 
@@ -153,13 +157,16 @@ module AssessmentAutograde
 
     failure_jobs = failed_list.length
     if failure_jobs > 0
-      flash[:error] = "Warning: Could not regrade #{ActionController::Base.helpers.pluralize(failure_jobs, "submission")}:<br>"
+      flash[:error] =
+        "Warning: Could not regrade #{ActionController::Base.helpers.pluralize(failure_jobs, "submission")}"
+
+      @failure_messages = []
       failed_list.each do |failure|
-        if failure[:error].error_code == :nil_submission
-          flash[:error] += "Unrecognized submission ID<br>"
-        else
-          flash[:error] += "#{failure[:submission].filename}: #{failure[:error].message}<br>"
-        end
+        @failure_messages << if failure[:error].error_code == :nil_submission
+                               "Unrecognized submission ID"
+                             else
+                               "#{failure[:submission].filename}: #{failure[:error].message}"
+                             end
       end
     end
 
@@ -188,7 +195,8 @@ module AssessmentAutograde
   #
   def sendJob_AddHTMLMessages(course, assessment, submissions)
     # Check for nil first, since students should know about this
-    flash[:error] = "Submission could not be autograded due to an error in creation" && return if submissions.blank?
+    flash[:error] = 
+      "Submission could not be autograded due to an error in creation" && return if submissions.blank?
 
     begin
       job = sendJob(course, assessment, submissions, @cud)
@@ -197,25 +205,29 @@ module AssessmentAutograde
       when :missing_autograding_props
         flash[:error] = "Autograding failed because there are no autograding properties."
         if @cud.instructor?
-          link = (view_context.link_to "Autograder Settings", [:edit, course, assessment, :autograder])
+          link = (view_context.link_to "Autograder Settings", 
+[:edit, course, assessment, :autograder])
           flash[:error] += " Visit #{link} to set the autograding properties."
           flash[:html_safe] = true
         else
           flash[:error] += " Please contact your instructor."
         end
       when :tango_open
-        flash[:error] = "There was an error submitting your autograding job. We are likely down for maintenance if issues persist, please contact #{Rails.configuration.school['support_email']}"
+        flash[:error] = 
+          "There was an error submitting your autograding job. We are likely down for maintenance if issues persist, please contact #{Rails.configuration.school['support_email']}"
       when :tango_upload
         flash[:error] = "There was an error uploading the submission file."
       when :tango_add_job
         flash[:error] = "Submission was rejected by autograder."
         if @cud.instructor?
-          link = (view_context.link_to "Autograder Settings", [:edit, course, assessment, :autograder])
+          link = (view_context.link_to "Autograder Settings", 
+[:edit, course, assessment, :autograder])
           flash[:error] += " Verify the autograding properties at #{link}.<br>ErrorMsg: " + e.additional_data
           flash[:html_safe] = true
         end
       when :missing_autograder_file
-        flash[:error] = "One or more files are missing in the server. Please contact the instructor. The missing files are: " + e.additional_data
+        flash[:error] = 
+          "One or more files are missing in the server. Please contact the instructor. The missing files are: " + e.additional_data
       else
         flash[:error] = "Autograding failed because of an unexpected exception in the system."
       end
@@ -223,8 +235,10 @@ module AssessmentAutograde
       raise e # pass it on
     end
 
-    link = "<a href=\"#{url_for(controller: 'jobs', action: 'getjob', id: job)}\">Job ID = #{job}</a>"
-    viewFeedbackLink = "<a href=\"#{url_for(controller: 'assessments', action: 'viewFeedback', submission_id: submissions[0].id, feedback: assessment.problems[0].id)}\">View autograding progress.</a>"
+    link = "<a href=\"#{url_for(controller: 'jobs', action: 'getjob', 
+id: job)}\">Job ID = #{job}</a>"
+    viewFeedbackLink = "<a href=\"#{url_for(controller: 'assessments', action: 'viewFeedback', 
+submission_id: submissions[0].id, feedback: assessment.problems[0].id)}\">View autograding progress.</a>"
     flash[:success] = "Submitted file #{submissions[0].filename} (#{link}) for autograding." \
       " #{viewFeedbackLink}"
     flash[:html_safe] = true

--- a/app/controllers/assessment/autograde.rb
+++ b/app/controllers/assessment/autograde.rb
@@ -90,7 +90,9 @@ module AssessmentAutograde
 
     # Now regrade only the most recent submissions. Keep track of
     # any handins that fail.
-    submissions = submission_ids.map {|sid| @assessment.submissions.find_by_id(sid)}
+    submissions = submission_ids.filter_map do |sid|
+      _is_i?(sid) ? @assessment.submissions.find_by_id(sid) : nil
+    end
 
     begin
       failed_list = sendJob_batch(@course, @assessment, submissions, @cud)
@@ -114,7 +116,7 @@ module AssessmentAutograde
       end
     end
 
-    success_jobs = submission_ids.size - failure_jobs
+    success_jobs = submissions.size - failure_jobs
     if success_jobs > 0
       link = "<a href=\"#{url_for(controller: 'jobs')}\">#{ActionController::Base.helpers.pluralize(success_jobs, "submission")}</a>"
       flash[:success] = ("Regrading #{link}")
@@ -230,4 +232,7 @@ module AssessmentAutograde
     job
   end
 
+  def _is_i?(string)
+    !!(string =~ /\A[-+]?[0-9]+\z/)
+  end
 end

--- a/app/views/submissions/index.html.erb
+++ b/app/views/submissions/index.html.erb
@@ -75,14 +75,23 @@
                 missing_course_assessment_submissions_path(@course, @assessment),
                 { title: "List the students who have not submitted anything",
                   class: "btn submissions-main" } %>
-    </div>
+  </div>
 
-    <div class="buttons-spacing">
+  <div class="buttons-spacing">
     <%= link_to "<i class='material-icons left submissions-icons'>event</i>Manage Extensions".html_safe,
                 [@course, @assessment, :extensions],
                 { title: "Manage extensions for this assignment",
                   class: "btn submissions-main" } %>
-    </div>
+  </div>
+
+  <div>
+    <%= link_to "<i class='material-icons left submissions-icons'>cached</i>Regrade All".html_safe,
+                regradeAll_course_assessment_path(@course, @assessment),
+                { method: :post,
+                  title: "Regrade all submissions for this assignment",
+                  class: "btn submissions-main",
+                  data: { confirm: "Are you sure you want to regrade all #{@assessment.submissions.where(special_type: [Submission::NORMAL, nil]).count} submissions?" } } %>
+  </div>
 </div>
 
 <%# Selected buttons, hidden so HTML can be accessed in DataTables %>
@@ -119,7 +128,13 @@
                   title: "Excuse selected submissions",
                   class: "btn submissions-selected" } %>
   </div>
+</div>
 
+<div class="selected-count-placeholder" style="display: none;">
+  <span id="selected-count-html">0 submissions selected</span>
+  <span>Click <%= link_to "Regrade All", regradeAll_course_assessment_path(@course, @assessment),
+                          { method: :post, title: "Regrade all submissions", class: "selected-count-red",
+                            data: { confirm: "Are you sure you want to regrade all #{@assessment.submissions.where(special_type: [Submission::NORMAL, nil]).count} submissions?" } } %>  to regrade </span><%= @submissions.length %><span> submissions.</span>
 </div>
 
 <table class="prettyBorder" id="submissions">

--- a/app/views/submissions/index.html.erb
+++ b/app/views/submissions/index.html.erb
@@ -90,7 +90,7 @@
                 { method: :post,
                   title: "Regrade all submissions for this assignment",
                   class: "btn submissions-main",
-                  data: { confirm: "Are you sure you want to regrade all #{@assessment.submissions.where(special_type: [Submission::NORMAL, nil]).count} submissions?" } } %>
+                  data: { confirm: "Are you sure you want to regrade all #{@assessment.submissions.where(special_type: [Submission::NORMAL, nil]).latest.count} latest submissions?" } } %>
   </div>
 </div>
 
@@ -134,7 +134,7 @@
   <span id="selected-count-html">0 submissions selected</span>
   <span>Click <%= link_to "Regrade All", regradeAll_course_assessment_path(@course, @assessment),
                           { method: :post, title: "Regrade all submissions", class: "selected-count-red",
-                            data: { confirm: "Are you sure you want to regrade all #{@assessment.submissions.where(special_type: [Submission::NORMAL, nil]).count} submissions?" } } %>  to regrade </span><%= @submissions.length %><span> submissions.</span>
+                            data: { confirm: "Are you sure you want to regrade all #{@assessment.submissions.where(special_type: [Submission::NORMAL, nil]).latest.count} latest submissions?" } } %>  to regrade all </span><%= @submissions.latest.length %><span> latest submissions.</span>
 </div>
 
 <table class="prettyBorder" id="submissions">

--- a/app/views/submissions/index.html.erb
+++ b/app/views/submissions/index.html.erb
@@ -84,7 +84,7 @@
                   class: "btn submissions-main" } %>
   </div>
 
-  <div>
+  <div id="regrade-all-html">
     <%= link_to "<i class='material-icons left submissions-icons'>cached</i>Regrade All".html_safe,
                 regradeAll_course_assessment_path(@course, @assessment),
                 { method: :post,


### PR DESCRIPTION
## Description
Regrade all button regrades submissions for every page. Encountered a cookie overflow problem when grading large amount of submissions so I changed the flash message to include counts instead of links.

Not every submission is normal/excused/NG so I changed regrade all to also include if a submission is none of the above.

Added a message that appears when the select all checkbox is clicked and all submissions in the page are clicked.
<img width="1073" alt="Screenshot 2025-03-09 at 6 03 37 AM" src="https://github.com/user-attachments/assets/83aa9d4f-b02f-4247-b4e5-19ee60e8b8e3" />

## How Has This Been Tested?
- Create course with more than 100 users
- Check that regrade all button works as expected
- Check that message appears when you select all submissions in a page and that regrade all link in the button works as expected

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have run rubocop and erblint for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://docs.autolabproject.com/)
- [ ] I have updated the documentation accordingly, included in this PR