### PR TITLE
Manage submissions speed

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -44,7 +44,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -58,7 +58,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v3
+      uses: github/codeql-action/autobuild@v4
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -71,4 +71,4 @@ jobs:
     #   ./location_of_script_within_repo/buildscript.sh
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@v4

--- a/app/assets/javascripts/manage_submissions.js
+++ b/app/assets/javascripts/manage_submissions.js
@@ -11,7 +11,10 @@ const buttonIDs = ['#regrade-selected', '#delete-selected', '#download-selected'
 let tweaks = [];
 let currentPage = 0;
 $(document).ready(function() {
-  var submission_info = {}
+  var submission_info = {};
+  var selectedStudentCids = [];
+  var selectedSubmissions = [];
+  var submissions_to_cud = {}; // Build dynamically from server data
   const EditTweakButton = (totalSum) => {
     if (totalSum == null) {
       return `
@@ -70,7 +73,7 @@ $(document).ready(function() {
   $(document).ready(function () {
     $('.modal').modal();
 
-    $('.score-details').on('click', function () {
+    $(document).on('click', '.score-details', function () {
       // Get the email
       const course_user_datum_id = $(this).data('cuid');
       const email = $(this).data('email');
@@ -105,9 +108,9 @@ $(document).ready(function() {
         tweaks = [];
 
         const submissions_body = data.submissions.map((submission) => {
-          const Tweak = new AutolabComponent(`tweak-value-${submission.id}`, { amount: null });
+          const Tweak = new AutolabComponent(`tweak-value-${submission.id}`, {amount: null});
           Tweak.template = function () {
-            return EditTweakButton( this.state.amount );
+            return EditTweakButton(this.state.amount);
           }
           tweaks.push({tweak: Tweak, submission_id: submission.id, submission});
 
@@ -118,10 +121,10 @@ $(document).ready(function() {
 
           // Convert to human readable date with timezone
           const human_readable_created_at =
-                moment(submission.created_at).format('MMM Do YY, h:mma z UTC Z');
+              moment(submission.created_at).format('MMM Do YY, h:mma z UTC Z');
 
           const view_button = submission.filename ?
-                `<div class="submissions-center-icons">
+              `<div class="submissions-center-icons">
                     <a href="submissions/${submission.id}/view"
                       title="View the file for this submission"
                       class="btn small">
@@ -129,10 +132,10 @@ $(document).ready(function() {
                     </a>
                     <p>View Source</p>
                   </div>`
-                  : "None";
+              : "None";
 
           const download_button =
-                  /text/.test(submission.detected_mime_type) ?
+              /text/.test(submission.detected_mime_type) ?
                   `<div class="submissions-center-icons">
                       <a href="submissions/${submission.id}/download?forceMime=text/plain"
                         title="Download as text/plain"
@@ -160,16 +163,15 @@ $(document).ready(function() {
                 <td class="submissions-td">
                   ${submission.total}
                 </td>
-                ${submission.problems.
-                    map((problem) =>
-                        `<td class="submissions-td">
+                ${submission.problems.map((problem) =>
+              `<td class="submissions-td">
                         ${data.scores[submission.id]?.[problem.id]?.['score'] !== undefined
-                          ? `<a href="viewFeedback?submission_id=${submission.id}&feedback=${problem.id}">
+                  ? `<a href="viewFeedback?submission_id=${submission.id}&feedback=${problem.id}">
                         ${data.scores[submission.id][problem.id]['score'].toFixed(1)}
                      </a>`
-                        : "-"}
+                  : "-"}
                     </td>`
-                    ).join('')}
+          ).join('')}
                 <td class="submissions-td">
                   ${submission.late_penalty}
                 </td>
@@ -185,7 +187,7 @@ $(document).ready(function() {
         }).join('');
 
         const submissions_table =
-          ` <p>Click on non-autograded problem scores to edit or leave a comment. </p>
+            ` <p>Click on non-autograded problem scores to edit or leave a comment. </p>
             <table class="prettyBorder" id="score-details-table">
               <thead>
                 <tr>
@@ -211,10 +213,10 @@ $(document).ready(function() {
           "order": [[0, "desc"]],
           "paging": false,
           "info": false,
-          "searching": false,});
+          "searching": false,
+        });
 
         return data.submissions;
-
       }).then((submissions) => {
         $('.tweak-button').on('click', selectTweak(submissions));
       }).catch((err) => {
@@ -229,47 +231,93 @@ $(document).ready(function() {
       });
     });
 
-    var selectedStudentCids = [];
-    var selectedSubmissions = [];
-
+    // Initialize DataTable with server-side processing
     var table = $('#submissions').DataTable({
-      'dom': 'f<"selected-buttons">rtip', // show buttons, search, table
-      'paging': true,
-      'createdRow': completeRow,
-      'sPaginationType': 'full_numbers',
-      'pageLength': 100,
-      'info': true,
-      'deferRender': true,
+      dom: 'f<"selected-buttons">rtip',
+      processing: true,
+      serverSide: true,
+      ajax: {
+        url: window.location.pathname + '.json',
+        type: 'GET',
+        dataSrc: function (json) {
+          json.data.forEach(row => {
+            submissions_to_cud[row[7]] = row[8];
+          });
+          return json.data;
+        },
+        error: function (xhr, error, code) {
+          console.error('DataTables error:', error, code);
+        }
+      },
+      columns: [
+        {
+          data: null, orderable: false, className: 'submissions-td submissions-checkbox',
+          render: function (data, type, row, meta) {
+            return `<div><label class="submissions-cbox-label"><input class="cbox" type="checkbox" id="cbox-${row[7]}"><span></span></label></div>`;
+          }
+        },
+        {
+          data: 1, className: 'submissions-td',
+          render: function (data, type, row, meta) {
+            var excusedLabel = data.excused ? '<a class="submissions-excused-label" title="Click to unexcuse this student">EXCUSED</a>' : '';
+            return `<div class="submissions-name">${data.name || ''}${excusedLabel}</div>${data.email}`;
+          }
+        },
+        {data: 2, className: 'submissions-td'},
+        {
+          data: 3, className: 'submissions-td',
+          render: function (data, type, row, meta) {
+            var score = data.score != null ? data.score : '-';
+            return `<div class="submissions-score-align"><div class="score-num">${score}</div><div class="score-icon"><a class="modal-trigger score-details" data-email="${data.email}" data-cuid="${data.cud_id}"><i class="material-icons submissions-score-icon">zoom_in</i></a></div></div>`;
+          }
+        },
+        {data: 4, className: 'submissions-td', render: d => `<span class="moment-date-time">${d}</span>`},
+        {
+          data: 5,
+          orderable: false,
+          className: 'submissions-td',
+          render: d => d.has_file ? `<div class="submissions-center-icons"><a href="submissions/${d.submission_id}/view" title="View the file for this submission" class="btn small"><i class='material-icons'>zoom_in</i></a><p>View File</p></div>` : 'None'
+        },
+        {
+          data: 6, orderable: false, className: 'submissions-td exclude-click', render: function (data, row) {
+            var regradeBtn = data.is_autograded ? `<div class="submissions-center-icons"><a href="regradeBatch?submission_ids[]=${data.submission_id}" data-method="post" title="Regrade this submission" class="btn small"><i class='material-icons'>autorenew</i></a><p>Regrade</p></div>` : '';
+            return `${regradeBtn}<div class="submissions-center-icons"><a href="submissions/${data.submission_id}/destroyConfirm" title="Destroy this submission forever" class="btn small"><i class='material-icons'>delete_outline</i></a><p>Delete</p></div>`;
+          }
+        },
+        {data: 7, visible: false},
+        {data: 8, visible: false}
+      ],
+      pageLength: 100,
+      lengthMenu: [[25, 50, 100, 200], [25, 50, 100, 200]],
+      order: [[4, 'desc']],
+      createdRow: function (row, data) {
+        var submissionId = data[7];
+        $(row).attr('id', 'row-' + submissionId).attr('data-submission-id', submissionId).addClass('submission-row');
+      },
+      drawCallback: function () {
+        $('#submissions tbody .cbox').each(function () {
+          var submissionId = parseInt($(this).attr('id').replace('cbox-', ''), 10);
+          $(this).prop('checked', selectedSubmissions.includes(submissionId));
+          if (selectedSubmissions.includes(submissionId)) $(this).closest('tr').addClass('selected');
+        });
+        updateSelectAllCheckbox();
+      }
     });
 
-    // Check if the table is empty
-    if (table.data().count() === 0) {
-      $('#submissions').closest('.dataTables_wrapper').hide(); // Hide the table and its controls
-      $('#no-data-message').show(); // Optionally show a custom message
-    } else {
-      $('#no-data-message').hide(); // Hide custom message when there is data
-    }
-
-    function completeRow(row, data, index) {
-      var submission = additional_data[index];
-      $(row).attr('data-submission-id', submission['submission-id']);
-    }
-
-    $('thead').on('click', function(e) {
-      if (currentPage < 0) {
-        currentPage = 0
-      }
-      if (currentPage > table.page.info().pages) {
-        currentPage = table.page.info().pages - 1
-      }
-      table.page(currentPage).draw(false);
-    })
 
     // Listen for select-all checkbox click
     $('#cbox-select-all').on('click', async function(e) {
       var selectAll = $(this).is(':checked');
       await toggleAllRows(selectAll);
     });
+
+    function updateSelectAllCheckbox() {
+      var allChecked = true, anyChecked = false;
+      $('#submissions tbody .cbox').each(function () {
+        if ($(this).prop('checked')) anyChecked = true; else allChecked = false;
+      });
+      $('#cbox-select-all').prop('checked', allChecked && anyChecked);
+    }
 
     // Function to toggle all checkboxes
     function toggleAllRows(selectAll) {
@@ -297,21 +345,17 @@ $(document).ready(function() {
     var downloadHTML = $('#download-batch-html').html();
     var excuseHTML = $('#excuse-batch-html').html();
     $('div.selected-buttons').html(`<div id='selected-buttons'>${regradeHTML}${deleteHTML}${downloadHTML}${excuseHTML}</div>`);
-
-    // add ids to each selected button
     $('#selected-buttons > a').each(function () {
       let idText = this.title.split(' ')[0].toLowerCase() + '-selected';
       this.setAttribute('id', idText);
     });
-
     if (!is_autograded) {
       $('#regrade-selected').hide();
       $('#regrade-all-html').hide();
     }
 
-    // base URLs for selected buttons
     var baseURLs = {};
-    buttonIDs.forEach(function(id) {
+    buttonIDs.forEach(function (id) {
       baseURLs[id] = $(id).prop('href');
     });
 
@@ -374,7 +418,6 @@ $(document).ready(function() {
         }
       });
     });
-
     function changeButtonStates(state) {
       buttonIDs.forEach((id) => {
         const button = $(id);
@@ -396,14 +439,13 @@ $(document).ready(function() {
             return;
           }
           $(document).off("click", id).on("click", id, function (event) {
-            console.log(`${id} button clicked`);
             event.preventDefault();
             if (selectedSubmissions.length === 0) {
               alert("No submissions selected.");
               return;
             }
             const endpoint = manage_submissions_endpoints[id.replace("#", "")];
-            const requestData = { submission_ids: selectedSubmissions };
+            const requestData = {submission_ids: selectedSubmissions};
             if (id === "#delete-selected") {
               if (!confirm("Deleting will delete all checked submissions and cannot be undone. Are you sure you want to delete these submissions?")) {
                 return;
@@ -457,6 +499,8 @@ $(document).ready(function() {
 
     // SELECTING STUDENT CHECKBOXES
     function toggleRow(submissionId, forceSelect = null) {
+      console.log('toggleRow called:', submissionId, 'forceSelect:', forceSelect);
+      console.log('selectedSubmissions before:', [...selectedSubmissions]);
       var selectedCid = submissions_to_cud[submissionId];
       const isSelected = selectedSubmissions.includes(submissionId);
       const shouldSelect = forceSelect !== null ? forceSelect : !isSelected;
@@ -489,6 +533,8 @@ $(document).ready(function() {
       $('#cbox-select-all').prop('checked', numericSelectedSubmissions.length === $('#submissions tbody .cbox').length);
       updateSelectedCount(numericSelectedSubmissions);
       changeButtonStates(disableButtons);
+      console.log('selectedSubmissions after:', [...selectedSubmissions]);
+      console.log('Checkbox state:', $('#cbox-' + submissionId).prop('checked'));
     }
 
     $('#submissions').on('click', '.exclude-click i', function (e) {

--- a/app/assets/javascripts/manage_submissions.js
+++ b/app/assets/javascripts/manage_submissions.js
@@ -108,9 +108,9 @@ $(document).ready(function() {
         tweaks = [];
 
         const submissions_body = data.submissions.map((submission) => {
-          const Tweak = new AutolabComponent(`tweak-value-${submission.id}`, {amount: null});
+          const Tweak = new AutolabComponent(`tweak-value-${submission.id}`, { amount: null });
           Tweak.template = function () {
-            return EditTweakButton(this.state.amount);
+            return EditTweakButton( this.state.amount );
           }
           tweaks.push({tweak: Tweak, submission_id: submission.id, submission});
 
@@ -121,10 +121,10 @@ $(document).ready(function() {
 
           // Convert to human readable date with timezone
           const human_readable_created_at =
-              moment(submission.created_at).format('MMM Do YY, h:mma z UTC Z');
+                moment(submission.created_at).format('MMM Do YY, h:mma z UTC Z');
 
           const view_button = submission.filename ?
-              `<div class="submissions-center-icons">
+                `<div class="submissions-center-icons">
                     <a href="submissions/${submission.id}/view"
                       title="View the file for this submission"
                       class="btn small">
@@ -132,10 +132,10 @@ $(document).ready(function() {
                     </a>
                     <p>View Source</p>
                   </div>`
-              : "None";
+                  : "None";
 
           const download_button =
-              /text/.test(submission.detected_mime_type) ?
+                  /text/.test(submission.detected_mime_type) ?
                   `<div class="submissions-center-icons">
                       <a href="submissions/${submission.id}/download?forceMime=text/plain"
                         title="Download as text/plain"
@@ -163,15 +163,16 @@ $(document).ready(function() {
                 <td class="submissions-td">
                   ${submission.total}
                 </td>
-                ${submission.problems.map((problem) =>
-              `<td class="submissions-td">
+                ${submission.problems.
+                    map((problem) =>
+                        `<td class="submissions-td">
                         ${data.scores[submission.id]?.[problem.id]?.['score'] !== undefined
-                  ? `<a href="viewFeedback?submission_id=${submission.id}&feedback=${problem.id}">
+                          ? `<a href="viewFeedback?submission_id=${submission.id}&feedback=${problem.id}">
                         ${data.scores[submission.id][problem.id]['score'].toFixed(1)}
                      </a>`
-                  : "-"}
+                        : "-"}
                     </td>`
-          ).join('')}
+                    ).join('')}
                 <td class="submissions-td">
                   ${submission.late_penalty}
                 </td>
@@ -187,7 +188,7 @@ $(document).ready(function() {
         }).join('');
 
         const submissions_table =
-            ` <p>Click on non-autograded problem scores to edit or leave a comment. </p>
+          ` <p>Click on non-autograded problem scores to edit or leave a comment. </p>
             <table class="prettyBorder" id="score-details-table">
               <thead>
                 <tr>
@@ -213,10 +214,10 @@ $(document).ready(function() {
           "order": [[0, "desc"]],
           "paging": false,
           "info": false,
-          "searching": false,
-        });
+          "searching": false,});
 
         return data.submissions;
+
       }).then((submissions) => {
         $('.tweak-button').on('click', selectTweak(submissions));
       }).catch((err) => {
@@ -345,17 +346,21 @@ $(document).ready(function() {
     var downloadHTML = $('#download-batch-html').html();
     var excuseHTML = $('#excuse-batch-html').html();
     $('div.selected-buttons').html(`<div id='selected-buttons'>${regradeHTML}${deleteHTML}${downloadHTML}${excuseHTML}</div>`);
+
+    // add ids to each selected button
     $('#selected-buttons > a').each(function () {
       let idText = this.title.split(' ')[0].toLowerCase() + '-selected';
       this.setAttribute('id', idText);
     });
+
     if (!is_autograded) {
       $('#regrade-selected').hide();
       $('#regrade-all-html').hide();
     }
 
+    // base URLs for selected buttons
     var baseURLs = {};
-    buttonIDs.forEach(function (id) {
+    buttonIDs.forEach(function(id) {
       baseURLs[id] = $(id).prop('href');
     });
 
@@ -418,6 +423,7 @@ $(document).ready(function() {
         }
       });
     });
+
     function changeButtonStates(state) {
       buttonIDs.forEach((id) => {
         const button = $(id);
@@ -445,7 +451,7 @@ $(document).ready(function() {
               return;
             }
             const endpoint = manage_submissions_endpoints[id.replace("#", "")];
-            const requestData = {submission_ids: selectedSubmissions};
+            const requestData = { submission_ids: selectedSubmissions };
             if (id === "#delete-selected") {
               if (!confirm("Deleting will delete all checked submissions and cannot be undone. Are you sure you want to delete these submissions?")) {
                 return;
@@ -499,8 +505,6 @@ $(document).ready(function() {
 
     // SELECTING STUDENT CHECKBOXES
     function toggleRow(submissionId, forceSelect = null) {
-      console.log('toggleRow called:', submissionId, 'forceSelect:', forceSelect);
-      console.log('selectedSubmissions before:', [...selectedSubmissions]);
       var selectedCid = submissions_to_cud[submissionId];
       const isSelected = selectedSubmissions.includes(submissionId);
       const shouldSelect = forceSelect !== null ? forceSelect : !isSelected;
@@ -533,8 +537,6 @@ $(document).ready(function() {
       $('#cbox-select-all').prop('checked', numericSelectedSubmissions.length === $('#submissions tbody .cbox').length);
       updateSelectedCount(numericSelectedSubmissions);
       changeButtonStates(disableButtons);
-      console.log('selectedSubmissions after:', [...selectedSubmissions]);
-      console.log('Checkbox state:', $('#cbox-' + submissionId).prop('checked'));
     }
 
     $('#submissions').on('click', '.exclude-click i', function (e) {

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -39,7 +39,8 @@ class SubmissionsController < ApplicationController
         length = params[:length].to_i
         search_value = params.dig(:search, :value)
         order_column_index = params.dig(:order, '0', :column).to_i
-        order_direction = params.dig(:order, '0', :dir) || 'desc'
+        direction_param = params.dig(:order, '0', :dir).to_s.downcase
+        order_direction = %w[asc desc].include?(direction_param) ? direction_param : 'desc'
 
         columns_map = {
           1 => 'users.email',

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -95,6 +95,12 @@ class SubmissionsController < ApplicationController
     cud = submission.course_user_datum
     user = cud.user
     excused = @excused_cids.include?(cud.id)
+    score =
+      if submission.respond_to?(:calculated_score)
+        submission.calculated_score
+      else
+        submission.final_score(cud)
+      end
     [
       '',
       {
@@ -105,7 +111,7 @@ class SubmissionsController < ApplicationController
       },
       submission.version,
       {
-        score: computed_score { submission.final_score(@cud) },
+        score: computed_score { score },
         email: user.email,
         cud_id: cud.id
       },

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -49,35 +49,47 @@ class SubmissionsController < ApplicationController
         }
 
         order_column = columns_map[order_column_index] || 'submissions.created_at'
+
         base_query = @assessment.submissions
                                 .joins(course_user_datum: :user)
+
         if search_value.present?
           base_query = base_query.where(
             "users.email LIKE :search",
             search: "%#{search_value}%"
           )
         end
+
         total_records = @assessment.submissions.count
         filtered_records = base_query.count
-        submissions_query = base_query
-                            .includes(course_user_datum: :user)
-                            .left_joins(:scores)
-                            .select('submissions.*')
-                            .select('COALESCE(SUM(scores.score), 0) as calculated_score')
-                            .group('submissions.id')
 
-        # Apply sorting
-        submissions_query =
-          if order_column == 'calculated_score'
-            submissions_query.order("calculated_score #{order_direction}")
-          else
-            submissions_query.order("#{order_column} #{order_direction}")
+        # If sorting by score, we have to load the data into ruby b/c we don't stored
+        # final scores in our database
+        if order_column == 'calculated_score'
+          all_submissions = base_query.includes(course_user_datum: :user).to_a
+          submissions_with_scores = all_submissions.map do |submission|
+            cud = submission.course_user_datum
+            [submission, submission.final_score(cud)]
           end
-        # Apply pagination
-        submissions = submissions_query.limit(length).offset(start)
+          sorted_submissions = submissions_with_scores.sort_by { |_, score| score }
+          sorted_submissions.reverse! if order_direction == 'desc'
+          paginated_submissions = sorted_submissions[start, length] || []
 
-        data = submissions.map do |submission|
-          format_submission_for_datatable(submission)
+          data = paginated_submissions.map do |submission, score|
+            format_submission_for_datatable(submission, score)
+          end
+        else
+          submissions = base_query
+                        .includes(course_user_datum: :user)
+                        .order("#{order_column} #{order_direction}")
+                        .limit(length)
+                        .offset(start)
+
+          data = submissions.map do |submission|
+            cud = submission.course_user_datum
+            score = submission.final_score(cud)
+            format_submission_for_datatable(submission, score)
+          end
         end
 
         render json: {
@@ -91,16 +103,11 @@ class SubmissionsController < ApplicationController
   end
 
   action_auth_level :format_submission_for_datatable, :instructor
-  def format_submission_for_datatable(submission)
+  def format_submission_for_datatable(submission, score = nil)
     cud = submission.course_user_datum
     user = cud.user
     excused = @excused_cids.include?(cud.id)
-    score =
-      if submission.respond_to?(:calculated_score)
-        submission.calculated_score
-      else
-        submission.final_score(cud)
-      end
+    score ||= submission.final_score(cud)
     [
       '',
       {

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -17,29 +17,110 @@ class SubmissionsController < ApplicationController
 
   action_auth_level :index, :instructor
   def index
-    # cache ids instead of entire entries
-    submission_ids = Rails.cache.fetch(["submission_ids", @assessment.id], expires_in: 1.day) do
-      @assessment.submissions.order("created_at DESC").pluck(:id)
-    end
-    @submissions = Submission.where(id: submission_ids).includes({ course_user_datum: :user })
     @autograded = @assessment.has_autograder?
+    @problems = @assessment.problems.to_a
+    @excused_cids = AssessmentUserDatum
+                    .where(assessment_id: @assessment.id, grade_type: AssessmentUserDatum::EXCUSED)
+                    .pluck(:course_user_datum_id)
 
-    @submissions_to_cud =
-      Rails.cache.fetch(["submissions_to_cud", @assessment.id], expires_in: 1.day) do
-        submissions_to_cud = {}
-        @submissions.each do |submission|
-          submissions_to_cud[submission.id] = submission.course_user_datum_id
-        end
-        submissions_to_cud.to_json
+    respond_to do |format|
+      format.html do
+        @submissions = @assessment.submissions
+                                  .includes(course_user_datum: :user)
+                                  .order(created_at: :desc)
+                                  .limit(100)
+
+        @submissions_to_cud = @submissions.pluck(:id, :course_user_datum_id).to_h
       end
 
-    @excused_cids = []
-    excused_students = AssessmentUserDatum.where(
-      assessment_id: @assessment.id,
-      grade_type: AssessmentUserDatum::EXCUSED
-    )
-    @excused_cids = excused_students.pluck(:course_user_datum_id)
-    @problems = @assessment.problems.to_a
+      format.json do
+        draw = params[:draw].to_i
+        start = params[:start].to_i
+        length = params[:length].to_i
+        search_value = params.dig(:search, :value)
+        order_column_index = params.dig(:order, '0', :column).to_i
+        order_direction = params.dig(:order, '0', :dir) || 'desc'
+
+        columns_map = {
+          1 => 'users.email',
+          2 => 'submissions.version',
+          3 => 'calculated_score',
+          4 => 'submissions.created_at',
+        }
+
+        order_column = columns_map[order_column_index] || 'submissions.created_at'
+        base_query = @assessment.submissions
+                                .joins(course_user_datum: :user)
+        if search_value.present?
+          base_query = base_query.where(
+            "users.email LIKE :search",
+            search: "%#{search_value}%"
+          )
+        end
+        total_records = @assessment.submissions.count
+        filtered_records = base_query.count
+        submissions_query = base_query
+                            .includes(course_user_datum: :user)
+                            .left_joins(:scores)
+                            .select('submissions.*')
+                            .select('COALESCE(SUM(scores.score), 0) as calculated_score')
+                            .group('submissions.id')
+
+        # Apply sorting
+        submissions_query =
+          if order_column == 'calculated_score'
+            submissions_query.order("calculated_score #{order_direction}")
+          else
+            submissions_query.order("#{order_column} #{order_direction}")
+          end
+        # Apply pagination
+        submissions = submissions_query.limit(length).offset(start)
+
+        data = submissions.map do |submission|
+          format_submission_for_datatable(submission)
+        end
+
+        render json: {
+          draw:,
+          recordsTotal: total_records,
+          recordsFiltered: filtered_records,
+          data:,
+        }
+      end
+    end
+  end
+
+  action_auth_level :format_submission_for_datatable, :instructor
+  def format_submission_for_datatable(submission)
+    cud = submission.course_user_datum
+    user = cud.user
+    excused = @excused_cids.include?(cud.id)
+    [
+      '',
+      {
+        name: [user.first_name, user.last_name].reject(&:blank?).join(' '),
+        email: user.email,
+        excused:,
+        cud_id: cud.id
+      },
+      submission.version,
+      {
+        score: computed_score { submission.final_score(@cud) },
+        email: user.email,
+        cud_id: cud.id
+      },
+      submission.created_at.in_time_zone.to_s,
+      {
+        has_file: submission.filename.present?,
+        submission_id: submission.id
+      },
+      {
+        submission_id: submission.id,
+        is_autograded: @autograded
+      },
+      submission.id,
+      cud.id
+    ]
   end
 
   action_auth_level :score_details, :instructor

--- a/app/views/submissions/index.html.erb
+++ b/app/views/submissions/index.html.erb
@@ -10,8 +10,6 @@
 <script>
   var is_autograded = <%= @autograded %>;
   var excused_cids = <%= @excused_cids %>;
-  var submissions_to_cud = <%= @submissions_to_cud.html_safe %>;
-
   // additional data for each row
   additional_data = [
       <% for s in @submissions do %>
@@ -59,7 +57,7 @@
                 new_course_assessment_submission_path(@course, @assessment),
                 { title: "Create a new submission for a student, with an option to submit a handin file on their behalf",
                   class: "btn submissions-main" } %>
-    </div>
+  </div>
 
   <div class="buttons-spacing">
     <%= link_to "<i class='material-icons left submissions-icons'>file_download</i>Download Final Submissions".html_safe,
@@ -118,146 +116,34 @@
   </div>
 </div>
 
-<div class="selected-count-placeholder" style="display: none;">
-  <span id="selected-count-html">0 submissions selected</span>
-  <span>
-    Click
-    <a href="#" id="regrade-all-trigger" class="selected-count-red" title="Regrade all submissions">
-      Regrade All
-    </a>
-    to regrade all <%= @submissions.latest.length %> latest submissions.
-  </span>
-</div>
-
 <table class="prettyBorder" id="submissions">
-  <% headers = ["Submitted By",
-                "Version",
-                "Score",
-                "Submission Date",
-                "File",
-                "Actions"] %>
+  <% headers = ["Submitted By", "Version", "Score", "Submission Date", "File", "Actions"] %>
   <thead class="float">
-    <tr>
-      <%# Select all checkbox in header row %>
-      <th class="submissions-td submissions-checkbox">
+  <tr>
+    <th class="submissions-td submissions-checkbox">
+      <div>
+        <label class="submissions-cbox-label">
+          <input class="cbox" type="checkbox" id="cbox-select-all">
+          <span></span>
+        </label>
+      </div>
+    </th>
+    <% headers.each do |header| %>
+      <th class="submissions-th sorting">
         <div>
-          <label class="submissions-cbox-label">
-            <input class="cbox" type="checkbox" id="cbox-select-all">
-            <span></span>
-          </label>
-        </div>
-      </th>
-      <%# Table headers %>
-      <% for header in headers %>
-        <th class="submissions-th sorting">
-          <div>
-            <p><%= header %></p>
-            <% if header != "File" && header != "Actions" then %>
-              <i class="material-icons tiny sort-icon sort-icon__both" aria-hidden="true">swap_vert</i>
-              <i class="material-icons tiny sort-icon sort-icon__up" aria-hidden="true">arrow_upward</i>
-              <i class="material-icons tiny sort-icon sort-icon__down" aria-hidden="true">arrow_downward</i>
-            <% end %>
-          </div>
-        </th>
-      <% end %>
-    </tr>
-  </thead>
-
-  <tbody id="submissions_table">
-  <div id="no-data-message" style="display: none;">No submissions available.</div>
-
-  <% for submission in @submissions %>
-    <tr id="row-<%= submission.id %>" class="submission-row">
-
-      <%# Checkbox %>
-      <td class="submissions-td submissions-checkbox">
-        <div>
-          <label class="submissions-cbox-label">
-            <input class="cbox" type="checkbox" id="cbox-<%= submission.id %>">
-            <span></span>
-          </label>
-        </div>
-      </td>
-
-      <%# Submitted By %>
-      <td class="submissions-td">
-        <div class="submissions-name">
-          <%= [submission.course_user_datum.first_name, submission.course_user_datum.last_name].reject(&:blank?).join(' ') %>
-          <% if @excused_cids.include? submission.course_user_datum_id %>
-            <a class="submissions-excused-label" title="Click to unexcuse this student">EXCUSED</a>
-            <div class="excused-popover">
-              <div class="excused-arrow"></div>
-            </div>
+          <p><%= header %></p>
+          <% unless ["File", "Actions"].include?(header) %>
+            <i class="material-icons tiny sort-icon sort-icon__both">swap_vert</i>
+            <i class="material-icons tiny sort-icon sort-icon__up">arrow_upward</i>
+            <i class="material-icons tiny sort-icon sort-icon__down">arrow_downward</i>
           <% end %>
         </div>
-        <%= submission.course_user_datum.email %>
-      </td>
-
-      <%# Version %>
-      <td class="submissions-td" style="<%= ignored_submission_style submission %>">
-        <%= submission.version %>
-      </td>
-
-      <%# Score %>
-      <td class="submissions-td">
-        <div class="submissions-score-align">
-          <div class="score-num"><%= computed_score { submission.final_score(@cud) } %></div>
-          <div class="score-icon">
-            <a class="modal-trigger score-details"
-              data-email="<%= submission.course_user_datum.email %>"
-              data-cuid=" <%= submission.course_user_datum.id %>">
-              <i class="material-icons submissions-score-icon">zoom_in</i>
-            </a>
-            </div>
-        </div>
-      </td>
-
-      <%# Submission Date %>
-      <td class="submissions-td">
-        <span class="moment-date-time">
-          <%= submission.created_at.in_time_zone.to_s %>
-        </span>
-      </td>
-
-      <%# File %>
-      <td class="submissions-td" style="<%= ignored_submission_style submission %>">
-        <% if submission.filename then %>
-          <div class="submissions-center-icons">
-            <%= link_to "<i class='material-icons'>zoom_in</i>".html_safe,
-                        view_course_assessment_submission_url(@course, @assessment, submission),
-                        { title: "View the file for this submission",
-                          class: "btn small" } %>
-            <p>View File</p>
-          </div>
-        <% else %>
-          None
-        <% end %>
-      </td>
-
-      <%# Actions %>
-      <td class="submissions-td" class="exclude-click">
-        <% if @autograded then %>
-          <div class="submissions-center-icons">
-            <div id="regrade-batch-html">
-              <%= link_to "<i class='material-icons'>autorenew</i>".html_safe,
-                          regradeBatch_course_assessment_path(@course, @assessment, { submission_ids: [submission.id] }),
-                          { method: :post,
-                            title: "Regrade selected submissions",
-                            class: "btn small" } %>
-            </div>
-            <p>Regrade</p>
-          </div>
-        <% end %>
-        <div class="submissions-center-icons">
-          <%= link_to "<i class='material-icons i-no-margin'>delete_outline</i>".html_safe,
-                      destroyConfirm_course_assessment_submission_path(@course, @assessment, submission),
-                      { title: "Destroy this submission forever",
-                        class: "btn small" } %>
-          <p>Delete</p>
-        </div>
-      </td>
-    </tr>
-  <% end %>
+      </th>
+    <% end %>
+  </tr>
+  </thead>
+  <tbody id="submissions_table">
+  <!-- Rows will be populated by DataTables -->
   </tbody>
 </table>
 

--- a/app/views/submissions/index.html.erb
+++ b/app/views/submissions/index.html.erb
@@ -57,7 +57,7 @@
                 new_course_assessment_submission_path(@course, @assessment),
                 { title: "Create a new submission for a student, with an option to submit a handin file on their behalf",
                   class: "btn submissions-main" } %>
-  </div>
+    </div>
 
   <div class="buttons-spacing">
     <%= link_to "<i class='material-icons left submissions-icons'>file_download</i>Download Final Submissions".html_safe,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This changes implements server-side pagination for the manage submissions page to improve loading times.

## Motivation and Context
Previously, it would take about 1.5 seconds for each page of the manage submissions page to load since we would render all of them at once. For example, for a submissions page with 400 submissions, it would take about 6 seconds. This change renders only one page at a time, to take a maximum of 1.5 seconds each time. 

## How Has This Been Tested?
Tested all of the manage submissions functions locally

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have run rubocop and erblint for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://docs.autolabproject.com/)
- [ ] I have updated the documentation accordingly, included in this PR

