### PR TITLE
Fix NoMethodError in lti_launch_link_course action

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,8 +2,7 @@ class UsersController < ApplicationController
   skip_before_action :set_course
   skip_before_action :authorize_user_for_course
   skip_before_action :authenticate_for_action,
-                     except: [:change_password_for_user, :update_password_for_user,
-                              :lti_launch_link_course]
+                     except: [:change_password_for_user, :update_password_for_user]
   skip_before_action :update_persistent_announcements
   before_action :set_gh_oauth_client, only: [:github_oauth, :github_oauth_callback]
   before_action :set_user,
@@ -330,15 +329,22 @@ class UsersController < ApplicationController
                                               :bad_request)
     end
 
+    # Verify user is instructor for the target course (security check)
+    course = Course.find(params[:course_id])
+    cud = CourseUserDatum.find_cud_for_course(course, current_user.id)
+    unless cud&.has_auth_level?(:instructor)
+      flash[:error] = "Permission denied: you must be an instructor for this course."
+      redirect_to(root_path) && return
+    end
+
     LtiCourseDatum.create(
-      course_id: params[:course_id],
+      course_id: course.id,
       context_id: params[:context_id],
       membership_url: params[:course_memberships_url],
       platform: params[:platform],
       last_synced: DateTime.current
     )
 
-    course = Course.find(params[:course_id])
     flash[:success] = "#{course.name} successfully linked."
     redirect_to(course)
   end


### PR DESCRIPTION
**Title:** Fix NoMethodError in lti_launch_link_course when linking LTI course

**Description:**

The lti_launch_link_course action was incorrectly included in the authenticate_for_action exception list, causing authenticate_for_action to run. However, since UsersController skips both set_course and authorize_user_for_course, the @cud instance variable is never set, resulting in 'undefined method has_auth_level? for nil:NilClass'.

This fix:
1. Removes lti_launch_link_course from the authenticate_for_action exception list (so it gets skipped like other actions)
2. Adds inline authorization check within the action to verify the current user is an instructor for the target course

This maintains security while fixing the nil reference error.

## Description
When users attempt to link a Canvas course via LTI at `/users/:id/lti_launch_link_course`, a 500 Internal Server Error occurs because `@cud.has_auth_level?(:instructor)` is called on a nil object in `authenticate_for_action`.

## Motivation and Context
LTI course linking is completely broken in the current codebase. Any user attempting to link a Canvas course to Autolab encounters this crash, preventing LTI integration from working.

## How Has This Been Tested?
- Tested on production Autolab instance (v2.x) with Canvas LTI 1.3 integration
- Verified course linking completes successfully after fix
- Verified the linked course appears in LtiCourseDatum table
- Non-instructor denial logic is in place but not explicitly tested in production

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have run rubocop and erblint for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://docs.autolabproject.com/)
- [ ] I have updated the documentation accordingly, included in this PR

## Other details

This bug was introduced in commit 301689ab5 (October 24, 2024) which added lti_launch_link_course to the authenticate_for_action exception list. This change was part of a PR to add admin checks for password-related actions, but lti_launch_link_course, it seems, was incorrectly included.
