### PR TITLE
Manage submissions page shows progress for regrading selected submissions

### DIFF
--- a/app/assets/stylesheets/_variables.scss
+++ b/app/assets/stylesheets/_variables.scss
@@ -25,3 +25,4 @@ $autolab-selected-gray: #f5f5f5;
 $autolab-border-gray: #f4f1f1;
 $autolab-gray-text: #676464;
 $autolab-highlight-comments: #008000;
+$autolab-yellow: #f7e788;

--- a/app/assets/stylesheets/style.css.scss
+++ b/app/assets/stylesheets/style.css.scss
@@ -1718,3 +1718,13 @@ table.sub td, th {
   margin-top: 5px;
   color: $autolab-grey;
 }
+
+.regrade-refresh {
+  color: $autolab-gray-text;
+  background-color: rgba($autolab-yellow, 0.3);
+  border: 1px solid $autolab-yellow;
+  border-left: 5px solid $autolab-yellow;
+  padding: 10px;
+  border-radius: 3px;
+  font-weight: 500;
+}

--- a/app/controllers/assessment/autograde.rb
+++ b/app/controllers/assessment/autograde.rb
@@ -117,15 +117,15 @@ module AssessmentAutograde
     end
 
     success_jobs = submissions.size - failure_jobs
-    if success_jobs > 0
-      link = "<a href=\"#{url_for(controller: 'jobs')}\">#{ActionController::Base.helpers.pluralize(success_jobs, "submission")}</a>"
-      flash[:success] = ("Regrading #{link}")
-    end
+    # if success_jobs > 0
+    #   link = "<a href=\"#{url_for(controller: 'jobs')}\">#{ActionController::Base.helpers.pluralize(success_jobs, "submission")}</a>"
+    #   flash[:success] = ("Regrading #{link}")
+    # end
 
     # For both :success and :error
     flash[:html_safe] = true
 
-    redirect_to([@course, @assessment, :submissions]) && return
+    redirect_to([@course, @assessment, :submissions, regrading: 'true']) && return
   end
 
   #

--- a/app/views/submissions/index.html.erb
+++ b/app/views/submissions/index.html.erb
@@ -50,6 +50,15 @@
   <%= javascript_include_tag "manage_submissions" %>
 <% end %>
 
+<% if @regrading %>
+  <div class="regrade-refresh">
+    Currently regrading <%= ActionController::Base.helpers.pluralize(@regrading_submissions.count, "submission") %>.
+    View detailed progress
+    <%= link_to "here", url_for(controller: 'jobs') %>. To update scores,
+    <%= link_to "refresh", url_for([@course, @assessment, :submissions, regrading: 'true']) %>.
+  </div>
+<% end %>
+
 <h3>Manage Submissions</h3>
 <hr>
 
@@ -194,15 +203,22 @@
       <%# Score %>
       <td class="submissions-td">
         <div class="submissions-score-align">
-          <div class="score-num"><%= computed_score { submission.final_score(@cud) } %></div>
-          <div class="score-icon">
-            <a class="modal-trigger score-details"
-              data-email="<%= submission.course_user_datum.email %>"
-              data-cuid=" <%= submission.course_user_datum.id %>">
-              <i class="material-icons submissions-score-icon">zoom_in</i>
-            </a>
+          <% if @regrading_submissions.include?(submission.id) then %>
+            <div class="score-icon">
+              <%= link_to "<i class='tiny material-icons'>access_time</i>".html_safe,
+                          { controller: "jobs", action: "getjob", id: submission.jobid } %>
             </div>
-        </div>
+          <% else %>
+            <div class="score-num"><%= computed_score { submission.final_score(@cud) } %></div>
+            <div class="score-icon">
+              <a class="modal-trigger score-details"
+                data-email="<%= submission.course_user_datum.email %>"
+                data-cuid=" <%= submission.course_user_datum.id %>">
+                <i class="material-icons submissions-score-icon">zoom_in</i>
+              </a>
+              </div>
+            </div>
+          <% end %>
       </td>
 
       <%# Submission Date %>


### PR DESCRIPTION
## Description
When a submission is being graded, a clock icon replaces the score. There is a message on top of the page that tells the user to either check the jobs page or refresh the page so that they update the score. The message only goes away when there is no more submissions that are being graded. 
![image](https://github.com/user-attachments/assets/0cfe7ecb-31b4-48a8-aee8-87f54ccfc00c)

## Motivation and Context
Currently, when the user pressed the regrade selected button on Manage Submissions, it is unclear when the regrade all ended. The only way a user knows if the regrade has finished is if they go to the jobs page and see that all the jobs have finished running. This was a problem raised in issue #2223, by 213 and 122 TAs. 

## How Has This Been Tested?
I first submitted files to an autograder set up incorrectly, such as not adding a problem to the assessment. After the submission has been graded, add the missing problem to the assessment, and regrade those submissions that have the wrong scores. Check that when the submissions are being regraded, a clock icon appears instead of the score. Refresh the page until the message on the top of the page disappears, and check that the scores have been updated to a correct score. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have run rubocop and erblint for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://docs.autolabproject.com/)
- [ ] I have updated the documentation accordingly, included in this PR

## Other issues / help required
One issue with my implementation is that all submissions that are currently graded will have the status of being regraded. Therefore, if I regrade all submissions, then another user decides to submit a new file while the regrade is running, the message will only go away when that new submission also finishes grading. One way I thought of to address this issue is just making the clock icons and the yellow message a default feature regardless of if a regrade is going on or not. Therefore, if an instructor goes to Manage Submissions while a student creates a new submission, the instructor will see on the page that one grading process is going on. 
