### PR TITLE
Progress loading for manage submissions

### DIFF
--- a/app/assets/javascripts/manage_submissions.js
+++ b/app/assets/javascripts/manage_submissions.js
@@ -329,9 +329,56 @@ $(document).ready(function() {
       }
     }
 
+    $(document).on("click", "#regrade-all-btn, #regrade-all-trigger", function (event) {
+      event.preventDefault();
+      if (!confirm(`Are you sure you want to regrade all selected submissions?`)) return;
+      const icon = $("#regrade-all-icon");
+      const button = $("#regrade-all-btn");
+      const link = $('#regrade-all-trigger');
+      let refreshInterval = setInterval(() => {
+        location.reload();
+      }, 5000);
+
+      $.ajax({
+        url: "regradeAll",
+        type: "POST",
+        contentType: "application/json",
+        headers: {
+          "X-CSRF-Token": $('meta[name="csrf-token"]').attr("content")
+        },
+        beforeSend: function () {
+          if (icon && button) {
+            button.addClass("disabled");
+            link.addClass("disabled-link");
+            icon.text("autorenew");
+            icon.addClass("loading-icon");
+          }
+        },
+        success: function (response) {
+          clearInterval(refreshInterval);
+          if (response.redirect) {
+            console.log(response.redirect);
+            window.location.href = response.redirect;
+            return;
+          }
+          if (response.error) {
+            alert(response.error);
+          }
+          if (response.success) {
+            alert(response.success);
+          }
+        },
+        error: function () {
+          clearInterval(refreshInterval);
+          alert("An error occurred while regrading.");
+        }
+      });
+    });
+
     function changeButtonStates(state) {
       buttonIDs.forEach((id) => {
         const button = $(id);
+        const icon = button.find("i");
         if (state) {
           if (id === "#download-selected") {
             $(id).prop('href', baseURLs[id]);
@@ -373,6 +420,13 @@ $(document).ready(function() {
               dataType: "json",
               headers: {
                 "X-CSRF-Token": $('meta[name="csrf-token"]').attr("content"),
+              },
+              beforeSend: function () {
+                button.addClass('disabled');
+                if (icon) {
+                  icon.text("autorenew");
+                  icon.addClass("loading-icon");
+                }
               },
               success: function (response) {
                 clearInterval(refreshInterval);

--- a/app/assets/stylesheets/manage_submissions.css.scss
+++ b/app/assets/stylesheets/manage_submissions.css.scss
@@ -74,3 +74,21 @@ table.prettyBorder tr:hover {
 .i-no-margin {
   margin-left: 0;
 }
+
+.loading-icon {
+  animation: spin 1.5s linear infinite;
+  display: inline-block;
+}
+
+.disabled-link {
+  pointer-events: none;
+  color: gray !important;
+  opacity: 0.6;
+  text-decoration: none;
+  cursor: default;
+}
+
+@keyframes spin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}

--- a/app/views/submissions/index.html.erb
+++ b/app/views/submissions/index.html.erb
@@ -84,21 +84,16 @@
                   class: "btn submissions-main" } %>
   </div>
 
-  <div id="regrade-all-html">
-    <%= link_to "<i class='material-icons left submissions-icons'>cached</i>Regrade All".html_safe,
-                regradeAll_course_assessment_path(@course, @assessment),
-                { method: :post,
-                  title: "Regrade all submissions for this assignment",
-                  class: "btn submissions-main",
-                  data: { confirm: "Are you sure you want to regrade all #{@assessment.submissions.where(special_type: [Submission::NORMAL, nil]).latest.count} latest submissions?" } } %>
-  </div>
+  <a id="regrade-all-btn" class="btn submissions-main" title="Regrade all submissions for this assignment">
+    <i class='material-icons left submissions-icons' id="regrade-all-icon">cached</i>Regrade All
+  </a>
 </div>
 
 <%# Selected buttons, hidden so HTML can be accessed in DataTables %>
 <div class="selected-buttons-placeholder">
   <div id="regrade-batch-html">
-    <%= link_to "Regrade Selected", class: "btn submissions-selected", title: "Regrade selected submissions" do %>
-      <i class="material-icons">cached</i> Regrade Selected
+    <%= link_to "Regrade Selected", class: "btn submissions-selected", id: "regrade-selected-btn", title: "Regrade selected submissions" do %>
+      <i class="material-icons" id="regrade-selected-icon">cached</i>Regrade Selected
     <% end %>
   </div>
 
@@ -125,9 +120,13 @@
 
 <div class="selected-count-placeholder" style="display: none;">
   <span id="selected-count-html">0 submissions selected</span>
-  <span>Click <%= link_to "Regrade All", regradeAll_course_assessment_path(@course, @assessment),
-                          { method: :post, title: "Regrade all submissions", class: "selected-count-red",
-                            data: { confirm: "Are you sure you want to regrade all #{@assessment.submissions.where(special_type: [Submission::NORMAL, nil]).latest.count} latest submissions?" } } %>  to regrade all </span><%= @submissions.latest.length %><span> latest submissions.</span>
+  <span>
+    Click
+    <a href="#" id="regrade-all-trigger" class="selected-count-red" title="Regrade all submissions">
+      Regrade All
+    </a>
+    to regrade all <%= @submissions.latest.length %> latest submissions.
+  </span>
 </div>
 
 <table class="prettyBorder" id="submissions">


### PR DESCRIPTION
## Description
- Fixes selecting-all checkbox and then regrading
- Converts regrade-all into Ajax
- Adds loading before Ajax to all Ajax function calls (regrade-selected, excuse-selected, delete-selected, regrade-all)

## Motivation and Context
Loading takes a long time for a large class, instructors don't get any visual feedback when buttons are clicked. This might result in them clicking buttons another time which increases the time spent waiting for regrade-alls etc. This is now fixed by adding a loading symbol when the button is clicked.
<img width="1089" alt="Screenshot 2025-04-14 at 3 32 16 AM" src="https://github.com/user-attachments/assets/6d49b2ba-afd5-4aaa-bffb-d7de0925ad9e" />

## How Has This Been Tested?
- Check to see if manage submission buttons work as expected
- Check that loading symbol renders when buttons are clicked and removed when the request is completed

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have run rubocop and erblint for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://docs.autolabproject.com/)
- [ ] I have updated the documentation accordingly, included in this PR
