### PR TITLE
Prevent setting invalid MySQL TIMESTAMPs for assessment dates

### DIFF
--- a/lib/archive.rb
+++ b/lib/archive.rb
@@ -71,7 +71,7 @@ module Archive
 
       # edge case for removing "./" from pathnames
       if file[:pathname].include?("./")
-        file[:pathname] = File.cleanpath(file[:pathname], rel_root = true).gsub("..", "__PARENT__")
+        file[:pathname] = Pathname.new(file[:pathname]).cleanpath.to_s.gsub("..", "__PARENT__")
       end
 
       if(file[:directory])


### PR DESCRIPTION
## Description
This update ensures that the "start at," "due at," and "end at," assessment dates are valid for the [MySQL TIMESTAMP](https://dev.mysql.com/doc/refman/8.4/en/datetime.html) type. 

## Motivation and Context
Instructors at UB ran into a bug where they set a due date several years into the future (after 2038) and they weren't able to load the course page afterwards. The invalid date got stored in the database as `0000-00-00 00:00:00`.

I did some further research into why this could happen. Modern versions of MySQL have "strict mode" enabled by default, which wouldn't allow an invalid date to be inserted, but strict mode is disabled in `database.yml` with `sql_mode: NO_ENGINE_SUBSTITUTION`. It could be enabled by setting that field to `NO_ENGINE_SUBSTITUTION,ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO`, but I tested that and wasn't able to load the course page. It appears we're currently depending on a lack of validation for functionality.

I think it would be a good idea to move towards complying with strict mode in the long term, but it may take major refactoring, so this is a reasonable fix in the meantime.

## How Has This Been Tested?

Before making this update, I created an assessment with a due date in the year 2039. I was unable to load the course page afterwards.

![image](https://github.com/user-attachments/assets/f4037c13-949d-4049-afc9-023b025f4cfc)

I had to edit the record in the database to a real value in order to view the course page again.

![image](https://github.com/user-attachments/assets/f4834dfe-6f9b-482a-85d2-431d0d794d4a)

![image](https://github.com/user-attachments/assets/185e8a3b-373b-4868-982e-53a6cafbf425)

After applying this update, trying to set an invalid date too far into the future gives the user a warning instead of locking people out of the course: 

![image](https://github.com/user-attachments/assets/a56eb010-39b9-4039-9e1d-77bda9f4f246)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have run rubocop and erblint for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://docs.autolabproject.com/)
- [ ] I have updated the documentation accordingly, included in this PR

