### PR TITLE
Filter out non-ready container images in autograder settings and add …

### DIFF
--- a/app/controllers/autograders_controller.rb
+++ b/app/controllers/autograders_controller.rb
@@ -37,7 +37,8 @@ class AutogradersController < ApplicationController
     tar_path = Rails.root.join("courses", @course.name, @assessment.name, "autograde.tar")
     @makefile_exists = File.exist?(makefile_path) ? makefile_path : nil
     @tar_exists = File.exist?(tar_path) ? tar_path : nil
-    @container_images = ContainerImage.where(course: @course).or(ContainerImage.where(is_public: true))
+    @container_images = ContainerImage.ready.where(course: @course)
+                                      .or(ContainerImage.ready.where(is_public: true))
   end
 
   action_auth_level :update, :instructor

--- a/db/migrate/20260416010842_add_dockerfile_contents_to_container_images.rb
+++ b/db/migrate/20260416010842_add_dockerfile_contents_to_container_images.rb
@@ -1,0 +1,5 @@
+class AddDockerfileContentsToContainerImages < ActiveRecord::Migration[6.1]
+  def change
+    add_column :container_images, :dockerfile_contents, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2026_04_07_033729) do
+ActiveRecord::Schema.define(version: 2026_04_16_010842) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -212,6 +212,7 @@ ActiveRecord::Schema.define(version: 2026_04_07_033729) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.text "build_logs", default: "", null: false
+    t.text "dockerfile_contents"
     t.index ["course_id"], name: "index_container_images_on_course_id"
     t.index ["image_uri"], name: "index_container_images_on_image_uri", unique: true
     t.index ["is_public"], name: "index_container_images_on_is_public"


### PR DESCRIPTION
## Description
This PR addresses two specific requests for the EC2 Docker manager workflow:

1. Autograder UI Filtering: Updated `AutogradersController#edit` to only expose healthy, ready-to-use container images to instructors. Attached the `.ready` enum scope to the `@container_images` query so that images with a status of `failed` or `building` no longer clutter the settings dropdown.
2. Database Migration: Added a `dockerfile_contents` (text) column to the `container_images` table to allow storing the raw Dockerfile text directly in the database for future debugging/reference.

## Motivation and Context
This is a supporting PR for the ongoing `somanarita-ec2docker-manager` feature branch. It improves the instructor UX by preventing them from accidentally selecting broken or incomplete Docker images, and sets up the schema necessary for saving Dockerfile payloads.

## How Has This Been Tested?
Tested locally on a development environment:

1. Seeded the local database with dummy `ContainerImage` records mapping to different enum statuses (`ready`, `failed`, `building`).
2. Navigated to an assessment's "Edit Autograder" page as an instructor.
3. Verified that only the images with the `ready` status appeared in the dropdown menu.
4. Verified the database migration successfully applied and rolled back cleanly.

## Types of changes
[ ] Bug fix (non-breaking change which fixes an issue)

[x] New feature (non-breaking change which adds functionality)

[ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
[x] I have run rubocop and erblint for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting

[ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://docs.autolabproject.com/)

[ ] I have updated the documentation accordingly, included in this PR

## Other issues / help required
None!