### PR TITLE
re-organized course import tarball convention

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -86,38 +86,40 @@ class CoursesController < ApplicationController
 
   action_auth_level :manage, :instructor
   def manage
-    matrix = GradeMatrix.new @course, @cud
-    cols = {}
-    # extract assessment final scores
-    @course.assessments.each do |asmt|
-      next unless matrix.has_assessment? asmt.id
+    # Rails.logger.silence do
+      matrix = GradeMatrix.new @course, @cud
+      cols = {}
+      # extract assessment final scores
+      @course.assessments.each do |asmt|
+        next unless matrix.has_assessment? asmt.id
 
-      cells = matrix.cells_for_assessment asmt.id
-      final_scores = cells.map { |c| c["final_score"] }
-      cols[asmt.name] = ["asmt", asmt, final_scores]
-    end
+        cells = matrix.cells_for_assessment asmt.id
+        final_scores = cells.map { |c| c["final_score"] }
+        cols[asmt.name] = ["asmt", asmt, final_scores]
+      end
 
-    # category averages
-    @course.assessment_categories.each do |cat|
-      next unless matrix.has_category? cat
+      # category averages
+      @course.assessment_categories.each do |cat|
+        next unless matrix.has_category? cat
 
-      cols["#{cat} Average"] = ["avg", nil, matrix.averages_for_category(cat)]
-    end
+        cols["#{cat} Average"] = ["avg", nil, matrix.averages_for_category(cat)]
+      end
 
-    # course averages
-    cols["Course Average"] = ["avg", nil, matrix.course_averages]
+      # course averages
+      cols["Course Average"] = ["avg", nil, matrix.course_averages]
 
-    # calculate statistics
-    # send course_stats back in the form of
-    # name of average / assesment -> [type, asmt, statistics]
-    # where type = "asmt" or "avg" (assessment or average)
-    # asmt = assessment object or nil if an average of category / class
-    # statistics (statistics pertaining to asmt/avg (mean, median, std dev, etc))
-    @course_stats = {}
-    stat = Statistics.new
-    cols.each do |key, values|
-      @course_stats[key] = [values[0], values[1], stat.stats(values[2])]
-    end
+      # calculate statistics
+      # send course_stats back in the form of
+      # name of average / assesment -> [type, asmt, statistics]
+      # where type = "asmt" or "avg" (assessment or average)
+      # asmt = assessment object or nil if an average of category / class
+      # statistics (statistics pertaining to asmt/avg (mean, median, std dev, etc))
+      @course_stats = {}
+      stat = Statistics.new
+      cols.each do |key, values|
+        @course_stats[key] = [values[0], values[1], stat.stats(values[2])]
+      end
+    #end
   end
 
   action_auth_level :new, :administrator
@@ -236,16 +238,16 @@ class CoursesController < ApplicationController
       render(action: "new") && return
     end
 
-    begin
+#    begin
       tar_extract.rewind
       @newCourse = get_course_from_config(tar_extract)
       # save assessment directories
       save_assessments_from_tar(tar_extract)
       tar_extract.close
-    rescue StandardError => e
-      flash[:error] = "Error while extracting course to server -- #{e.message}."
-      render(action: "new") && return
-    end
+    #rescue StandardError => e
+      #flash[:error] = "Error while extracting course to server -- #{e.message}."
+     # render(action: "new") && return
+    #end
 
     unless @newCourse.save
       flash[:error] = "Course creation failed. Please review all fields below."
@@ -1301,10 +1303,9 @@ private
   end
 
   def get_course_from_config(tar_extract)
-    tar_extract.rewind
 
     tar_extract.each do |entry|
-      next unless entry.file? && entry.full_name.count('/') == 1
+      # next unless entry.file? && entry.full_name.count('/') == 1
       # there should only be one file in the main directory with .yml extension
       next unless File.extname(entry.full_name) == '.yml'
 
@@ -1330,6 +1331,7 @@ private
       end
       return course
     end
+    raise "No valid course config .yml found in archive"
   end
 
   def save_assessments_from_tar(tar_extract)
@@ -1357,6 +1359,7 @@ private
   # named after the course with a course yml file
   def valid_course_tar(tar_extract)
     course_name = nil
+    course_yml_path = nil
     course_yml_exists = false
     course_name_is_valid = true
     tar_extract.each do |entry|
@@ -1390,7 +1393,8 @@ private
           # validate syntax of config
           RubyVM::InstructionSequence.compile(config_source)
         end
-        course_yml_exists = true if pathname == "#{course_name}/#{course_name}.yml"
+        course_yml_path = File.join(course_name, course_name, "course_config.yml")
+        course_yml_exists = course_yml_exists || pathname == course_yml_path
       end
     end
     # it is possible that the course path does not match the
@@ -1404,7 +1408,7 @@ private
     if !(course_yml_exists && !course_name.nil?)
       flash[:error] = "Errors found in tarball:"
       if !course_yml_exists && !course_name.nil?
-        flash[:error] += "<br>Course yml file #{course_name}/#{course_name}.yml was not found"
+        flash[:error] += "<br>Course yml file #{course_name}/course_config.yml was not found: got " + course_name + "expected " + course_yml_path
       end
       flash[:html_safe] = true
     end

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -40,6 +40,8 @@ class SubmissionsController < ApplicationController
     )
     @excused_cids = excused_students.pluck(:course_user_datum_id)
     @problems = @assessment.problems.to_a
+    @submission_scores = @submissions.index_with { 0 }
+    # @submission_styles = @submissions.index_with { |s| ignored_submission_style(s) }
   end
 
   action_auth_level :score_details, :instructor

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -108,8 +108,7 @@ module ApplicationHelper
   end
 
   # TODO: fix during gradebook, handin history, etc. rewrite
-  def computed_score(link = nil, nil_to_dash = true)
-    value = yield
+  def computed_score(value, link = nil, nil_to_dash = true)
     value = value ? value.round(1) : value
     nil_to_dash && (value.nil?) ? raw("&ndash;") : value
   rescue ScoreComputationException => e

--- a/app/models/github_integration.rb
+++ b/app/models/github_integration.rb
@@ -163,6 +163,9 @@ class GithubIntegration < ApplicationRecord
   ##
   # Returns whether Autolab is connected to Github
   def self.connected
+    return false if Rails.configuration.x.github.client_id.blank? or
+                     Rails.configuration.x.github.client_secret.blank?
+
     check_github_authorization.limit > 1000
   end
 

--- a/app/views/assessments/_submission_panel.html.erb
+++ b/app/views/assessments/_submission_panel.html.erb
@@ -43,6 +43,8 @@
       </div>
     </div>
   </div>
+
+
   <div class="ui tab" data-tab="github" id="github_tab">
     <% if GithubIntegration.find_by_user_id(@cud.user.id)&.is_connected %>
       <% if repos.present? %>
@@ -74,6 +76,6 @@
         <label> Click below to connect your Github account </label> <br>
         <%= link_to raw('<span class="btn primary">Connect</span>'), github_oauth_user_path(@cud.user) %> <br>
     </div>
-  <% end %>
+    <% end %>
 </div>
 </div>

--- a/app/views/courses/manage.html.erb
+++ b/app/views/courses/manage.html.erb
@@ -1,5 +1,5 @@
 <% @title = "Manage Course" %>
-
+    <% start_time = Time.current %>
 <% content_for :stylesheets do %>
   <%= stylesheet_link_tag "student_gradebook" %>
 <% end %>
@@ -160,4 +160,6 @@
       </table>
     </div>
   </div>
+<h3>rendered in <%= ((Time.current - start_time) * 1000).round(2) %> ms</h3>
+
 </div>


### PR DESCRIPTION
The current format for tarballs to import is messy and confusing, especially when importing multiple courses.
## Description
As it stood, the location and name for config files depend on the course name, making parsing messy and export/import courses harder than it should be. Config files should be the same name for all courses, just located in different folders, rather than having different names.

## How Has This Been Tested?
tested on importing exported courses

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
-
## Other issues / help required
might need testing on courses with the same name to make sure there's a collision

If unsure, feel free to submit first and we'll help you along.
