### PR TITLE
Fix AWS setup and SSH

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -547,7 +547,7 @@ class Course < ApplicationRecord
         # Directory is locked down, use delegate to read file
         Rails.logger.info("File not readable, using delegate to read with root privileges")
         content = UnixGroupManager.read_file_via_delegate(source_config_file_path)
-        lines = content.split("\n")
+        lines = content.to_s.lines
         Rails.logger.info("Successfully read #{lines.length} lines from " \
                             "source config file via delegate")
       else

--- a/app/services/filesystem_enforcer.rb
+++ b/app/services/filesystem_enforcer.rb
@@ -47,7 +47,8 @@ class FilesystemEnforcer
     end
 
     begin
-      mode = File.directory?(path) ? MODE_DIR : MODE_FILE
+      # Always enforce 2770 for directories, never allow world access
+      mode = File.directory?(path) ? 0o2770 : MODE_FILE
       # Skip symlinks to avoid lchmod issues on some platforms
       unless File.symlink?(path)
         # When using delegate, use delegate chmod (runs on host with proper privileges)

--- a/app/services/unix_group_manager.rb
+++ b/app/services/unix_group_manager.rb
@@ -438,8 +438,10 @@ class UnixGroupManager
     self.add_user_to_group(username, username)
 
     # PATH DEFINITIONS
-    # Use the host path so links are valid via SSH on the AWS machine
-    host_courses_root = "/home/autolab/autolab-docker/Autolab/courses"
+    # Use the host path so links are valid via SSH on the AWS machine.
+    # Override with AUTOLAB_HOST_COURSES_ROOT when deployments use a different
+    # checkout location (for example, /home/ubuntu/autolab-docker/Autolab/courses).
+    host_courses_root = ENV.fetch("AUTOLAB_HOST_COURSES_ROOT", "/home/autolab/docker/Autolab/courses")
     user_courses_dir = File.join(home_dir, "courses")
 
     # 1. Clean up the user's courses folder entirely

--- a/config/environments/production.rb.template
+++ b/config/environments/production.rb.template
@@ -89,10 +89,10 @@ Autolab3::Application.configure do
   config.x.docker_image_upload_enabled = false
 
   # Feature flag for EC2 Docker autograder
-  config.x.ec2_docker = false
+  config.x.ec2_docker = true
 
   # Feature flag for EC2 SSH autograder
-  config.x.ec2_ssh = false
+  config.x.ec2_ssh = true
 
   # ID for Heap Analytics
   config.x.analytics_id = nil

--- a/docs/permission-model.md
+++ b/docs/permission-model.md
@@ -81,6 +81,7 @@ This implementation is aligned with the Autolab authorization model in [security
 - `UNIX_OPS_DELEGATE_URL`
 - `UNIX_OPS_SHARED_SECRET`
 - optional: `UNIX_OPS_DELEGATE_TIMEOUT`
+- optional: `AUTOLAB_HOST_COURSES_ROOT` (default: `/home/autolab/docker/Autolab/courses`)
 
 ---
 
@@ -110,3 +111,18 @@ Run these in order.
 - Course group exists and instructor membership is correct.
 - User home and `authorized_keys` are created with secure ownership.
 - Course directory modes are locked down and setgid is preserved.
+
+---
+
+## Troubleshooting
+
+- **`cd <course>` returns `No such file or directory` from `~/courses`**
+   - This usually means the per-user course link points to the wrong host path.
+   - Verify the link target:
+      - `readlink -f ~/courses/<course-name>`
+   - Ensure `AUTOLAB_HOST_COURSES_ROOT` matches your host checkout path (for example, `/home/ubuntu/autolab-docker/Autolab/courses` on some deployments).
+   - Recreate user links by re-syncing SSH keys/provisioning (or trigger `ensure_courses_directory` via key update flow).
+
+- **Bootstrap prints `chgrp: invalid group` inside the Rails container**
+   - In delegate mode, groups are host-scoped and may not exist in the container's group database.
+   - This is handled by delegate-backed permission enforcement; use the updated bootstrap script that applies delegated filesystem enforcement.

--- a/docs/permission-model.md
+++ b/docs/permission-model.md
@@ -90,6 +90,7 @@ This implementation is aligned with the Autolab authorization model in [security
 Run these in order.
 
 1. **Bootstrap course Unix groups and permissions**
+   - `sudo chmod o+x /home/ubuntu`  # Ensure parent directory is traversable for group members
    - `docker compose exec autolab bundle exec rails runner -e production script/bootstrap_course_groups.rb`
 
 2. **Run verification harness**

--- a/script/bootstrap_course_groups.rb
+++ b/script/bootstrap_course_groups.rb
@@ -101,16 +101,27 @@ scope.find_each do |course|
   course_dir = course.directory_path.to_s
   if Dir.exist?(course_dir)
     if DRY_RUN
-      say "  [SYS] chgrp -R #{group_name} #{course_dir}"
-      say "  [SYS] find #{course_dir} -type d -exec chmod 2770 {} +"
-      say "  [SYS] find #{course_dir} -type f -exec chmod 660 {} +"
+      if UnixGroupManager.delegate_enabled?
+        say "  [DELEGATE] FilesystemEnforcer.fix_tree(#{course_dir})"
+      else
+        say "  [SYS] chgrp -R #{group_name} #{course_dir}"
+        say "  [SYS] find #{course_dir} -type d -exec chmod 2770 {} +"
+        say "  [SYS] find #{course_dir} -type f -exec chmod 660 {} +"
+      end
     else
-      sys("chgrp -R #{group_name} #{course_dir}")
-      sys("find #{course_dir} -type d -exec chmod 2770 {} +")
-      sys("find #{course_dir} -type f -exec chmod 660 {} +")
+      if UnixGroupManager.delegate_enabled?
+        # In delegate mode, group operations occur on the host via delegate.
+        # Running local chgrp inside the Rails container can fail with
+        # "invalid group" because the group database is host-scoped.
+        FilesystemEnforcer.fix_tree(course_dir)
+      else
+        sys("chgrp -R #{group_name} #{course_dir}")
+        sys("find #{course_dir} -type d -exec chmod 2770 {} +")
+        sys("find #{course_dir} -type f -exec chmod 660 {} +")
 
-      # Also use FilesystemEnforcer to ensure consistency
-      FilesystemEnforcer.fix_tree(course_dir)
+        # Also use FilesystemEnforcer to ensure consistency
+        FilesystemEnforcer.fix_tree(course_dir)
+      end
     end
   else
     say "  [WARN] Course directory #{course_dir} does not exist"

--- a/script/bootstrap_course_groups.rb
+++ b/script/bootstrap_course_groups.rb
@@ -1,8 +1,3 @@
-unless system('chmod o+x /home/ubuntu')
-  puts '[WARN] Failed to set o+x on /home/ubuntu (parent directory may not be traversable for group members)'
-else
-  puts '[INFO] Ensured /home/ubuntu is o+x (traversable)'
-end
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 #

--- a/script/bootstrap_course_groups.rb
+++ b/script/bootstrap_course_groups.rb
@@ -1,3 +1,8 @@
+unless system('chmod o+x /home/ubuntu')
+  puts '[WARN] Failed to set o+x on /home/ubuntu (parent directory may not be traversable for group members)'
+else
+  puts '[INFO] Ensured /home/ubuntu is o+x (traversable)'
+end
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 #


### PR DESCRIPTION
## Description

Previously SSH would not work because file traversal encounters a directory that blocks traversal. This PR also adds backups for symlinks and fallbacks for bootstrap script.

Additionally, production.rb is not setup for instant deployment to ec2Docker.

## Testing
This PR has been tested by making changes to dev instance on ec2 and making sure that everything works as expected.

