### PR TITLE
File manager fixes

### DIFF
--- a/app/assets/javascripts/file_manager.js
+++ b/app/assets/javascripts/file_manager.js
@@ -5,7 +5,7 @@ function rename(path) {
         $.ajax({
             url: "/file_manager/" + rel_path,
             type: "PUT",
-            data: { new_name: new_name, relative_path: rel_path},
+            data: { new_name: new_name, relative_path: rel_path },
             success: function(data) {
                 console.log(`Renamed: ${rel_path}`)
                 location.reload();
@@ -19,11 +19,11 @@ function deleteSelected(path) {
         $.ajax({
             url: path,
             type: "DELETE",
-            success: function () {
+            success: function() {
                 console.log(`Deleted: ${path}`);
                 resolve();
             },
-            error: function (xhr, status, error) {
+            error: function(xhr, status, error) {
                 reject(error);
             }
         });
@@ -38,7 +38,7 @@ function downloadSelected(path) {
             data: {
                 path: path
             },
-            success: function (data) {
+            success: function(data) {
                 let blob = new Blob([data], { type: 'application/x-tar' });
                 let url = URL.createObjectURL(blob);
                 let a = document.createElement('a');
@@ -53,7 +53,7 @@ function downloadSelected(path) {
                 console.log(`Downloaded: ${data.filename}`);
                 resolve();
             },
-            error: function (xhr, status, error) {
+            error: function(xhr, status, error) {
                 console.error(`Failed to download ${path}: ${error}`);
                 reject(error);
             }
@@ -76,11 +76,11 @@ function uploadFile(file, path, name) {
             data: formData,
             contentType: false,
             processData: false,
-            success: function () {
+            success: function() {
                 console.log("Uploaded file successfully");
                 resolve();
             },
-            error: function (xhr, status, error) {
+            error: function(xhr, status, error) {
                 console.error(`Failed to upload file: ${error}`);
                 reject(error);
             }
@@ -98,14 +98,14 @@ function uploadAllFiles(path) {
     }
     if (files.length > 0) {
         Promise.all(uploadPromises)
-        .then(() => {
-            alert("All files uploaded successfully.");
-            location.reload();
-        })
-        .catch((error) => {
-            alert("Some files failed to upload successfully. Ensure that you are not in the root directory, the file is smaller than 1 GB, and does not already exist.");
-            location.reload();
-        });
+            .then(() => {
+                alert("All files uploaded successfully.");
+                location.reload();
+            })
+            .catch((error) => {
+                alert("Some files failed to upload successfully. Ensure that you are not in the root directory, the file is smaller than 1 GB, and does not already exist.");
+                location.reload();
+            });
     } else {
         console.log('No files selected.');
     }
@@ -130,8 +130,7 @@ function createFolder(path) {
             })
             .catch((error) => {
                 alert("Failed to create folder. Check that you are not in the root directory and that the tile/folder does not already exist.");
-            })
-        ;
+            });
     }
 }
 

--- a/app/assets/javascripts/file_manager.js
+++ b/app/assets/javascripts/file_manager.js
@@ -203,60 +203,6 @@ function handleSelectionChange() {
     updateButtonStatesAndStyle(deleteBtn, deleteParent);
 }
 
-function changePermissions(path, permissions) {
-    // Validate permissions format
-    if (!/^[0-7]{3,4}$/.test(permissions)) {
-        alert("Invalid permission format. Please use 3-4 digit octal format (e.g., 755, 644)");
-        return;
-    }
-
-    let rel_path = decodeURIComponent(path.split("/file_manager/")[1]);
-    $.ajax({
-        url: "/file_manager/" + rel_path + "/chmod",
-        type: "PATCH",
-        data: {
-            path: rel_path,
-            permissions: permissions
-        },
-        success: function(data) {
-            console.log(`Changed permissions for: ${rel_path} to ${permissions}`);
-            location.reload();
-        },
-        error: function(xhr, status, error) {
-            console.error("Error changing permissions:", error);
-            alert("Error changing permissions: " + (xhr.responseJSON ? xhr.responseJSON.error : error));
-        }
-    });
-}
-
-// Add keyboard support for permissions input
-function setupPermissionsKeyboardSupport() {
-    document.querySelectorAll('.permissions-input').forEach(function(input) {
-        input.addEventListener('keypress', function(e) {
-            if (e.key === 'Enter') {
-                e.preventDefault();
-                const filePath = this.getAttribute('data-file-path');
-                changePermissions(filePath, this.value);
-            }
-        });
-
-        // Real-time validation feedback
-        input.addEventListener('input', function(e) {
-            const value = this.value;
-            if (value && !/^[0-7]{0,4}$/.test(value)) {
-                this.style.borderColor = '#dc3545';
-                this.style.backgroundColor = '#ffe6e6';
-            } else if (value && /^[0-7]{3,4}$/.test(value)) {
-                this.style.borderColor = '#28a745';
-                this.style.backgroundColor = '#e6ffe6';
-            } else {
-                this.style.borderColor = '#ddd';
-                this.style.backgroundColor = '#f9f9f9';
-            }
-        });
-    });
-}
-
 document.addEventListener('DOMContentLoaded', function() {
     const otherCheckboxes = document.querySelectorAll('.check');
     handleSelectionChange();
@@ -272,7 +218,4 @@ document.addEventListener('DOMContentLoaded', function() {
     $(".check").click(function() {
         handleSelectionChange();
     });
-
-    // Setup permissions input keyboard support
-    setupPermissionsKeyboardSupport();
 });

--- a/app/assets/javascripts/file_manager.js
+++ b/app/assets/javascripts/file_manager.js
@@ -203,6 +203,60 @@ function handleSelectionChange() {
     updateButtonStatesAndStyle(deleteBtn, deleteParent);
 }
 
+function changePermissions(path, permissions) {
+    // Validate permissions format
+    if (!/^[0-7]{3,4}$/.test(permissions)) {
+        alert("Invalid permission format. Please use 3-4 digit octal format (e.g., 755, 644)");
+        return;
+    }
+
+    let rel_path = decodeURIComponent(path.split("/file_manager/")[1]);
+    $.ajax({
+        url: "/file_manager/" + rel_path + "/chmod",
+        type: "PATCH",
+        data: {
+            path: rel_path,
+            permissions: permissions
+        },
+        success: function(data) {
+            console.log(`Changed permissions for: ${rel_path} to ${permissions}`);
+            location.reload();
+        },
+        error: function(xhr, status, error) {
+            console.error("Error changing permissions:", error);
+            alert("Error changing permissions: " + (xhr.responseJSON ? xhr.responseJSON.error : error));
+        }
+    });
+}
+
+// Add keyboard support for permissions input
+function setupPermissionsKeyboardSupport() {
+    document.querySelectorAll('.permissions-input').forEach(function(input) {
+        input.addEventListener('keypress', function(e) {
+            if (e.key === 'Enter') {
+                e.preventDefault();
+                const filePath = this.getAttribute('data-file-path');
+                changePermissions(filePath, this.value);
+            }
+        });
+
+        // Real-time validation feedback
+        input.addEventListener('input', function(e) {
+            const value = this.value;
+            if (value && !/^[0-7]{0,4}$/.test(value)) {
+                this.style.borderColor = '#dc3545';
+                this.style.backgroundColor = '#ffe6e6';
+            } else if (value && /^[0-7]{3,4}$/.test(value)) {
+                this.style.borderColor = '#28a745';
+                this.style.backgroundColor = '#e6ffe6';
+            } else {
+                this.style.borderColor = '#ddd';
+                this.style.backgroundColor = '#f9f9f9';
+            }
+        });
+    });
+}
+
 document.addEventListener('DOMContentLoaded', function() {
     const otherCheckboxes = document.querySelectorAll('.check');
     handleSelectionChange();
@@ -217,5 +271,8 @@ document.addEventListener('DOMContentLoaded', function() {
 
     $(".check").click(function() {
         handleSelectionChange();
-    })
+    });
+
+    // Setup permissions input keyboard support
+    setupPermissionsKeyboardSupport();
 });

--- a/app/assets/stylesheets/file_manager.scss
+++ b/app/assets/stylesheets/file_manager.scss
@@ -1,91 +1,142 @@
 .div-row {
-  display: flex;
-  flex-direction: row;
-  gap: 5rem;
+    display: flex;
+    flex-direction: row;
+    gap: 5rem;
 }
 
 [type="checkbox"]:not(:checked) {
-  opacity: 100;
-  position: relative;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  pointer-events: auto;
+    opacity: 100;
+    position: relative;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    pointer-events: auto;
 }
 
 [type="checkbox"]:checked {
-  position: relative;
-  opacity: 1;
-  pointer-events: unset;
+    position: relative;
+    opacity: 1;
+    pointer-events: unset;
 }
 
 .table-col-center {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  padding-top: 35%;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding-top: 35%;
 }
 
 .table-scroll {
-  height: 40rem;
-  overflow-y: auto;
+    height: 40rem;
+    overflow-y: auto;
 }
 
 .div-row-cols {
-  display: flex;
-  align-items: center;
+    display: flex;
+    align-items: center;
 }
 
 .button-file {
-  position: relative;
-  overflow: hidden;
+    position: relative;
+    overflow: hidden;
 }
 
 .button-file input[type=submit] {
-  left: -10px;
-  right: 0;
-  padding: 0;
+    left: -10px;
+    right: 0;
+    padding: 0;
 }
 
 .button-file input {
-  position: absolute;
-  top: 0;
-  right: 0;
-  min-width: 100%;
-  min-height: 100%;
-  font-size: 100px;
-  text-align: right;
-  filter: alpha(opacity=0);
-  opacity: 0;
-  outline: none;
-  background: green;
-  display: block;
+    position: absolute;
+    top: 0;
+    right: 0;
+    min-width: 100%;
+    min-height: 100%;
+    font-size: 100px;
+    text-align: right;
+    filter: alpha(opacity=0);
+    opacity: 0;
+    outline: none;
+    background: green;
+    display: block;
 }
 
 .button-file a {
-  color: white;
+    color: white;
 }
 
 @media screen and (max-width: 1164px) {
-  .div-row {
-    display: grid;
-    grid-template-columns: auto auto;
-    gap: 1rem;
-  }
-  .button-file {
-    width: 200px;
-  }
-  .div-row-cols {
-    margin: 0;
-    padding: 0;
-  }
+    .div-row {
+        display: grid;
+        grid-template-columns: auto auto;
+        gap: 1rem;
+    }
+    .button-file {
+        width: 200px;
+    }
+    .div-row-cols {
+        margin: 0;
+        padding: 0;
+    }
 }
 
 @media screen and (max-width: 478px) {
-  .div-row {
-    display: grid;
-    grid-template-columns: auto;
-    gap: 1rem;
-  }
+    .div-row {
+        display: grid;
+        grid-template-columns: auto;
+        gap: 1rem;
+    }
 }
 
+// Permissions input styling
+input[type=text].permissions-input {
+    width: 40px;
+    text-align: center;
+    font-family: monospace;
+    font-size: 12px;
+    padding: 2px 4px;
+    border: 1px solid #ddd;
+    border-radius: 3px;
+    background-color: #f9f9f9;
+    &:focus {
+        outline: none;
+        border-color: #007bff;
+        background-color: white;
+    }
+    &:invalid {
+        border-color: #dc3545;
+        background-color: #ffe6e6;
+    }
+}
+
+.permissions-button {
+    padding: 2px 4px;
+    font-size: 12px;
+    border: none;
+    background-color: #28a745;
+    color: white;
+    border-radius: 3px;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 10px;
+    height: 24px;
+    &:hover {
+        background-color: #218838;
+    }
+    &:active {
+        background-color: #1e7e34;
+    }
+    .material-icons {
+        font-size: 14px;
+    }
+}
+
+.permissions-container {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    // justify-content: center;
+}

--- a/app/assets/stylesheets/file_manager.scss
+++ b/app/assets/stylesheets/file_manager.scss
@@ -89,54 +89,8 @@
     }
 }
 
-// Permissions input styling
-input[type=text].permissions-input {
-    width: 40px;
-    text-align: center;
+.permissions-display {
     font-family: monospace;
     font-size: 12px;
-    padding: 2px 4px;
-    border: 1px solid #ddd;
-    border-radius: 3px;
-    background-color: #f9f9f9;
-    &:focus {
-        outline: none;
-        border-color: #007bff;
-        background-color: white;
-    }
-    &:invalid {
-        border-color: #dc3545;
-        background-color: #ffe6e6;
-    }
-}
-
-.permissions-button {
-    padding: 2px 4px;
-    font-size: 12px;
-    border: none;
-    background-color: #28a745;
-    color: white;
-    border-radius: 3px;
-    cursor: pointer;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    min-width: 10px;
-    height: 24px;
-    &:hover {
-        background-color: #218838;
-    }
-    &:active {
-        background-color: #1e7e34;
-    }
-    .material-icons {
-        font-size: 14px;
-    }
-}
-
-.permissions-container {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    // justify-content: center;
+    color: #333;
 }

--- a/app/controllers/file_manager_controller.rb
+++ b/app/controllers/file_manager_controller.rb
@@ -315,6 +315,9 @@ class FileManagerController < ApplicationController
       elsif File.directory?(absolute_path)
         tar_stream = StringIO.new("")
         Gem::Package::TarWriter.new(tar_stream) do |tar|
+          # Make base directory
+          mode = File.stat(absolute_path).mode
+          tar.mkdir(File.basename(absolute_path), mode)
           add_directory_to_tar(tar, absolute_path, File.basename(absolute_path))
         end
         tar_stream.rewind

--- a/app/controllers/file_manager_controller.rb
+++ b/app/controllers/file_manager_controller.rb
@@ -81,7 +81,8 @@ class FileManagerController < ApplicationController
           end
 
           flash[:success] =
-            "Successfully extracted #{File.basename(absolute_path)} to #{File.basename(extract_dir)}/"
+            "Successfully extracted #{File.basename(absolute_path)} to
+              #{File.basename(extract_dir)}/"
           redirect_to file_manager_index_path(path: File.dirname(path))
           nil
         rescue Gem::Package::TarInvalidError => e
@@ -182,12 +183,13 @@ class FileManagerController < ApplicationController
 
       # Validate permission format (should be 3-4 digit octal)
       unless params[:permissions].match(/\A[0-7]{3,4}\Z/)
-        raise ArgumentError, "Invalid permission format. Use 3-4 digit octal format (e.g., 755, 644)"
+        raise ArgumentError,
+              "Invalid permission format. Use 3-4 digit octal format (e.g., 755, 644)"
       end
 
       # Convert octal string to integer
       permission_mode = params[:permissions].to_i(8)
-      
+
       # Validate permission range (0000 to 7777)
       unless permission_mode.between?(0, 0o7777)
         raise ArgumentError, "Permission value out of range"
@@ -216,7 +218,10 @@ class FileManagerController < ApplicationController
     flash[:error] = "Error changing permissions: #{e.message}"
     respond_to do |format|
       format.html { redirect_back(fallback_location: file_manager_index_path) }
-      format.json { render json: { error: "Error changing permissions: #{e.message}" }, status: :internal_server_error }
+      format.json {
+        render json: { error: "Error changing permissions: #{e.message}" },
+               status: :internal_server_error
+      }
     end
   end
 
@@ -295,7 +300,7 @@ class FileManagerController < ApplicationController
       elsif assessment.present?
         tar_stream = StringIO.new("")
         Gem::Package::TarWriter.new(tar_stream) do |tar_assessment|
-          asmt_dir = assessment.name
+          assessment.name
           assessment.dump_yaml
           filter = []
           assessment.load_dir_to_tar(absolute_path.to_s, "", tar_assessment, filter, "")
@@ -409,7 +414,7 @@ private
           '-'
         end,
         permissions: begin
-          sprintf('%o', stat.mode & 0777)
+          sprintf('%o', stat.mode & 0o777)
         rescue StandardError
           '-'
         end,
@@ -508,7 +513,8 @@ private
             end
           rescue StandardError => e
             # If reading fails, try to read the entire content at once as fallback
-            Rails.logger.warn "Chunked reading failed for #{entry.full_name}: #{e.message}, trying full read"
+            Rails.logger.warn "Chunked reading failed for #{entry.full_name}:
+              #{e.message}, trying full read"
             begin
               entry.rewind
               content = entry.read
@@ -523,7 +529,8 @@ private
 
           # Verify file size matches expected size
           if expected_size > 0 && bytes_written != expected_size
-            Rails.logger.warn "Size mismatch for #{entry.full_name}: expected #{expected_size}, got #{bytes_written}"
+            Rails.logger.warn "Size mismatch for #{entry.full_name}:
+              expected #{expected_size}, got #{bytes_written}"
           end
         end
 
@@ -629,7 +636,8 @@ private
   # Validate tar file integrity before extraction
   def validate_tar_file(file_path)
     # Check if file is readable and has content
-    raise "Tar file is empty or unreadable" unless File.readable?(file_path) && File.size(file_path) > 0
+    raise "Tar file is empty or unreadable" unless File.readable?(file_path) &&
+                                                   File.size(file_path) > 0
 
     # Validate based on file extension
     if File.extname(file_path).downcase.in?(['.gz', '.tgz']) ||

--- a/app/controllers/file_manager_controller.rb
+++ b/app/controllers/file_manager_controller.rb
@@ -173,6 +173,53 @@ class FileManagerController < ApplicationController
     flash[:error] = e.message
   end
 
+  def chmod
+    absolute_path = check_path_exist(params[:path])
+    if check_instructor(absolute_path)
+      if params[:permissions].nil? || params[:permissions].empty?
+        raise ArgumentError, "Permissions not provided"
+      end
+
+      # Validate permission format (should be 3-4 digit octal)
+      unless params[:permissions].match(/\A[0-7]{3,4}\Z/)
+        raise ArgumentError, "Invalid permission format. Use 3-4 digit octal format (e.g., 755, 644)"
+      end
+
+      # Convert octal string to integer
+      permission_mode = params[:permissions].to_i(8)
+      
+      # Validate permission range (0000 to 7777)
+      unless permission_mode.between?(0, 0o7777)
+        raise ArgumentError, "Permission value out of range"
+      end
+
+      # Apply the permission change
+      File.chmod(permission_mode, absolute_path)
+      flash[:success] = "Successfully changed permissions to #{params[:permissions]}"
+    else
+      flash[:error] = "You are not authorized to change permissions for this path"
+      redirect_to root_path
+    end
+  rescue ArgumentError => e
+    flash[:error] = e.message
+    respond_to do |format|
+      format.html { redirect_back(fallback_location: file_manager_index_path) }
+      format.json { render json: { error: e.message }, status: :bad_request }
+    end
+  rescue Errno::EPERM, Errno::EACCES => e
+    flash[:error] = "Permission denied: #{e.message}"
+    respond_to do |format|
+      format.html { redirect_back(fallback_location: file_manager_index_path) }
+      format.json { render json: { error: "Permission denied: #{e.message}" }, status: :forbidden }
+    end
+  rescue StandardError => e
+    flash[:error] = "Error changing permissions: #{e.message}"
+    respond_to do |format|
+      format.html { redirect_back(fallback_location: file_manager_index_path) }
+      format.json { render json: { error: "Error changing permissions: #{e.message}" }, status: :internal_server_error }
+    end
+  end
+
   def find_by_directory_path(absolute_path)
     # Normalize the path to ensure consistent comparison
     normalized_path = Pathname.new(absolute_path).cleanpath.to_s
@@ -358,6 +405,11 @@ private
         type: (is_file ? :file : :directory),
         date: begin
           stat.mtime.strftime('%d %b %Y %H:%M')
+        rescue StandardError
+          '-'
+        end,
+        permissions: begin
+          sprintf('%o', stat.mode & 0777)
         rescue StandardError
           '-'
         end,

--- a/app/controllers/file_manager_controller.rb
+++ b/app/controllers/file_manager_controller.rb
@@ -258,27 +258,23 @@ class FileManagerController < ApplicationController
 
       full_path = File.join(dir_path, entry)
       tar_path = base_name.empty? ? entry : File.join(base_name, entry)
-
+      mode = File.stat(full_path).mode
       if File.directory?(full_path)
         # Add directory entry
-        tar.mkdir(tar_path, 0o755)
+        tar.mkdir(tar_path, mode)
         # Recursively add directory contents
         add_directory_to_tar(tar, full_path, tar_path)
       elsif File.file?(full_path)
         # Add file entry
         File.open(full_path, 'rb') do |_file|
-          File.stat(full_path)
-          # tar.add_file_simple(tar_path, File.stat(full_path).mode,
-          #                     File.size(full_path)) do |tar_file|
-          #   while (chunk = file.read(8192))
-          #     tar_file.write(chunk)
-          #   end
-          # end
+          tar.add_file(tar_path, mode) do |tar_file|
+            tar_file.write(_file.read)
+          end
         end
       elsif File.symlink?(full_path)
         # Add symbolic link
         target = File.readlink(full_path)
-        tar.add_symlink(tar_path, target, 0o755)
+        tar.add_symlink(tar_path, target, mode)
       end
     end
   end

--- a/app/controllers/file_manager_controller.rb
+++ b/app/controllers/file_manager_controller.rb
@@ -32,7 +32,79 @@ class FileManagerController < ApplicationController
       populate_directory(absolute_path, new_url)
       render 'file_manager/index'
     elsif File.file?(absolute_path) && check_instructor(absolute_path)
-      if File.size(absolute_path) > 1_000_000 || params[:download]
+      # Check if this is a tar file and extract parameter is present
+      if params[:extract] && is_tar_file?(absolute_path)
+        # Skip extraction if the tar file itself is an executable
+        if is_likely_executable?(absolute_path, File.basename(absolute_path))
+          flash[:error] = "Cannot extract tar files that are not directories"
+          redirect_to file_manager_index_path(path: File.dirname(path))
+          return
+        end
+
+        begin
+          parent_dir = File.dirname(absolute_path)
+          # Create subdirectory for extraction based on tar filename without extension
+          base_name = File.basename(absolute_path, '.*')
+          # Remove additional extensions for files like .tar.gz
+          base_name = base_name.gsub(/\.tar$/, '')
+          extract_dir = File.join(parent_dir, base_name)
+
+          # Ensure extract directory doesn't already exist to avoid conflicts
+          counter = 1
+          original_extract_dir = extract_dir
+          while File.exist?(extract_dir)
+            extract_dir = "#{original_extract_dir}_#{counter}"
+            counter += 1
+          end
+
+          # Create the extraction directory
+          FileUtils.mkdir_p(extract_dir)
+
+          # Validate tar file before attempting extraction
+          validate_tar_file(absolute_path)
+
+          # Handle different tar formats
+          if File.extname(absolute_path).downcase.in?(['.gz', '.tgz']) ||
+             absolute_path.to_s.downcase.end_with?('.tar.gz')
+            # Handle gzipped tar files
+            require 'zlib'
+            Zlib::GzipReader.open(absolute_path) do |gz|
+              tar_extract_method = Gem::Package::TarReader.new(gz)
+              extract_tar_entries(tar_extract_method, extract_dir)
+            end
+          else
+            # Handle regular tar files - ensure proper resource management
+            File.open(absolute_path, 'rb') do |file|
+              tar_extract_method = Gem::Package::TarReader.new(file)
+              extract_tar_entries(tar_extract_method, extract_dir)
+            end
+          end
+
+          flash[:success] =
+            "Successfully extracted #{File.basename(absolute_path)} to #{File.basename(extract_dir)}/"
+          redirect_to file_manager_index_path(path: File.dirname(path))
+          nil
+        rescue Gem::Package::TarInvalidError => e
+          # Clean up partially extracted directory
+          FileUtils.rm_rf(extract_dir) if File.exist?(extract_dir)
+          flash[:error] =
+            "Corrupted tar file: #{e.message}. The file appears to be damaged or invalid."
+          redirect_to file_manager_index_path(path: File.dirname(path))
+          nil
+        rescue Zlib::GzipFile::Error => e
+          # Clean up partially extracted directory
+          FileUtils.rm_rf(extract_dir) if File.exist?(extract_dir)
+          flash[:error] = "Corrupted gzip archive: #{e.message}. The compressed file is damaged."
+          redirect_to file_manager_index_path(path: File.dirname(path))
+          nil
+        rescue StandardError => e
+          # Clean up partially extracted directory
+          FileUtils.rm_rf(extract_dir) if File.exist?(extract_dir)
+          flash[:error] = "Unable to extract tar file: #{e.message}"
+          redirect_to file_manager_index_path(path: File.dirname(path))
+          nil
+        end
+      elsif File.size(absolute_path) > 1_000_000 || params[:download]
         send_file absolute_path
       elsif !is_binary_file?(absolute_path)
         @path = path
@@ -101,33 +173,109 @@ class FileManagerController < ApplicationController
     flash[:error] = e.message
   end
 
+  def find_by_directory_path(absolute_path)
+    # Normalize the path to ensure consistent comparison
+    normalized_path = Pathname.new(absolute_path).cleanpath.to_s
+    # Find course where the directory_path matches the given absolute path
+    Course.find do |course|
+      course.directory_path.to_s == normalized_path
+    end
+  end
+
+  def find_by_folder_path(absolute_path)
+    # Normalize the path to ensure consistent comparison
+    normalized_path = Pathname.new(absolute_path).cleanpath.to_s
+
+    # Find assessment where the folder_path matches the given absolute path
+    Assessment.find do |assessment|
+      assessment.folder_path.to_s == normalized_path
+    end
+  end
+
+  def path_belongs_to_assessment?(absolute_path)
+    find_by_folder_path(absolute_path)
+  end
+
+  def path_belongs_to_course?(absolute_path)
+    find_by_directory_path(absolute_path)
+  end
+
+  def add_directory_to_tar(tar, dir_path, base_name = "")
+    Dir.entries(dir_path).each do |entry|
+      next if [".", ".."].include?(entry)
+
+      full_path = File.join(dir_path, entry)
+      tar_path = base_name.empty? ? entry : File.join(base_name, entry)
+
+      if File.directory?(full_path)
+        # Add directory entry
+        tar.mkdir(tar_path, 0o755)
+        # Recursively add directory contents
+        add_directory_to_tar(tar, full_path, tar_path)
+      elsif File.file?(full_path)
+        # Add file entry
+        File.open(full_path, 'rb') do |_file|
+          File.stat(full_path)
+          # tar.add_file_simple(tar_path, File.stat(full_path).mode,
+          #                     File.size(full_path)) do |tar_file|
+          #   while (chunk = file.read(8192))
+          #     tar_file.write(chunk)
+          #   end
+          # end
+        end
+      elsif File.symlink?(full_path)
+        # Add symbolic link
+        target = File.readlink(full_path)
+        tar.add_symlink(tar_path, target, 0o755)
+      end
+    end
+  end
+
   def download_tar
     path = params[:path]&.split("/")&.drop(2)&.join("/")
     path = CGI.unescape(path)
     absolute_path = check_path_exist(path)
     if check_instructor(absolute_path)
-      if File.directory?(absolute_path)
+      course = path_belongs_to_course?(absolute_path)
+      assessment = path_belongs_to_assessment?(absolute_path)
+
+      if course.present?
+        tar_course = generate_tar(course)
+        send_data tar_course.string.force_encoding("binary"),
+                  filename: "#{course.name}.tar",
+                  type: "application/x-tar",
+                  disposition: "attachment"
+      elsif assessment.present?
         tar_stream = StringIO.new("")
-        Gem::Package::TarWriter.new(tar_stream) do |tar|
-          Dir[File.join(absolute_path.to_s, '**', '**')].each do |file|
-            mode = File.stat(file).mode
-            relative_path = file.sub(%r{^#{Regexp.escape(absolute_path.to_s)}/?}, '')
-            if File.directory?(file)
-              tar.mkdir relative_path, mode
-            else
-              tar.add_file relative_path, mode do |tar_file|
-                File.open(file, "rb") { |f| tar_file.write f.read }
-              end
-            end
-          end
+        Gem::Package::TarWriter.new(tar_stream) do |tar_assessment|
+          asmt_dir = assessment.name
+          assessment.dump_yaml
+          filter = []
+          assessment.load_dir_to_tar(absolute_path.to_s, "", tar_assessment, filter, "")
         end
         tar_stream.rewind
         tar_stream.close
         send_data tar_stream.string.force_encoding("binary"),
-                  filename: "file_manager.tar",
+                  filename: "#{assessment.name}.tar",
+                  type: "application/x-tar",
+                  disposition: "attachment"
+      elsif File.file?(absolute_path)
+        # Individual file - send directly without zipping
+        send_file(absolute_path,
+                  filename: File.basename(absolute_path),
+                  disposition: 'attachment')
+      elsif File.directory?(absolute_path)
+        tar_stream = StringIO.new("")
+        Gem::Package::TarWriter.new(tar_stream) do |tar|
+          add_directory_to_tar(tar, absolute_path, File.basename(absolute_path))
+        end
+        tar_stream.rewind
+        send_data tar_stream.string.force_encoding("binary"),
+                  filename: "#{File.basename(absolute_path)}.tar",
                   type: "application/x-tar",
                   disposition: "attachment"
       else
+        # Path exists but is neither a file nor directory (eg: symlink)
         send_file(absolute_path,
                   filename: File.basename(absolute_path),
                   disposition: 'attachment')
@@ -262,5 +410,209 @@ private
   def is_binary_file?(path)
     mm = MimeMagic.by_path(path)
     mm.present? && !mm.text?
+  end
+
+  def is_tar_file?(path)
+    extension = File.extname(path).downcase
+    extension == '.tar' ||
+      extension == '.tgz' ||
+      extension == '.gz' && path.to_s.downcase.end_with?('.tar.gz')
+  end
+
+  def extract_tar_entries(tar_reader, extract_dir)
+    tar_reader.rewind
+    tar_reader.each do |entry|
+      # Skip entries with invalid names or paths that try to escape the extraction directory
+      next if entry.full_name.include?('..')
+      next if entry.full_name.start_with?('/')
+
+      # Handle entries that might be at the root level or in subdirectories
+      target_path = File.join(extract_dir, entry.full_name)
+
+      if entry.directory?
+        FileUtils.mkdir_p(target_path)
+      elsif entry.file?
+        # Ensure parent directory exists (especially important for files at root level)
+        parent_dir = File.dirname(target_path)
+        FileUtils.mkdir_p(parent_dir) unless parent_dir == extract_dir
+
+        # Properly read and write file data to prevent corruption
+        File.open(target_path, 'wb') do |f|
+          # Read in chunks to handle large files properly and detect corruption
+          bytes_written = 0
+          expected_size = entry.header.size
+
+          begin
+            while (chunk = entry.read(8192))
+              break if chunk.empty?
+
+              f.write(chunk)
+              bytes_written += chunk.length
+
+              # Safety check to prevent infinite loops with corrupted entries
+              if bytes_written > expected_size + 8192
+                raise "File size mismatch: expected #{expected_size}, got #{bytes_written}+"
+              end
+            end
+          rescue StandardError => e
+            # If reading fails, try to read the entire content at once as fallback
+            Rails.logger.warn "Chunked reading failed for #{entry.full_name}: #{e.message}, trying full read"
+            begin
+              entry.rewind
+              content = entry.read
+              f.rewind
+              f.truncate(0)
+              f.write(content)
+              bytes_written = content.length
+            rescue StandardError => fallback_error
+              raise "Failed to extract #{entry.full_name}: #{fallback_error.message}"
+            end
+          end
+
+          # Verify file size matches expected size
+          if expected_size > 0 && bytes_written != expected_size
+            Rails.logger.warn "Size mismatch for #{entry.full_name}: expected #{expected_size}, got #{bytes_written}"
+          end
+        end
+
+        # Handle file permissions, especially for executables
+        begin
+          mode = entry.header.mode
+          if mode.is_a?(Integer) && mode > 0 && mode < 0o777777
+            # Preserve original permissions
+            File.chmod(mode, target_path)
+          elsif is_likely_executable?(target_path, entry.full_name)
+            # Determine if this should be executable based on file characteristics
+            File.chmod(0o755, target_path)
+          # Set executable permissions (owner: rwx, group: rx, other: rx)
+          else
+            # Set default readable permissions for regular files
+            File.chmod(0o644, target_path)
+          end
+        rescue StandardError => e
+          # Log the error but continue extraction
+          Rails.logger.warn "Could not set permissions for #{target_path}: #{e.message}"
+
+          # Fallback: try to determine if it should be executable
+          if is_likely_executable?(target_path, entry.full_name)
+            begin
+              File.chmod(0o755, target_path)
+            rescue StandardError
+              File.chmod(0o644, target_path)
+            end
+          else
+            File.chmod(0o644, target_path)
+          end
+        end
+      elsif entry.symlink?
+        # Handle symbolic links if present
+        begin
+          File.symlink(entry.header.linkname, target_path)
+        rescue StandardError => e
+          Rails.logger.warn "Could not create symlink #{target_path}: #{e.message}"
+        end
+      end
+    end
+  end
+
+  def is_likely_executable?(file_path, original_name)
+    # Check file extension for common executable types
+    executable_extensions = ['.exe', '.bin', '.run', '.sh', '.bash', '.zsh', '.py', '.pl', '.rb',
+                             '.jar', '.out']
+    extension = File.extname(original_name).downcase
+    return true if executable_extensions.include?(extension)
+
+    # Check for common executable names without extensions
+    executable_names = ['makefile', 'dockerfile', 'configure', 'install', 'setup', 'build',
+                        'autograde']
+    base_name = File.basename(original_name).downcase
+    # return true if any executable names is in the base_name
+    return true if executable_names.any? { |name| base_name.include?(name) }
+
+    # Check if filename has no extension and is not a common non-executable file
+    if extension.empty? && !original_name.include?('.')
+      # Common non-executable files without extensions
+      non_executable_names = ['readme', 'license', 'changelog', 'authors', 'contributors', 'todo',
+                              'news']
+      return false if non_executable_names.include?(base_name)
+
+      # If it's not a known non-executable, assume it might be executable
+      return true
+    end
+
+    # Check file content for executable signatures (if file exists and is readable)
+    begin
+      if File.exist?(file_path) && File.readable?(file_path) && File.size(file_path) > 0
+        # Read first few bytes to check for executable signatures
+        first_bytes = File.read(file_path, [File.size(file_path), 16].min)
+
+        # ELF executable (Linux/Unix)
+        return true if first_bytes.start_with?("\x7fELF")
+
+        # Mach-O executable (macOS) - multiple signatures
+        return true if first_bytes.start_with?("\xfe\xed\xfa\xce") # 32-bit
+        return true if first_bytes.start_with?("\xfe\xed\xfa\xcf") # 64-bit
+        return true if first_bytes.start_with?("\xcf\xfa\xed\xfe") # reverse byte order
+
+        # PE executable (Windows)
+        return true if first_bytes.start_with?("MZ")
+
+        # Script with shebang
+        return true if first_bytes.start_with?("#!")
+
+        # Java class files
+        return true if first_bytes.start_with?("\xca\xfe\xba\xbe")
+
+        # Archive files that might contain executables
+        return true if first_bytes.start_with?("PK") && extension.empty? # ZIP-based executable
+      end
+    rescue StandardError => e
+      # If we can't read the file, fall back to name-based detection
+      Rails.logger.debug "Could not read file for executable detection: #{e.message}"
+    end
+
+    false
+  end
+
+  # Validate tar file integrity before extraction
+  def validate_tar_file(file_path)
+    # Check if file is readable and has content
+    raise "Tar file is empty or unreadable" unless File.readable?(file_path) && File.size(file_path) > 0
+
+    # Validate based on file extension
+    if File.extname(file_path).downcase.in?(['.gz', '.tgz']) ||
+       file_path.to_s.downcase.end_with?('.tar.gz')
+      # Validate gzipped tar file
+      begin
+        require 'zlib'
+        Zlib::GzipReader.open(file_path) do |gz|
+          # Try to read the first tar header to validate format
+          tar_reader = Gem::Package::TarReader.new(gz)
+          tar_reader.rewind
+          # Just peek at the first entry to validate the format
+          first_entry = tar_reader.first
+          raise "Invalid tar format: no valid entries found" if first_entry.nil?
+        end
+      rescue Zlib::GzipFile::Error => e
+        raise "Corrupted gzip file: #{e.message}"
+      rescue Gem::Package::TarInvalidError => e
+        raise "Invalid tar format: #{e.message}"
+      end
+    else
+      # Validate regular tar file
+      begin
+        File.open(file_path, 'rb') do |file|
+          tar_reader = Gem::Package::TarReader.new(file)
+          tar_reader.rewind
+          # Just peek at the first entry to validate the format
+          first_entry = tar_reader.first
+          raise "Invalid tar format: no valid entries found" if first_entry.nil?
+        end
+      rescue Gem::Package::TarInvalidError => e
+        raise "Invalid tar format: #{e.message}"
+      rescue StandardError => e
+        raise "Error reading tar file: #{e.message}"
+      end
+    end
   end
 end

--- a/app/controllers/file_manager_controller.rb
+++ b/app/controllers/file_manager_controller.rb
@@ -32,78 +32,15 @@ class FileManagerController < ApplicationController
       populate_directory(absolute_path, new_url)
       render 'file_manager/index'
     elsif File.file?(absolute_path) && check_instructor(absolute_path)
-      # Check if this is a tar file and extract parameter is present
-      if params[:extract] && is_tar_file?(absolute_path)
-        # Skip extraction if the tar file itself is an executable
-        if is_likely_executable?(absolute_path, File.basename(absolute_path))
-          flash[:error] = "Cannot extract tar files that are not directories"
-          redirect_to file_manager_index_path(path: File.dirname(path))
-          return
-        end
-
+      if params[:preview] && is_tar_file?(absolute_path)
         begin
-          parent_dir = File.dirname(absolute_path)
-          # Create subdirectory for extraction based on tar filename without extension
-          base_name = File.basename(absolute_path, '.*')
-          # Remove additional extensions for files like .tar.gz
-          base_name = base_name.gsub(/\.tar$/, '')
-          extract_dir = File.join(parent_dir, base_name)
-
-          # Ensure extract directory doesn't already exist to avoid conflicts
-          counter = 1
-          original_extract_dir = extract_dir
-          while File.exist?(extract_dir)
-            extract_dir = "#{original_extract_dir}_#{counter}"
-            counter += 1
-          end
-
-          # Create the extraction directory
-          FileUtils.mkdir_p(extract_dir)
-
-          # Validate tar file before attempting extraction
-          validate_tar_file(absolute_path)
-
-          # Handle different tar formats
-          if File.extname(absolute_path).downcase.in?(['.gz', '.tgz']) ||
-             absolute_path.to_s.downcase.end_with?('.tar.gz')
-            # Handle gzipped tar files
-            require 'zlib'
-            Zlib::GzipReader.open(absolute_path) do |gz|
-              tar_extract_method = Gem::Package::TarReader.new(gz)
-              extract_tar_entries(tar_extract_method, extract_dir)
-            end
-          else
-            # Handle regular tar files - ensure proper resource management
-            File.open(absolute_path, 'rb') do |file|
-              tar_extract_method = Gem::Package::TarReader.new(file)
-              extract_tar_entries(tar_extract_method, extract_dir)
-            end
-          end
-
-          flash[:success] =
-            "Successfully extracted #{File.basename(absolute_path)} to
-              #{File.basename(extract_dir)}/"
-          redirect_to file_manager_index_path(path: File.dirname(path))
-          nil
-        rescue Gem::Package::TarInvalidError => e
-          # Clean up partially extracted directory
-          FileUtils.rm_rf(extract_dir) if File.exist?(extract_dir)
-          flash[:error] =
-            "Corrupted tar file: #{e.message}. The file appears to be damaged or invalid."
-          redirect_to file_manager_index_path(path: File.dirname(path))
-          nil
-        rescue Zlib::GzipFile::Error => e
-          # Clean up partially extracted directory
-          FileUtils.rm_rf(extract_dir) if File.exist?(extract_dir)
-          flash[:error] = "Corrupted gzip archive: #{e.message}. The compressed file is damaged."
-          redirect_to file_manager_index_path(path: File.dirname(path))
-          nil
+          @tar_contents = list_tar_contents(absolute_path)
+          @path = path
+          @tar_file_name = File.basename(absolute_path)
+          render :tar_preview, formats: :html
         rescue StandardError => e
-          # Clean up partially extracted directory
-          FileUtils.rm_rf(extract_dir) if File.exist?(extract_dir)
-          flash[:error] = "Unable to extract tar file: #{e.message}"
+          flash[:error] = "Unable to read tar file: #{e.message}"
           redirect_to file_manager_index_path(path: File.dirname(path))
-          nil
         end
       elsif File.size(absolute_path) > 1_000_000 || params[:download]
         send_file absolute_path
@@ -174,57 +111,6 @@ class FileManagerController < ApplicationController
     flash[:error] = e.message
   end
 
-  def chmod
-    absolute_path = check_path_exist(params[:path])
-    if check_instructor(absolute_path)
-      if params[:permissions].nil? || params[:permissions].empty?
-        raise ArgumentError, "Permissions not provided"
-      end
-
-      # Validate permission format (should be 3-4 digit octal)
-      unless params[:permissions].match(/\A[0-7]{3,4}\Z/)
-        raise ArgumentError,
-              "Invalid permission format. Use 3-4 digit octal format (e.g., 755, 644)"
-      end
-
-      # Convert octal string to integer
-      permission_mode = params[:permissions].to_i(8)
-
-      # Validate permission range (0000 to 7777)
-      unless permission_mode.between?(0, 0o7777)
-        raise ArgumentError, "Permission value out of range"
-      end
-
-      # Apply the permission change
-      File.chmod(permission_mode, absolute_path)
-      flash[:success] = "Successfully changed permissions to #{params[:permissions]}"
-    else
-      flash[:error] = "You are not authorized to change permissions for this path"
-      redirect_to root_path
-    end
-  rescue ArgumentError => e
-    flash[:error] = e.message
-    respond_to do |format|
-      format.html { redirect_back(fallback_location: file_manager_index_path) }
-      format.json { render json: { error: e.message }, status: :bad_request }
-    end
-  rescue Errno::EPERM, Errno::EACCES => e
-    flash[:error] = "Permission denied: #{e.message}"
-    respond_to do |format|
-      format.html { redirect_back(fallback_location: file_manager_index_path) }
-      format.json { render json: { error: "Permission denied: #{e.message}" }, status: :forbidden }
-    end
-  rescue StandardError => e
-    flash[:error] = "Error changing permissions: #{e.message}"
-    respond_to do |format|
-      format.html { redirect_back(fallback_location: file_manager_index_path) }
-      format.json {
-        render json: { error: "Error changing permissions: #{e.message}" },
-               status: :internal_server_error
-      }
-    end
-  end
-
   def find_by_directory_path(absolute_path)
     # Normalize the path to ensure consistent comparison
     normalized_path = Pathname.new(absolute_path).cleanpath.to_s
@@ -266,9 +152,9 @@ class FileManagerController < ApplicationController
         add_directory_to_tar(tar, full_path, tar_path)
       elsif File.file?(full_path)
         # Add file entry
-        File.open(full_path, 'rb') do |_file|
+        File.open(full_path, 'rb') do |file|
           tar.add_file(tar_path, mode) do |tar_file|
-            tar_file.write(_file.read)
+            tar_file.write(file.read)
           end
         end
       elsif File.symlink?(full_path)
@@ -378,6 +264,55 @@ class FileManagerController < ApplicationController
     end
   end
 
+  def view_tar_file
+    tar_path = params[:tar_path]
+    file_path = params[:file_path]
+
+    absolute_tar_path = check_path_exist(tar_path)
+
+    unless check_instructor(absolute_tar_path)
+      flash[:error] = "You are not authorized to view this path"
+      redirect_to root_path
+      return
+    end
+
+    unless is_tar_file?(absolute_tar_path)
+      flash[:error] = "Not a valid tar file"
+      redirect_to file_manager_index_path(path: File.dirname(tar_path))
+      return
+    end
+
+    begin
+      file_content = extract_single_file_from_tar(absolute_tar_path, file_path)
+
+      if file_content.nil?
+        flash[:error] = "File not found in archive"
+        redirect_to file_manager_index_path(path: "#{tar_path}?preview=true")
+        return
+      end
+
+      is_binary = file_content.bytes.take(8192).any? { |byte|
+        byte.zero? || (byte < 32 && ![9, 10, 13].include?(byte))
+      }
+
+      if is_binary || file_content.bytesize > 1_000_000
+        send_data file_content,
+                  filename: File.basename(file_path),
+                  disposition: 'attachment'
+      else
+        @tar_path = tar_path
+        @file_path = file_path
+        @file = file_content.force_encoding('UTF-8')
+        @tar_file_name = File.basename(absolute_tar_path)
+        @file_name = file_path
+        render :tar_file_view, formats: :html
+      end
+    rescue StandardError => e
+      flash[:error] = "Unable to extract file: #{e.message}"
+      redirect_to file_manager_index_path(path: "#{tar_path}?preview=true")
+    end
+  end
+
 private
 
   def populate_directory(current_directory, current_url)
@@ -475,203 +410,111 @@ private
       extension == '.gz' && path.to_s.downcase.end_with?('.tar.gz')
   end
 
-  def extract_tar_entries(tar_reader, extract_dir)
-    tar_reader.rewind
-    tar_reader.each do |entry|
-      # Skip entries with invalid names or paths that try to escape the extraction directory
-      next if entry.full_name.include?('..')
-      next if entry.full_name.start_with?('/')
+  def list_tar_contents(file_path)
+    contents = []
 
-      # Handle entries that might be at the root level or in subdirectories
-      target_path = File.join(extract_dir, entry.full_name)
-
-      if entry.directory?
-        FileUtils.mkdir_p(target_path)
-      elsif entry.file?
-        # Ensure parent directory exists (especially important for files at root level)
-        parent_dir = File.dirname(target_path)
-        FileUtils.mkdir_p(parent_dir) unless parent_dir == extract_dir
-
-        # Properly read and write file data to prevent corruption
-        File.open(target_path, 'wb') do |f|
-          # Read in chunks to handle large files properly and detect corruption
-          bytes_written = 0
-          expected_size = entry.header.size
-
-          begin
-            while (chunk = entry.read(8192))
-              break if chunk.empty?
-
-              f.write(chunk)
-              bytes_written += chunk.length
-
-              # Safety check to prevent infinite loops with corrupted entries
-              if bytes_written > expected_size + 8192
-                raise "File size mismatch: expected #{expected_size}, got #{bytes_written}+"
-              end
-            end
-          rescue StandardError => e
-            # If reading fails, try to read the entire content at once as fallback
-            Rails.logger.warn "Chunked reading failed for #{entry.full_name}:
-              #{e.message}, trying full read"
-            begin
-              entry.rewind
-              content = entry.read
-              f.rewind
-              f.truncate(0)
-              f.write(content)
-              bytes_written = content.length
-            rescue StandardError => fallback_error
-              raise "Failed to extract #{entry.full_name}: #{fallback_error.message}"
-            end
-          end
-
-          # Verify file size matches expected size
-          if expected_size > 0 && bytes_written != expected_size
-            Rails.logger.warn "Size mismatch for #{entry.full_name}:
-              expected #{expected_size}, got #{bytes_written}"
-          end
-        end
-
-        # Handle file permissions, especially for executables
-        begin
-          mode = entry.header.mode
-          if mode.is_a?(Integer) && mode > 0 && mode < 0o777777
-            # Preserve original permissions
-            File.chmod(mode, target_path)
-          elsif is_likely_executable?(target_path, entry.full_name)
-            # Determine if this should be executable based on file characteristics
-            File.chmod(0o755, target_path)
-          # Set executable permissions (owner: rwx, group: rx, other: rx)
-          else
-            # Set default readable permissions for regular files
-            File.chmod(0o644, target_path)
-          end
-        rescue StandardError => e
-          # Log the error but continue extraction
-          Rails.logger.warn "Could not set permissions for #{target_path}: #{e.message}"
-
-          # Fallback: try to determine if it should be executable
-          if is_likely_executable?(target_path, entry.full_name)
-            begin
-              File.chmod(0o755, target_path)
-            rescue StandardError
-              File.chmod(0o644, target_path)
-            end
-          else
-            File.chmod(0o644, target_path)
-          end
-        end
-      elsif entry.symlink?
-        # Handle symbolic links if present
-        begin
-          File.symlink(entry.header.linkname, target_path)
-        rescue StandardError => e
-          Rails.logger.warn "Could not create symlink #{target_path}: #{e.message}"
-        end
-      end
-    end
-  end
-
-  def is_likely_executable?(file_path, original_name)
-    # Check file extension for common executable types
-    executable_extensions = ['.exe', '.bin', '.run', '.sh', '.bash', '.zsh', '.py', '.pl', '.rb',
-                             '.jar', '.out']
-    extension = File.extname(original_name).downcase
-    return true if executable_extensions.include?(extension)
-
-    # Check for common executable names without extensions
-    executable_names = ['makefile', 'dockerfile', 'configure', 'install', 'setup', 'build',
-                        'autograde']
-    base_name = File.basename(original_name).downcase
-    # return true if any executable names is in the base_name
-    return true if executable_names.any? { |name| base_name.include?(name) }
-
-    # Check if filename has no extension and is not a common non-executable file
-    if extension.empty? && !original_name.include?('.')
-      # Common non-executable files without extensions
-      non_executable_names = ['readme', 'license', 'changelog', 'authors', 'contributors', 'todo',
-                              'news']
-      return false if non_executable_names.include?(base_name)
-
-      # If it's not a known non-executable, assume it might be executable
-      return true
-    end
-
-    # Check file content for executable signatures (if file exists and is readable)
     begin
-      if File.exist?(file_path) && File.readable?(file_path) && File.size(file_path) > 0
-        # Read first few bytes to check for executable signatures
-        first_bytes = File.read(file_path, [File.size(file_path), 16].min)
-
-        # ELF executable (Linux/Unix)
-        return true if first_bytes.start_with?("\x7fELF")
-
-        # Mach-O executable (macOS) - multiple signatures
-        return true if first_bytes.start_with?("\xfe\xed\xfa\xce") # 32-bit
-        return true if first_bytes.start_with?("\xfe\xed\xfa\xcf") # 64-bit
-        return true if first_bytes.start_with?("\xcf\xfa\xed\xfe") # reverse byte order
-
-        # PE executable (Windows)
-        return true if first_bytes.start_with?("MZ")
-
-        # Script with shebang
-        return true if first_bytes.start_with?("#!")
-
-        # Java class files
-        return true if first_bytes.start_with?("\xca\xfe\xba\xbe")
-
-        # Archive files that might contain executables
-        return true if first_bytes.start_with?("PK") && extension.empty? # ZIP-based executable
-      end
-    rescue StandardError => e
-      # If we can't read the file, fall back to name-based detection
-      Rails.logger.debug "Could not read file for executable detection: #{e.message}"
-    end
-
-    false
-  end
-
-  # Validate tar file integrity before extraction
-  def validate_tar_file(file_path)
-    # Check if file is readable and has content
-    raise "Tar file is empty or unreadable" unless File.readable?(file_path) &&
-                                                   File.size(file_path) > 0
-
-    # Validate based on file extension
-    if File.extname(file_path).downcase.in?(['.gz', '.tgz']) ||
-       file_path.to_s.downcase.end_with?('.tar.gz')
-      # Validate gzipped tar file
-      begin
+      if File.extname(file_path).downcase.in?(['.gz', '.tgz']) ||
+         file_path.to_s.downcase.end_with?('.tar.gz')
         require 'zlib'
         Zlib::GzipReader.open(file_path) do |gz|
-          # Try to read the first tar header to validate format
           tar_reader = Gem::Package::TarReader.new(gz)
           tar_reader.rewind
-          # Just peek at the first entry to validate the format
-          first_entry = tar_reader.first
-          raise "Invalid tar format: no valid entries found" if first_entry.nil?
+          tar_reader.each do |entry|
+            next if entry.full_name.include?('..')
+            next if entry.full_name.start_with?('/')
+
+            mode_str = begin
+              sprintf('%o', entry.header.mode)
+            rescue StandardError
+              '-'
+            end
+
+            mtime_val = begin
+              entry.header.mtime
+            rescue StandardError
+              nil
+            end
+
+            contents << {
+              name: entry.full_name,
+              size: entry.header.size,
+              type: if entry.directory?
+                      'directory'
+                    else
+                      (entry.file? ? 'file' : 'other')
+                    end,
+              mode: mode_str,
+              mtime: mtime_val
+            }
+          end
         end
-      rescue Zlib::GzipFile::Error => e
-        raise "Corrupted gzip file: #{e.message}"
-      rescue Gem::Package::TarInvalidError => e
-        raise "Invalid tar format: #{e.message}"
-      end
-    else
-      # Validate regular tar file
-      begin
+      else
         File.open(file_path, 'rb') do |file|
           tar_reader = Gem::Package::TarReader.new(file)
           tar_reader.rewind
-          # Just peek at the first entry to validate the format
-          first_entry = tar_reader.first
-          raise "Invalid tar format: no valid entries found" if first_entry.nil?
+          tar_reader.each do |entry|
+            next if entry.full_name.include?('..')
+            next if entry.full_name.start_with?('/')
+
+            mode_str = begin
+              sprintf('%o', entry.header.mode)
+            rescue StandardError
+              '-'
+            end
+
+            mtime_val = begin
+              entry.header.mtime
+            rescue StandardError
+              nil
+            end
+
+            contents << {
+              name: entry.full_name,
+              size: entry.header.size,
+              type: if entry.directory?
+                      'directory'
+                    else
+                      (entry.file? ? 'file' : 'other')
+                    end,
+              mode: mode_str,
+              mtime: mtime_val
+            }
+          end
         end
-      rescue Gem::Package::TarInvalidError => e
-        raise "Invalid tar format: #{e.message}"
-      rescue StandardError => e
-        raise "Error reading tar file: #{e.message}"
+      end
+    rescue StandardError => e
+      raise "Error reading tar file: #{e.message}"
+    end
+
+    contents
+  end
+
+  def extract_single_file_from_tar(tar_path, file_path)
+    if File.extname(tar_path).downcase.in?(['.gz', '.tgz']) ||
+       tar_path.to_s.downcase.end_with?('.tar.gz')
+      require 'zlib'
+      Zlib::GzipReader.open(tar_path) do |gz|
+        tar_reader = Gem::Package::TarReader.new(gz)
+        tar_reader.rewind
+        tar_reader.each do |entry|
+          if entry.full_name == file_path && entry.file?
+            return entry.read
+          end
+        end
+      end
+    else
+      File.open(tar_path, 'rb') do |file|
+        tar_reader = Gem::Package::TarReader.new(file)
+        tar_reader.rewind
+        tar_reader.each do |entry|
+          if entry.full_name == file_path && entry.file?
+            return entry.read
+          end
+        end
       end
     end
+
+    nil
   end
 end

--- a/app/views/file_manager/index.html.erb
+++ b/app/views/file_manager/index.html.erb
@@ -55,10 +55,10 @@
           <td>
             <%= check_box_tag 'selected_files[]', entry[:relative], false, { class: "check", html: { data: { path: entry[:relative] } } } %>
           <td>
-            <% 
+            <%
               # Check if file is a tar archive
               file_ext = File.extname(entry[:entry]).downcase
-              is_tar = file_ext == '.tar' || file_ext == '.tgz' || 
+              is_tar = file_ext == '.tar' || file_ext == '.tgz' ||
                        (file_ext == '.gz' && entry[:entry].downcase.end_with?('.tar.gz'))
             %>
             <% if entry[:type] == :file && is_tar %>
@@ -69,9 +69,9 @@
               <% end %>
               <div style="margin-top: 5px;">
                 <%= link_to "View", entry[:relative], style: "margin-right: 10px; font-size: 12px;" %>
-                <%= link_to "Extract", "#{entry[:relative]}?extract=true", 
-                    onclick: "return confirm('This will extract the tar file to a new subdirectory. Continue?');", 
-                    style: "margin-right: 10px; font-size: 12px; color: #4CAF50;" %>
+                <%= link_to "Extract", "#{entry[:relative]}?extract=true",
+                            onclick: "return confirm('This will extract the tar file to a new subdirectory. Continue?');",
+                            style: "margin-right: 10px; font-size: 12px; color: #4CAF50;" %>
               </div>
             <% else %>
               <!-- Normal file/directory handling -->
@@ -86,15 +86,16 @@
           </td>
           <td>
             <div class="permissions-container">
-              <input type="text" 
-                     id="permissions-<%= entry[:relative].gsub(/[^a-zA-Z0-9]/, '_') %>" 
-                     value="<%= entry[:permissions] %>" 
+              <input type="text"
+                     id="permissions-<%= entry[:relative].gsub(/[^a-zA-Z0-9]/, '_') %>"
+                     value="<%= entry[:permissions] %>"
                      class="permissions-input"
                      data-file-path="<%= entry[:relative] %>"
-                     maxlength="4" 
+                     maxlength="4"
                      pattern="[0-7]{3,4}"
+                     autocomplete="off"
                      title="Enter 3-4 digit octal permissions (e.g., 755, 644)">
-              <button type="button" 
+              <button type="button"
                       class="permissions-button"
                       onclick="changePermissions('<%= entry[:relative] %>', document.getElementById('permissions-<%= entry[:relative].gsub(/[^a-zA-Z0-9]/, '_') %>').value)"
                       title="Apply permissions">

--- a/app/views/file_manager/index.html.erb
+++ b/app/views/file_manager/index.html.erb
@@ -54,9 +54,30 @@
           <td>
             <%= check_box_tag 'selected_files[]', entry[:relative], false, { class: "check", html: { data: { path: entry[:relative] } } } %>
           <td>
-            <%= link_to entry[:relative].to_s do %>
-              <i class='material-icons left middle'><%= entry[:type] == :file ? 'article' : 'folder' %></i>
-              <span><%= entry[:entry] %></span>
+            <% 
+              # Check if file is a tar archive
+              file_ext = File.extname(entry[:entry]).downcase
+              is_tar = file_ext == '.tar' || file_ext == '.tgz' || 
+                       (file_ext == '.gz' && entry[:entry].downcase.end_with?('.tar.gz'))
+            %>
+            <% if entry[:type] == :file && is_tar %>
+              <!-- Special handling for tar files -->
+              <%= link_to entry[:relative].to_s, onclick: "return false;", style: "cursor: pointer;" do %>
+                <i class='material-icons left middle'>archive</i>
+                <span><%= entry[:entry] %></span>
+              <% end %>
+              <div style="margin-top: 5px;">
+                <%= link_to "View", entry[:relative], style: "margin-right: 10px; font-size: 12px;" %>
+                <%= link_to "Extract", "#{entry[:relative]}?extract=true", 
+                    onclick: "return confirm('This will extract the tar file to a new subdirectory. Continue?');", 
+                    style: "margin-right: 10px; font-size: 12px; color: #4CAF50;" %>
+              </div>
+            <% else %>
+              <!-- Normal file/directory handling -->
+              <%= link_to entry[:relative].to_s do %>
+                <i class='material-icons left middle'><%= entry[:type] == :file ? 'article' : 'folder' %></i>
+                <span><%= entry[:entry] %></span>
+              <% end %>
             <% end %>
           </td>
           <td>

--- a/app/views/file_manager/index.html.erb
+++ b/app/views/file_manager/index.html.erb
@@ -42,6 +42,7 @@
       </th>
       <th>Filename</th>
       <th>Bytes</th>
+      <th>Permissions</th>
       <th>Date</th>
       <th>Rename</th>
       <th>Delete</th>
@@ -82,6 +83,24 @@
           </td>
           <td>
             <%= entry[:size] %>
+          </td>
+          <td>
+            <div class="permissions-container">
+              <input type="text" 
+                     id="permissions-<%= entry[:relative].gsub(/[^a-zA-Z0-9]/, '_') %>" 
+                     value="<%= entry[:permissions] %>" 
+                     class="permissions-input"
+                     data-file-path="<%= entry[:relative] %>"
+                     maxlength="4" 
+                     pattern="[0-7]{3,4}"
+                     title="Enter 3-4 digit octal permissions (e.g., 755, 644)">
+              <button type="button" 
+                      class="permissions-button"
+                      onclick="changePermissions('<%= entry[:relative] %>', document.getElementById('permissions-<%= entry[:relative].gsub(/[^a-zA-Z0-9]/, '_') %>').value)"
+                      title="Apply permissions">
+                <i class='material-icons'>check</i>
+              </button>
+            </div>
           </td>
           <td>
             <%= entry[:date] %>

--- a/app/views/file_manager/index.html.erb
+++ b/app/views/file_manager/index.html.erb
@@ -68,9 +68,8 @@
                 <span><%= entry[:entry] %></span>
               <% end %>
               <div style="margin-top: 5px;">
-                <%= link_to "View", entry[:relative], style: "margin-right: 10px; font-size: 12px;" %>
-                <%= link_to "Extract", "#{entry[:relative]}?extract=true",
-                            onclick: "return confirm('This will extract the tar file to a new subdirectory. Continue?');",
+                <%= link_to "Download", entry[:relative], style: "margin-right: 10px; font-size: 12px;" %>
+                <%= link_to "Preview Contents", "#{entry[:relative]}?preview=true",
                             style: "margin-right: 10px; font-size: 12px; color: #4CAF50;" %>
               </div>
             <% else %>
@@ -85,23 +84,7 @@
             <%= entry[:size] %>
           </td>
           <td>
-            <div class="permissions-container">
-              <input type="text"
-                     id="permissions-<%= entry[:relative].gsub(/[^a-zA-Z0-9]/, '_') %>"
-                     value="<%= entry[:permissions] %>"
-                     class="permissions-input"
-                     data-file-path="<%= entry[:relative] %>"
-                     maxlength="4"
-                     pattern="[0-7]{3,4}"
-                     autocomplete="off"
-                     title="Enter 3-4 digit octal permissions (e.g., 755, 644)">
-              <button type="button"
-                      class="permissions-button"
-                      onclick="changePermissions('<%= entry[:relative] %>', document.getElementById('permissions-<%= entry[:relative].gsub(/[^a-zA-Z0-9]/, '_') %>').value)"
-                      title="Apply permissions">
-                <i class='material-icons'>check</i>
-              </button>
-            </div>
+            <span class="permissions-display"><%= entry[:permissions] %></span>
           </td>
           <td>
             <%= entry[:date] %>

--- a/app/views/file_manager/tar_file_view.html.erb
+++ b/app/views/file_manager/tar_file_view.html.erb
@@ -1,0 +1,84 @@
+<% content_for :stylesheets do %>
+  <%= stylesheet_link_tag "file_manager" %>
+  <%= stylesheet_link_tag "style" %>
+  <%= stylesheet_link_tag "highlight.css" %>
+<% end %>
+
+<% content_for :javascripts do %>
+  <%= javascript_include_tag "highlight.pack" %>
+  <script>
+    document.addEventListener('DOMContentLoaded', function() {
+      document.querySelectorAll('pre code').forEach((block) => {
+        hljs.highlightBlock(block);
+      });
+    });
+  </script>
+<% end %>
+
+<div class="tar-file-view-container">
+  <h2>
+    <i class="material-icons" style="vertical-align: middle;">description</i>
+    File from Archive: <%= @file_name %>
+  </h2>
+
+  <div class="info-message">
+    <i class="material-icons" style="vertical-align: middle; margin-right: 5px;">info</i>
+    <span>Viewing file from: <strong><%= @tar_file_name %></strong> (extracted temporarily, not saved to filesystem)</span>
+  </div>
+
+  <div style="margin-bottom: 20px;">
+    <%= link_to "← Back to Archive Preview", "#{path_file_manager_index_path(@tar_path)}?preview=true", class: "btn" %>
+    <%= link_to "← Back to File Manager", path_file_manager_index_path(File.dirname(@tar_path)), class: "btn" %>
+  </div>
+
+  <div class="file-content-container">
+    <pre><code><%= @file %></code></pre>
+  </div>
+</div>
+
+<style>
+  .tar-file-view-container {
+    padding: 20px;
+  }
+
+  .tar-file-view-container h2 {
+    margin-bottom: 20px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+  }
+
+  .info-message {
+    padding: 10px 15px;
+    background-color: #e3f2fd;
+    border-left: 4px solid #2196F3;
+    margin-bottom: 20px;
+    border-radius: 4px;
+    display: flex;
+    align-items: center;
+  }
+
+  .info-message i {
+    color: #2196F3;
+  }
+
+  .file-content-container {
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    background-color: #f8f9fa;
+    max-height: 70vh;
+    overflow: auto;
+  }
+
+  .file-content-container pre {
+    margin: 0;
+    padding: 15px;
+    background-color: #f8f9fa;
+  }
+
+  .file-content-container code {
+    font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;
+    font-size: 13px;
+    line-height: 1.5;
+  }
+</style>

--- a/app/views/file_manager/tar_preview.html.erb
+++ b/app/views/file_manager/tar_preview.html.erb
@@ -1,0 +1,127 @@
+<% content_for :stylesheets do %>
+  <%= stylesheet_link_tag "file_manager" %>
+  <%= stylesheet_link_tag "style" %>
+<% end %>
+
+<div class="tar-preview-container">
+  <h2>
+    <i class="material-icons" style="vertical-align: middle;">archive</i>
+    Archive Contents: <%= @tar_file_name %>
+  </h2>
+
+  <div style="margin-bottom: 20px;">
+    <%= link_to "← Back to File Manager", file_manager_index_path(path: File.dirname(@path)), class: "btn" %>
+  </div>
+
+  <div class="info-message">
+    <i class="material-icons" style="vertical-align: middle; margin-right: 5px;">info</i>
+    <span>This is a preview of the archive contents. No files are extracted to the filesystem.</span>
+  </div>
+
+  <div class="table-scroll">
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Type</th>
+          <th>Size (bytes)</th>
+          <th>Permissions</th>
+          <th>Modified</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% if @tar_contents.empty? %>
+          <tr>
+            <td colspan="5" style="text-align: center; padding: 20px;">
+              <i>No files found in archive</i>
+            </td>
+          </tr>
+        <% else %>
+          <% @tar_contents.each do |item| %>
+            <tr>
+              <td>
+                <i class='material-icons left middle' style="font-size: 16px;">
+                  <%= item[:type] == 'directory' ? 'folder' : 'description' %>
+                </i>
+                <% if item[:type] == 'file' %>
+                  <%= link_to item[:name],
+                              view_tar_file_path(tar_path: @path, file_path: item[:name]),
+                              style: "color: #007bff; text-decoration: none;" %>
+                <% else %>
+                  <%= item[:name] %>
+                <% end %>
+              </td>
+              <td><%= item[:type].capitalize %></td>
+              <td><%= item[:size] %></td>
+              <td><span class="permissions-display"><%= item[:mode] %></span></td>
+              <td>
+                <% if item[:mtime] %>
+                  <% mtime = item[:mtime].is_a?(Integer) ? Time.zone.at(item[:mtime]) : item[:mtime] %>
+                  <%= mtime.strftime('%d %b %Y %H:%M') %>
+                <% else %>
+                  -
+                <% end %>
+              </td>
+            </tr>
+          <% end %>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+
+  <div style="margin-top: 20px; padding: 15px; background-color: #f5f5f5; border-radius: 5px;">
+    <strong>Total files:</strong> <%= @tar_contents.count %>
+  </div>
+</div>
+
+<style>
+  .tar-preview-container {
+    padding: 20px;
+  }
+
+  .tar-preview-container h2 {
+    margin-bottom: 20px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+  }
+
+  .info-message {
+    padding: 10px 15px;
+    background-color: #e3f2fd;
+    border-left: 4px solid #2196F3;
+    margin-bottom: 20px;
+    border-radius: 4px;
+    display: flex;
+    align-items: center;
+  }
+
+  .info-message i {
+    color: #2196F3;
+  }
+
+  .table-scroll {
+    max-height: 60vh;
+    overflow-y: auto;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+  }
+
+  .tar-preview-container table tbody tr {
+    transition: background-color 0.2s;
+  }
+
+  .tar-preview-container table tbody tr:hover {
+    background-color: #f5f5f5;
+  }
+
+  .tar-preview-container table td a {
+    text-decoration: none;
+    color: #007bff;
+  }
+
+  .tar-preview-container table td a:hover {
+    text-decoration: underline;
+    color: #0056b3;
+  }
+</style>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -72,6 +72,8 @@ Rails.application.routes.draw do
   get "device_flow_resolve", to: "device_flow_activation#resolve"
   get "device_flow_auth_cb", to: "device_flow_activation#authorization_callback"
 
+  get 'file_manager/view_tar_file', to: 'file_manager#view_tar_file', as: :view_tar_file
+  
   resources :file_manager, param: :path, path: 'file_manager', only: [:index] do
     collection do
       post 'upload', to: 'file_manager#upload'
@@ -81,7 +83,6 @@ Rails.application.routes.draw do
       put ':path', to: 'file_manager#rename', constraints: { path: /.+/ }, as: :rename
       post ':path', to: 'file_manager#upload', constraints: { path: /.+/ }, as: :upload_path
       delete ':path', to: 'file_manager#delete', constraints: { path: /.+/ }, as: :delete
-      patch ':path/chmod', to: 'file_manager#chmod', constraints: { path: /.+/ }, as: :chmod
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -81,6 +81,7 @@ Rails.application.routes.draw do
       put ':path', to: 'file_manager#rename', constraints: { path: /.+/ }, as: :rename
       post ':path', to: 'file_manager#upload', constraints: { path: /.+/ }, as: :upload_path
       delete ':path', to: 'file_manager#delete', constraints: { path: /.+/ }, as: :delete
+      patch ':path/chmod', to: 'file_manager#chmod', constraints: { path: /.+/ }, as: :chmod
     end
   end
 

--- a/import_submissions.rb
+++ b/import_submissions.rb
@@ -1,0 +1,78 @@
+require 'zip'
+require 'fileutils'
+require 'tempfile'
+require 'rack/test'
+include Rack::Test::Methods
+
+# Usage: rails runner import_submissions.rb path/to/zipfile.zip "Assessment Name"
+
+zip_path = ARGV[0]
+assessment_name = ARGV[1]
+
+unless zip_path && assessment_name
+  puts "Usage: rails runner import_submissions.rb path/to/zipfile.zip \"Assessment Name\""
+  exit 1
+end
+
+# Replace this with your actual course ID
+course_name = "18213-m25"  # <-- change this to your course name
+course = Course.find_by(name: course_name)
+unless course
+  puts "Course not found for name #{course_name}"
+  exit 1
+end
+
+assessment = course.assessments.find_by(name: assessment_name)
+unless assessment
+  puts "Assessment '#{assessment_name}' not found in course ID #{course_name}"
+  exit 1
+end
+
+temp_dir = Dir.mktmpdir
+
+begin
+  Zip::File.open(zip_path) do |zip_file|
+    zip_file.each do |entry|
+      # Match filenames like <username>_<id>_<assessment>-handin.tar
+      next unless entry.name =~ /\A(.+?)_\d+?_#{Regexp.escape(assessment_name)}-handin\.tar\z/
+
+      username = Regexp.last_match(1)
+      user = User.find_by(email: username)
+      unless user
+        puts "User not found: #{username}"
+        next
+      end
+
+      cud = CourseUserDatum.find_by(user_id: user.id, course_id: course.id)
+      unless cud
+        puts "CourseUserDatum not found for #{username}"
+        next
+      end
+
+      puts "Creating submission for #{username}"
+
+      # Extract tar to temporary path
+      temp_tar_path = File.join(temp_dir, entry.name)
+      entry.extract(temp_tar_path) { true }
+
+      submission = Submission.new(
+        assessment_id: assessment.id,
+        course_user_datum_id: cud.id,
+        submitted_by_id: cud.id,
+        notes: "Bulk uploaded from ZIP",
+        special_type: nil
+      )
+
+      begin
+        submission.save!
+        file_param = { "file" => Rack::Test::UploadedFile.new(temp_tar_path, "application/x-tar") }
+        submission.save_file(file_param)
+        puts "Successfully created submission for #{username}"
+      rescue => e
+        puts "Failed to create submission for #{username}: #{e.message}"
+      end
+    end
+  end
+ensure
+  FileUtils.remove_entry(temp_dir)
+end

--- a/spec/controllers/file_manager_controller_spec.rb
+++ b/spec/controllers/file_manager_controller_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe FileManagerController, type: :controller do
       doc = Nokogiri::HTML(response.body)
       expect(doc).to have_selector("th", text: "Filename")
       expect(doc).to have_selector("th", text: "Bytes")
+      expect(doc).to have_selector("th", text: "Permissions")
       expect(doc).to have_selector("th", text: "Date")
       expect(doc).to have_selector("th", text: "Rename")
       expect(doc).to have_selector("th", text: "Delete")


### PR DESCRIPTION
## Description
Previously, courses, labs and assessments that were downloaded as tar files ended up being corrupted. There was also no quick and easy way to view permission bits and change permissions of files on the system.

This PR allows
- Courses and labs to be downloaded and exported correctly as tar files
- Tar files can be exported and opened in the file manager without affecting the core project directory
- File manager shows permission bits of each file and directory

<img width="627" height="237" alt="Screenshot 2025-10-06 at 4 06 27 PM" src="https://github.com/user-attachments/assets/3bf31e28-ede3-4630-8559-d81aebc8f11e" />

## How Has This Been Tested?
1. Create new course and assessments
2. Check that they appear in the file manager
3. Click download tar and check that you can un-tar the file after it is downloaded
4. Upload the tar file and check that you can extract the contents of the tar file
5. Check that you can view permission bits of a file, try changing one of the permission bits and check that the permission bits are as you expect

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have run rubocop and erblint for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://docs.autolabproject.com/)
- [ ] I have updated the documentation accordingly, included in this PR

If unsure, feel free to submit first and we'll help you along.
