### PR TITLE
Fix duplicate file naming for "Download All" submissions

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -215,10 +215,10 @@ class UsersController < ApplicationController
 
         # Find unique file name for assignment to be saved as
         final_entry_path = File.join(assignment_directory, original_entry_name)
-        # If file name duplicate exists, add "_ver#" suffix
-        version_counter = 1
+        # If file name duplicate exists, add "_#" suffix
+        version_counter = 2
         while used_paths.include?(final_entry_path)
-          new_entry_name = "#{basename}_ver#{version_counter}#{extname}"
+          new_entry_name = "#{basename}_#{version_counter}#{extname}"
           final_entry_path = File.join(assignment_directory, new_entry_name)
           version_counter += 1
         end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -170,16 +170,20 @@ class UsersController < ApplicationController
       flash[:error] = "Permission denied: You are not allowed to download submissions of this user."
       redirect_to(user_path(current_user)) && return
     end
+
     submissions = if params[:final]
                     Submission.latest.where(course_user_datum: CourseUserDatum.where(user_id: user))
                   else
                     Submission.where(course_user_datum: CourseUserDatum.where(user_id: user))
                   end
+
+    # filter out invalid submissions
     submissions = submissions.select do |s|
       p = s.handin_file_path
       is_disabled = s.course_user_datum.course.is_disabled?
       !p.nil? && File.exist?(p) && File.readable?(p) && !is_disabled
     end
+
     if submissions.empty?
       flash[:error] = "There are no submissions to download."
       redirect_to(user_path(user)) && return
@@ -194,38 +198,34 @@ class UsersController < ApplicationController
 
     temp_file = Tempfile.new("autolab_submissions.zip")
     Zip::File.open(temp_file.path, Zip::File::CREATE) do |zipfile|
-      # track counts of each file name
-      track_duplicate_counts = Hash.new(0)
-      submissions.each do |s|
-        p = s.handin_file_path
-        course_name = s.course_user_datum.course.name
-        assignment_name = s.assessment.name
-        course_directory = "#{filename}/#{course_name}"
-        assignment_directory = "#{course_directory}/#{assignment_name}"
-        entry_name = download_filename(p, assignment_name)
-        final_path = "#{assignment_directory}/#{entry_name}"
-        track_duplicate_counts[final_path] += 1
-      end
+      # Track paths already added to zip file
+      used_paths = Set.new
 
-      # track which version is being processed (for naming purposes)
-      filename_counts = Hash.new(0)
       submissions.each do |s|
         p = s.handin_file_path
         course_name = s.course_user_datum.course.name
         assignment_name = s.assessment.name
-        course_directory = "#{filename}/#{course_name}"
-        assignment_directory = "#{course_directory}/#{assignment_name}"
-        entry_name = download_filename(p, assignment_name)
-        final_path = "#{assignment_directory}/#{entry_name}"
-        filename_counts[final_path] += 1
-        # append version number to submission if more than one of same name
-        if track_duplicate_counts[final_path] > 1
-          version_suffix = "_ver#{filename_counts[final_path]}"
-          extname = File.extname(entry_name)
-          basename = File.basename(entry_name, extname)
-          entry_name = "#{basename}#{version_suffix}#{extname}"
+
+        # Define the directory structure in zip file
+        assignment_directory = "#{filename}/#{course_name}/#{assignment_name}"
+        original_entry_name = download_filename(p, assignment_name)
+
+        extname = File.extname(original_entry_name)
+        basename = File.basename(original_entry_name, extname)
+
+        # Find unique file name for assignment to be saved as
+        final_entry_path = File.join(assignment_directory, original_entry_name)
+        # If file name duplicate exists, add "_ver#" suffix
+        version_counter = 1
+        while used_paths.include?(final_entry_path)
+          new_entry_name = "#{basename}_ver#{version_counter}#{extname}"
+          final_entry_path = File.join(assignment_directory, new_entry_name)
+          version_counter += 1
         end
-        zipfile.add(File.join(assignment_directory, entry_name), p)
+
+        # Add to zip and list of already used file names
+        used_paths.add(final_entry_path)
+        zipfile.add(final_entry_path, p)
       end
     end
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Previously, this issue came up in production, and it was addressed with a double pass here: https://github.com/autolab/Autolab/pull/2244. The idea was to check if a file name is duplicated and, if so, to append a version number to the file name to prevent issues when saving it in a zip file.

This new implementation checks this concern more safely by directly checking when saving if a rename is needed, and if so, to rename the file accordingly.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Failure in production.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This issue seems to come up for 15213's bomb and attack labs, as those labs are submitted through the terminal in "phases". Typically, Autolab will automatically append submission version numbers to the files. 
To emulate this for testing, I made "submissions" store multiple versions of the same submission to check that naming works as expected.
<img width="759" height="239" alt="Screenshot 2026-03-03 at 5 21 30 PM" src="https://github.com/user-attachments/assets/9cceffbb-b24f-4152-a5a7-553e3a9e36e0" />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)