### PR TITLE
Fixed polling issue with ECR builder

### DIFF
--- a/app/controllers/admin/container_images_controller.rb
+++ b/app/controllers/admin/container_images_controller.rb
@@ -46,7 +46,8 @@ module Admin
           )
           if @container_image.update(resp)
             flash[:success] = "Successfully started docker image build process"
-            redirect_to admin_container_images_path, notice: "Container image was successfully created."
+            redirect_to admin_container_images_path,
+                        notice: "Container image was successfully created."
             return
           else
             flash[:error] = "Successfully started docker image build process, failed to write to DB"
@@ -96,7 +97,7 @@ module Admin
         updated_status = resp["status"]
         @container_image.update!(
           status: updated_status,
-          build_logs: @container_image.build_logs.to_s + resp["logs"]
+          build_logs: resp["logs"].join
         )
         if updated_status == 2
           @container_image.update!(image_uri: resp["image_uri"])
@@ -126,33 +127,31 @@ module Admin
     end
 
     def refresh_images;
-      begin
-        updated_images = TangoClient.all_build_status
-        public_images = ContainerImage.where(is_public: true)
-        public_images.transaction do
-          public_images.each do |image|
-            next if image.status == "ready" || image.status == "failed"
+      updated_images = TangoClient.all_build_status
+      public_images = ContainerImage.where(is_public: true)
+      public_images.transaction do
+        public_images.each do |image|
+          next if image.status == "ready" || image.status == "failed"
 
-            updated_image = updated_images[image.id.to_s]
-            if updated_image.nil?
-              image.update!(status: "failed")
-            else
-              updated_status = updated_image["statusId"]
-              image.update!(
-                status: updated_status,
-                build_logs: image.build_logs.to_s + updated_image["logs"].join
-              )
-              if updated_status == 2
-                image.update!(image_uri: updated_image["ecrImageUri"])
-              end
+          updated_image = updated_images[image.id.to_s]
+          if updated_image.nil?
+            image.update!(status: "failed")
+          else
+            updated_status = updated_image["statusId"]
+            image.update!(
+              status: updated_status,
+              build_logs: updated_image["logs"].join
+            )
+            if updated_status == 2
+              image.update!(image_uri: updated_image["ecrImageUri"])
             end
           end
         end
-      rescue TangoClient::TangoException => e
-        flash[:error] = "Error while refreshing docker image build status: #{e.message}"
-      rescue StandardError => e
-        flash[:error] = "Unexpected error occurred: #{e.message}"
       end
+    rescue TangoClient::TangoException => e
+      flash[:error] = "Error while refreshing docker image build status: #{e.message}"
+    rescue StandardError => e
+      flash[:error] = "Unexpected error occurred: #{e.message}"
     end
 
     def container_image_params;

--- a/app/controllers/container_images_controller.rb
+++ b/app/controllers/container_images_controller.rb
@@ -24,8 +24,10 @@ class ContainerImagesController < ApplicationController
     dockerfile_content = uploaded_file.read if uploaded_file.present?
 
     if @container_image.save
-      template_name = @container_image.public_template.name if @container_image.public_template.present?
-      template_uri = @container_image.public_template.uri if @container_image.public_template.present?
+      template_name = @container_image.public_template.name if @container_image.public_template
+                                                                               .present?
+      template_uri = @container_image.public_template.uri if @container_image.public_template
+                                                                             .present?
       begin
         resp = TangoClient.build_image(
           @container_image.name,
@@ -37,7 +39,8 @@ class ContainerImagesController < ApplicationController
         )
         if @container_image.update(resp)
           flash[:success] = "Successfully started docker image build process"
-          redirect_to course_container_images_path(@course), notice: "Container image was successfully created."
+          redirect_to course_container_images_path(@course),
+                      notice: "Container image was successfully created."
           return
         else
           flash[:error] = "Successfully started docker image build process, failed to write to DB"
@@ -57,7 +60,8 @@ class ContainerImagesController < ApplicationController
   action_auth_level :update, :instructor
   def update;
     if @container_image.update(container_image_params)
-      redirect_to course_container_images_path(@course), notice: "Container image was successfully updated."
+      redirect_to course_container_images_path(@course),
+                  notice: "Container image was successfully updated."
     else
       render :edit, status: :unprocessable_entity
     end
@@ -66,7 +70,8 @@ class ContainerImagesController < ApplicationController
   action_auth_level :destroy, :instructor
   def destroy;
     @container_image.destroy
-    redirect_to course_container_images_path(@course), notice: "Container image was successfully deleted."
+    redirect_to course_container_images_path(@course),
+                notice: "Container image was successfully deleted."
   end
 
   action_auth_level :refresh_status, :instructor
@@ -82,7 +87,7 @@ class ContainerImagesController < ApplicationController
     begin
       resp = TangoClient.build_status(@container_image.id)
       updated_status = resp["status"]
-      @container_image.update!(status: updated_status, build_logs: @container_image.build_logs.to_s + resp["logs"])
+      @container_image.update!(status: updated_status, build_logs: resp["logs"])
       if updated_status == 2
         @container_image.update!(image_uri: resp["image_uri"])
       end
@@ -102,36 +107,34 @@ class ContainerImagesController < ApplicationController
     @container_image = ContainerImage.find(params[:container_image_id])
   end
 
-  private
+private
 
   def set_container_image;
     @container_image = ContainerImage.find(params[:id])
   end
 
   def refresh_images;
-    begin
-      updated_images = TangoClient.all_build_status
-      @course.container_images.transaction do
-        @course.container_images.each do |image|
-          next if image.status == "ready" || image.status == "failed"
+    updated_images = TangoClient.all_build_status
+    @course.container_images.transaction do
+      @course.container_images.each do |image|
+        next if image.status == "ready" || image.status == "failed"
 
-          updated_image = updated_images[image.id.to_s]
-          if updated_image.nil?
-            image.update!(status: "failed")
-          else
-            updated_status = updated_image["statusId"]
-            image.update!(status: updated_status, build_logs: image.build_logs.to_s + updated_image["logs"].join)
-            if updated_status == 2
-              image.update!(image_uri: updated_image["ecrImageUri"])
-            end
+        updated_image = updated_images[image.id.to_s]
+        if updated_image.nil?
+          image.update!(status: "failed")
+        else
+          updated_status = updated_image["statusId"]
+          image.update!(status: updated_status, build_logs: updated_image["logs"])
+          if updated_status == 2
+            image.update!(image_uri: updated_image["ecrImageUri"])
           end
         end
       end
-    rescue TangoClient::TangoException => e
-      flash[:error] = "Error while refreshing docker image build status: #{e.message}"
-    rescue StandardError => e
-      flash[:error] = "Unexpected error occurred: #{e.message}"
     end
+  rescue TangoClient::TangoException => e
+    flash[:error] = "Error while refreshing docker image build status: #{e.message}"
+  rescue StandardError => e
+    flash[:error] = "Unexpected error occurred: #{e.message}"
   end
 
   def container_image_params;

--- a/app/views/container_images/_build_log.html.erb
+++ b/app/views/container_images/_build_log.html.erb
@@ -30,8 +30,9 @@
           </div>
         </div>
       </div>
-      <div id="partial-feedback"></div>
-    <% else %>
+      <div id="partial-feedback">
+        <pre><%= container_image.build_logs %></pre>
+      </div>    <% else %>
       <div class="feedback-header">
         <h3>Build Log</h3>
         <div id="status-badge" class="feedback-status feedback-status__completed">


### PR DESCRIPTION
## Description
- Fixed a view bug in `_partial-feedback` where "In-Progress" logs were missing the `<pre>` tag, causing the UI to hide the streaming text during an active build.
- Updated `refresh_status` and `refresh_images` in `ContainerImagesController` to directly overwrite `@container_image.build_logs` with the incoming string payload.
- Removed deprecated `.join` and append (`.to_s +`) logic to match Tango's updated stateless logging architecture.

## Motivation and Context
The previous polling architecture relied on "consume-on-read" log fragments, which caused the frontend to either fail to render the logs during the build or recursively duplicate the entire log history upon page refresh. This PR aligns the controller with Tango's new idempotent logging structure, ensuring safe and accurate real-time streaming in the browser.

## How Has This Been Tested?
- Spun up local instances of Tango and Autolab.
- Created a `Dockerfile.test` with multiple `sleep 5` steps to artificially slow down the build.
- Verified in the browser that the logs stream successfully in real-time as the image builds.
- Verified that refreshing the page multiple times safely overwrites the logs without duplicating text or crashing with `NoMethodError`.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have run rubocop and erblint for style check. If you haven't, run `overcommit --install && overcommit --sign` to use pre-commit hook for linting
- [ ] My change requires a change to the documentation, which is located at [Autolab Docs](https://docs.autolabproject.com/)
- [ ] I have updated the documentation accordingly, included in this PR

## Other issues / help required
None.