### PR TITLE
feat: add null check to github calls to prevent unwanted round-trips

### DIFF
--- a/app/models/github_integration.rb
+++ b/app/models/github_integration.rb
@@ -163,6 +163,9 @@ class GithubIntegration < ApplicationRecord
   ##
   # Returns whether Autolab is connected to Github
   def self.connected
+    return false if Rails.configuration.x.github.client_id.blank? or
+                     Rails.configuration.x.github.client_secret.blank?
+
     check_github_authorization.limit > 1000
   end
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
an investigation of the insanely high loading times on many pages showed that Rails spents an unreasonable amount of time
making round-trip calls to github (for the context of submitting assignments through github integration)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
load times on the "submit assignment" page is drastically lower (often ~80ms faster at least, but many cases much faster)
other pages benefit from this simple fix too

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have run rubocop and erblint for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://docs.autolabproject.com/)
- [x] I have updated the documentation accordingly, included in this PR

## Other issues / help required
<!--- Do you have any other relevant issues / questions? --->
<!--- For example, if you require assistance for a certain part of your PR --->
<!--- or are facing specific issues while creating the pull request that you would like to highlight --->

If unsure, feel free to submit first and we'll help you along.
