### PR TITLE
Pass cuds through session storage to fix issue

### DIFF
--- a/app/views/submissions/missing.html.erb
+++ b/app/views/submissions/missing.html.erb
@@ -11,8 +11,18 @@
             { title: "Grant extensions to students" } %>
 |
 <%= link_to "Fill In Empty Submissions",
-            new_course_assessment_submission_path(@course, @assessment, course_user_datum_id: @missing.collect{ |u| u[:id] }.join(',')),
-            { title: "Create submissions for all of the missing students" } %>
+            "#",
+            { title: "Create submissions for all of the missing students",
+              onclick: "submitMissingIds(); return false;" } %>
+
+<script>
+    function submitMissingIds() {
+        var ids = [<%= @missing.map { |u| u[:id] }.join(',') %>];
+        var url = '<%= new_course_assessment_submission_path(@course, @assessment) %>';
+        sessionStorage.setItem('course_user_datum_ids', JSON.stringify(ids));
+        window.location.href = url;
+    }
+</script>
 
 <p>
 <%= @users %>

--- a/app/views/submissions/new.html.erb
+++ b/app/views/submissions/new.html.erb
@@ -7,53 +7,78 @@
                           builder: FormBuilderWithDateTimeInput,
                           html: { multipart: true } do |f| %>
 
-<table class="verticalTable">
-<tr>
-  <th>User:</th>
-  <td>
-  <% if params[:course_user_datum_id].nil? then %>
+  <table class="verticalTable">
+    <tr>
+      <th>User:</th>
+      <td>
+        <% content_for :javascripts do %>
+          <% if params[:course_user_datum_id].blank? %>
+            <%= render partial: "components/autocomplete", locals: { hiddenCUDField: "#submission_course_user_datum_id" } %>
+          <% end %>
 
-  <% content_for :javascripts do %>
-    <%= render partial: "components/autocomplete", locals: { hiddenCUDField: "#submission_course_user_datum_id" } %>
-  <% end %>
+          <script>
+              document.addEventListener('DOMContentLoaded', function() {
+                  var storedIds = sessionStorage.getItem('course_user_datum_ids');
+                  if (storedIds) {
+                      sessionStorage.removeItem('course_user_datum_ids');
+                      var ids = JSON.parse(storedIds);
+                      document.querySelector('input[name="submission[course_user_datum_id]"]').value = ids.join(',');
+                      var studentSelectArea = document.getElementById('student_select_area');
+                      if (studentSelectArea) {
+                          studentSelectArea.style.display = 'none';
+                          var storedIdsArea = document.getElementById('stored_ids_area');
+                          if (storedIdsArea) {
+                              storedIdsArea.style.display = 'block';
+                          }
+                      }
+                      window.location.href = window.location.pathname + '?course_user_datum_id=' + ids.join(',');
+                  }
+              });
+          </script>
+        <% end %>
 
-  <div class="input-field">
-    <input type="text" size="3" id="student_autocomplete" class="autocomplete" autocomplete="off">
-    <label for="student_autocomplete">Start typing student name or email</label>
-  </div>
-  <%= f.hidden_field(:course_user_datum_id) %>
+        <% if params[:course_user_datum_id].nil? %>
+          <div id="student_select_area">
+            <div class="input-field">
+              <input type="text" size="3" id="student_autocomplete" class="autocomplete" autocomplete="off">
+              <label for="student_autocomplete">Start typing student name or email</label>
+            </div>
+            <%= f.hidden_field(:course_user_datum_id) %>
+          </div>
 
-  <% else %>
-    <%= @cuds.collect(&:email).join(", ") %>
-    <input type='hidden' name='submission[course_user_datum_id]' value='<%= @cuds.collect(&:id).join(',') %>'>
-  <% end %>
-  </td>
-</tr>
-<tr>
-  <th>Assessment:</th><td><%= @assessment.display_name %></td>
-  <%= f.hidden_field(:assessment_id) %>
-</tr>
-<tr>
-  <th>File:</th><td><%= f.file_field :file %></td>
-</tr>
-<tr>
-  <th>Notes:</th><td><%= f.text_area :notes, class: 'materialize-textarea', placeholder: "Notes on submission" %></td>
-</tr>
-<tr>
-  <th>Tweak:</th>
-  <td>
-  <%= f.fields_for :tweak, @submission.tweak do |t| %>
-    <%= t.text_field :value, placeholder: "Number of points or percentage" %>
-    <%= t.select :kind, options_for_select({ "points" => "points", "%" => "percent" },
-                                           selected: (@submission.tweak ? @submission.tweak.kind : "points")) %>
-  <% end %>
-  </td>
-</tr>
-<tr>
-  <td colspan=2>
-  <br>
-  <%= f.submit "Create Submission", { class: "btn primary" } %>
-  </td>
-</tr>
-</table>
+          <div id="stored_ids_area" style="display: none;">
+          </div>
+        <% else %>
+          <%= @cuds.collect(&:email).join(", ") %>
+          <input type='hidden' name='submission[course_user_datum_id]' value='<%= @cuds.collect(&:id).join(',') %>'>
+        <% end %>
+      </td>
+    </tr>
+    <tr>
+      <th>Assessment:</th><td><%= @assessment.display_name %></td>
+      <%= f.hidden_field(:assessment_id) %>
+    </tr>
+    <tr>
+      <th>File:</th><td><%= f.file_field :file %></td>
+    </tr>
+    <tr>
+      <th>Notes:</th><td><%= f.text_area :notes, class: 'materialize-textarea', placeholder: "Notes on submission" %></td>
+    </tr>
+    <tr>
+      <th>Tweak:</th>
+      <td>
+        <%= f.fields_for :tweak, @submission.tweak do |t| %>
+          <%= t.text_field :value, placeholder: "Number of points or percentage" %>
+          <%= t.select :kind, options_for_select({ "points" => "points", "%" => "percent" },
+                                                 selected: (@submission.tweak ? @submission.tweak.kind : "points")) %>
+        <% end %>
+      </td>
+    </tr>
+    <tr>
+      <td colspan=2>
+        <br>
+        <%= f.submit "Create Submission", { class: "btn primary" } %>
+      </td>
+    </tr>
+  </table>
 <% end %>


### PR DESCRIPTION
## Description
Passing cuds through session storage prevents the cookie that the cuds were previously passed through from overflowing. 

## Motivation and Context
Resolves issue #2274 


## How Has This Been Tested?
Tested locally by creating missing submissions for >400 students. 
<img width="1465" alt="image" src="https://github.com/user-attachments/assets/923bd0c5-b878-44de-8a20-a87927a40672" />


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x ] I have run rubocop and erblint for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://docs.autolabproject.com/)
- [ ] I have updated the documentation accordingly, included in this PR

## Other issues / help required
<!--- Do you have any other relevant issues / questions? --->
<!--- For example, if you require assistance for a certain part of your PR --->
<!--- or are facing specific issues while creating the pull request that you would like to highlight --->

If unsure, feel free to submit first and we'll help you along.
